### PR TITLE
Volumes, configuration and docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Each project contains at least 3 services:
 - `db` - holds database server (MySQL)
 - `cli` - container that is meant to serve as a single console access point to all necessary command line tools. You can access it with `fin bash`. For the list of tools available inside **cli** check [CLI image docs](https://github.com/docksal/service-cli)
 
+[Docksal Stack documentation](/docs/docksal-stack.md)
+
 <a name="updates"></a>
 ## Updating Docksal
 

--- a/bin/fin
+++ b/bin/fin
@@ -120,7 +120,7 @@ else
 	__current_active_machine=$(cat "$CONFIG_MACHINE_ACTIVE" 2>/dev/null || echo '')
 	DOCKER_MACHINE_NAME="${__current_active_machine:-$DEFAULT_MACHINE_NAME}"
 	DOCKER_MACHINE_STATUS=$(docker-machine status "$DOCKER_MACHINE_NAME" 2>&1 || echo '')
-	[[ "$DOCKER_MACHINE_STATUS" ==  'Running' ]] && \
+	[[ "$DOCKER_MACHINE_STATUS" == 'Running' ]] && \
 		eval $(docker-machine env --shell=bash "$DOCKER_MACHINE_NAME")
 	# current active machine folder
 	DOCKER_MACHINE_FOLDER="$CONFIG_MACHINES/$DOCKER_MACHINE_NAME"
@@ -1191,7 +1191,7 @@ docker_machine_create ()
 			docker run -d --restart=always \
 				-v "$HOME":"/srv/data" \
 				-v /root/.docksal/syncthing:/srv/config \
-				-p 22000:22000  -p 21025:21025/udp -p 8080:8080 \
+				-p 22000:22000 -p 21025:21025/udp -p 8080:8080 \
 				--name docksal-syncthing \
 				joeybaker/syncthing &&
 			# Wait 10 seconds for syncthing to start
@@ -1410,7 +1410,7 @@ docker_machine_mount_nfs ()
 
 	# Start/Restart nfsd
 	(ps aux | grep /sbin/nfsd | grep -v grep >/dev/null) && NFSD_IS_RUNNING="true"
-	if [[ "$NFSD_IS_RUNNING"  == "true" ]]; then
+	if [[ "$NFSD_IS_RUNNING" == "true" ]]; then
 		if [[ "$NFSD_RESTART_REQUIRED" == "true" ]]; then
 			echo-green "Restarting nfsd..."
 			sudo nfsd restart
@@ -1512,7 +1512,7 @@ docker_machine_mount_smb ()
 	# Get a list of logical drives (type 3 = Local disk).
 	local DRIVES=$(wmic logicaldisk get drivetype,name | grep 3 | awk '{print $2}' | sed 's/\r//g')
 	read -s -p "Enter your Windows account password: " PASSWORD
-	echo  # Add a new line after user input.
+	echo # Add a new line after user input.
 
 	for DRIVE in ${DRIVES}; do
 		local MOUNT_POINT=$(cygpath -u "$DRIVE" | sed 's/^\/cygdrive\///')
@@ -2205,7 +2205,7 @@ update ()
 			# Check out the case when current user on linux does not have access to docker daemon
 			if is_linux; then
 				ps -p $(cat /var/run/docker.pid) 2>&1 >/dev/null
-				[ ! $? -eq 0  ] && LINUX_DAEMON_RUNNING="exit 1"
+				[ ! $? -eq 0 ] && LINUX_DAEMON_RUNNING="exit 1"
 				# if daemon is running but docker info does not return 0 then this is the case
 				if (${LINUX_DAEMON_RUNNING}) && ! (exit ${RUNNING_CODE}); then
 					echo-red "Your Docker daemon is running but you don't have access to it."
@@ -2605,7 +2605,7 @@ remove ()
 {
 	check_docksal_environment
 	if [[ $1 == "" ]]; then
-		echo -e  "${red}WARNING:${NC} ${yellow}All containers and volumes for the current project will be removed!${NC}"
+		echo -e "${red}WARNING:${NC} ${yellow}All containers and volumes for the current project will be removed!${NC}"
 		_confirm "Continue?";
 	fi
 
@@ -2778,12 +2778,12 @@ sysinfo ()
 		docker-machine --version
 
 	if is_docker_running; then
-        echo "███  DOCKER: IMAGES"
-        docker images
+		echo "███  DOCKER: IMAGES"
+		docker images
 
-        echo "███  DOCKER: CONTAINERS"
-        docker ps
-    fi
+		echo "███  DOCKER: CONTAINERS"
+		docker ps
+	fi
 
 	if which "$vboxmanage" >/dev/null 2>&1; then
 		echo "███  VIRTUAL BOX"
@@ -2850,14 +2850,15 @@ load_configuration ()
 		# Source and allexport variables in the .env file
 		set -a; source "$env_file"; set +a
 	fi
-    # Source local env file if it exist
-    # Allow using this with the pre-configured stacks by not checking docksal.env presence.
-    if [[ -f "$local_env_file" ]]; then
-        ENV_FILE="${ENV_FILE}${SEPARATOR}${local_env_file}"
-        # Source and allexport variables in the .env file
-        set -a; source "$local_env_file"; set +a
-    fi
-    export ENV_FILE
+
+	# Source local env file if it exist
+	# Allow using this with the pre-configured stacks by not checking docksal.env presence.
+	if [[ -f "$local_env_file" ]]; then
+			ENV_FILE="${ENV_FILE}${SEPARATOR}${local_env_file}"
+			# Source and allexport variables in the .env file
+			set -a; source "$local_env_file"; set +a
+	fi
+	export ENV_FILE
 
 	# Legacy/traditional setup support
 	# TODO: get rid of this in 2017
@@ -2887,7 +2888,7 @@ load_configuration ()
 			exit 1
 		else
 			# Include docksal-local.yml (if exists)
-    	    # Allow using this with the pre-configured stacks by not checking docksal.env presence.
+			# Allow using this with the pre-configured stacks by not checking docksal.env presence.
 			[[ -f "$local_yml_file" ]] && COMPOSE_FILE="${COMPOSE_FILE}${SEPARATOR}${local_yml_file}"
 		fi
 
@@ -3002,8 +3003,8 @@ create_site ()
 	while true; do
 		read -p "Please enter the name of your project (all one word, no spaces or slashes): " project_name
 		if [[ "$project_name" =~ [^a-zA-Z0-9_-] ]]; then
-		  echo-red "Please provide a valid project name (only letters, numbers, dashes, and underscores are permitted)."
-		  continue
+			echo-red "Please provide a valid project name (only letters, numbers, dashes, and underscores are permitted)."
+			continue
 		fi
 		break
 	done

--- a/bin/fin
+++ b/bin/fin
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-FIN_VERSION=0.13.3
+FIN_VERSION=0.14.0
 
 # Console colors
 red='\033[0;91m'
@@ -16,7 +16,7 @@ FIN_BRANCH="${FIN_BRANCH:-develop}"
 
 #---------------------------- Global Constants --------------------------------
 REQUIREMENTS_DOCKER='1.12.3'
-REQUIREMENTS_DOCKER_COMPOSE='1.8.0'
+REQUIREMENTS_DOCKER_COMPOSE='1.9.0'
 REQUIREMENTS_DOCKER_MACHINE='0.8.2'
 REQUIREMENTS_VBOX='5.1.2'
 REQUIREMENTS_WINPTY='0.4.0'

--- a/bin/fin
+++ b/bin/fin
@@ -1083,7 +1083,8 @@ show_help_config ()
 	printh "fin config [command]" "" "yellow"
 	echo
 	echo-green "Commands:"
-	printh "show" "Display effective configuration for the project"
+	printh "show" "Display full effective configuration for the project"
+	printh "env" "Display only nevironment variables section of effective configuration"
 	printh "generate" "Generate Docksal configuration for the project"
 	printh "generate --static" "Generate static Docksal configuration for the project"
 	echo
@@ -1114,7 +1115,7 @@ bash_comp_words ()
 			exit 0
 		;;
 		config)
-			echo "generate show"
+			echo "generate show env"
 			exit 0
 			;;
 		fin)
@@ -2936,7 +2937,7 @@ config_show ()
 {
 	check_docksal_environment
 
-	echo
+	echo "---------------------"
 	echo "COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME}"
 	echo "COMPOSE_PROJECT_NAME_SAFE: ${COMPOSE_PROJECT_NAME_SAFE}"
 	# Replace separators with new lines
@@ -2949,8 +2950,9 @@ config_show ()
 	echo "VIRTUAL_HOST: ${VIRTUAL_HOST}"
 	local IP="$(fin vm ip)"; [[ "$DOCKER_NATIVE" == 1 ]] && IP="127.0.0.1"
 	echo "IP: $IP"
-	echo
-	echo "MYSQL_PORT:" $(docker-compose port db 3306 2>/dev/null)
+	echo "MYSQL:" $(docker-compose port db 3306 2>/dev/null | sed "s/0\.0\.0\.0/$IP/")
+	[[ "$1" == "env" ]] && return
+
 	echo
 	echo "Docker Compose configuration"
 	echo "---------------------"
@@ -3280,8 +3282,12 @@ case "$1" in
 		;;
 	config)
 		shift
-		if [[ "$*" == "" ]] || [[ "$1" == "show" ]]; then config_show; fi
-		if [[ "$1" == "generate" ]]; then shift; config_generate "$@"; fi
+		if [[ "$1" == "generate" ]]; then
+			shift;
+			config_generate "$@";
+		else
+			config_show "$@"
+		fi
 		;;
 	fix-smb)
 		smb_windows_fix

--- a/bin/fin
+++ b/bin/fin
@@ -2102,14 +2102,13 @@ update_config_files ()
 	# TODO: cleanup the stacks directory before downloading files (this will help with updates, when file names are changing).
 	(
 		cd "$CONFIG_STACKS_DIR" || exit 1;
+		echo "Starting..."
 		for f in ${files_to_download}; do
-			echo -n "  $(basename ${f})..."
-			curl -kfsSLO "$f"
+			echo-rewrite "$(basename ${f})"
 			# exit subshell with error if download failed
-			[ ! $? -eq 0 ] && exit 1
-			# otherwise print ok
-			echo "		[OK]"
+			curl -kfsSLO "$f" || exit 1
 		done
+		echo-rewrite "Done"
 	)
 
 	if_failed_error "One of the default configs was not downloaded." \

--- a/bin/fin
+++ b/bin/fin
@@ -1079,11 +1079,13 @@ show_help_share ()
 
 show_help_config ()
 {
-	echo-green "fin config <command> - Display/generate project configuration"
+	echo-green "Display/generate project configuration"
+	printh "fin config [command]" "" "yellow"
 	echo
 	echo-green "Commands:"
 	printh "show" "Display effective configuration for the project"
 	printh "generate" "Generate Docksal configuration for the project"
+	printh "generate --static" "Generate static Docksal configuration for the project"
 	echo
 }
 
@@ -2958,8 +2960,12 @@ config_show ()
 
 config_generate ()
 {
+	eval $(parse_params "$@")
 	# Allow to defined the default stack file.
 	DOCKSAL_STACK=${DOCKSAL_STACK:-default}
+	if [[ "$static" == "static" ]]; then
+		DOCKSAL_STACK="$DOCKSAL_STACK-static"
+	fi
 	yml_file="$(get_config_dir_dc)/stacks/stack-$DOCKSAL_STACK.yml"
 
 	if [[ -f ${yml_file} ]]; then
@@ -3274,8 +3280,8 @@ case "$1" in
 		;;
 	config)
 		shift
-		if [[ "$*" == "" ]] || [[ "$*" == "show" ]]; then config_show; fi
-		if [[ "$*" == "generate" ]]; then config_generate; fi
+		if [[ "$*" == "" ]] || [[ "$1" == "show" ]]; then config_show; fi
+		if [[ "$1" == "generate" ]]; then shift; config_generate "$@"; fi
 		;;
 	fix-smb)
 		smb_windows_fix

--- a/bin/fin
+++ b/bin/fin
@@ -2893,17 +2893,15 @@ load_configuration ()
 
 		# Experimental: Include a volumes yml if requested.
 		# Use bind mount for volumes if using default stack.
-		[[ "$COMPOSE_FILE" == "$default_yml_file" ]] && DOCKSAL_VOLUMES="bind"
-		if [[ "$DOCKSAL_VOLUMES" != "" ]]; then
-			volumes_yml_file="$(get_config_dir_dc)/stacks/volumes-$DOCKSAL_VOLUMES.yml"
-			if [[ -f "$volumes_yml_file" ]]; then
-				COMPOSE_FILE="${volumes_yml_file}${SEPARATOR}${COMPOSE_FILE}"
-			else
-				echo-error "Volumes definition not found in ${volumes_yml_file}." \
-					"Please check that ${yellow}DOCKSAL_VOLUMES${NC} is set properly." \
-					"You may need to run ${yellow}fin update${NC} to download volume definitions."
-				exit 1
-			fi
+		[[ "$DOCKSAL_VOLUMES" == "" ]] && DOCKSAL_VOLUMES="bind"
+		volumes_yml_file="$(get_config_dir_dc)/stacks/volumes-$DOCKSAL_VOLUMES.yml"
+		if [[ -f "$volumes_yml_file" ]]; then
+			COMPOSE_FILE="${volumes_yml_file}${SEPARATOR}${COMPOSE_FILE}"
+		else
+			echo-error "Volumes definition not found in ${volumes_yml_file}." \
+				"Please check that ${yellow}DOCKSAL_VOLUMES${NC} is set properly." \
+				"You may need to run ${yellow}fin update${NC} to download volume definitions."
+			exit 1
 		fi
 	fi
 	export COMPOSE_FILE

--- a/bin/fin
+++ b/bin/fin
@@ -2977,7 +2977,7 @@ config_generate ()
 
 		mkdir .docksal && \
 		# Use bind mount volumes by default
-		echo 'DOCKSAL_VOLUMES="bind"' > .docksal/docksal.env && \
+		echo '' > .docksal/docksal.env && \
 		cp "$yml_file" ".docksal/docksal.yml"
 		if [[ ! -f 'docroot/index.php' ]]; then
 			# Setup docroot and a basic index.php

--- a/bin/fin
+++ b/bin/fin
@@ -3051,17 +3051,15 @@ create_site ()
 
 	_confirm "Do you wish to proceed?"
 
-	# Todo: is git clone really the best way to do this?  What about
-	# users who don't have a github account, will this work for them?
 	echo -e "${green} Cloning repository...${NC}"
 	git clone -b master ${target_repo} ${project_name}
-	cd ${project_name}/.docksal
+	[ ! $? -eq 0 ] && _confirm "Checkout finished with errors. Do you wish to continue?"
 
-	# Edit docksal.env to use a custom user-supplied host name
-	sed -i.bak "s/${target_host_name_search_string}/${project_name}/g" docksal.env && rm docksal.env.bak > /dev/null 2>&1
-	cd ..
-
-	fin init
+	cd ${project_name}/.docksal &&
+		# Edit docksal.env to use a custom user-supplied host name
+		sed -i.bak "s/${target_host_name_search_string}/${project_name}/g" docksal.env && rm docksal.env.bak > /dev/null 2>&1 &&
+		cd ".." &&
+		fin init
 }
 
 #-------------------------- RUNTIME STARTS HERE ----------------------------

--- a/bin/fin
+++ b/bin/fin
@@ -2846,14 +2846,15 @@ load_configuration ()
 		ENV_FILE="$env_file"
 		# Source and allexport variables in the .env file
 		set -a; source "$env_file"; set +a
-		# Source local env file if both it and the main env file exist
-		if [[ -f "$local_env_file" ]]; then
-			ENV_FILE="${ENV_FILE}${SEPARATOR}${local_env_file}"
-			# Source and allexport variables in the .env file
-			set -a; source "$local_env_file"; set +a
-		fi
-		export ENV_FILE
 	fi
+    # Source local env file if it exist
+    # Allow using this with the pre-configured stacks by not checking docksal.env presence.
+    if [[ -f "$local_env_file" ]]; then
+        ENV_FILE="${ENV_FILE}${SEPARATOR}${local_env_file}"
+        # Source and allexport variables in the .env file
+        set -a; source "$local_env_file"; set +a
+    fi
+    export ENV_FILE
 
 	# Legacy/traditional setup support
 	# TODO: get rid of this in 2017
@@ -2873,8 +2874,6 @@ load_configuration ()
 		# Use .docksal/docksal.yml by default (if exists)
 		if [[ -f "$yml_file" ]]; then
 			COMPOSE_FILE="$yml_file"
-			# Include docksal-local.yml (if exists)
-			[[ -f "$local_yml_file" ]] && COMPOSE_FILE="${COMPOSE_FILE}${SEPARATOR}${local_yml_file}"
 		# Otherwise use the default.yml stack config (if exists)
 		elif [[ -f "$default_yml_file" ]]; then
 			COMPOSE_FILE="$default_yml_file"
@@ -2883,6 +2882,10 @@ load_configuration ()
 		if [[ "$COMPOSE_FILE" == "" ]]; then
 			echo-error "No configuration files found." "Expected in $yml_file"
 			exit 1
+		else
+			# Include docksal-local.yml (if exists)
+    	    # Allow using this with the pre-configured stacks by not checking docksal.env presence.
+			[[ -f "$local_yml_file" ]] && COMPOSE_FILE="${COMPOSE_FILE}${SEPARATOR}${local_yml_file}"
 		fi
 
 		# Experimental: Include a volumes yml if requested.

--- a/docs/apache-solr.md
+++ b/docs/apache-solr.md
@@ -4,16 +4,11 @@
 
 1. Add Apache Solr service to `docksal.yml`:
 
-    Replace `<project_name>` with your project name.
-
     ```yml
-    # Solr node
-    # Uncomment the service definition section below to start using Solr.
+    # Solr
     solr:
       hostname: solr
       image: docksal/solr:3.x-stable
-      environment:
-        - DOMAIN_NAME=solr.<project_name>.docksal
     ```
 
 2. Apply new configuration with `fin up`
@@ -24,4 +19,4 @@
 
 2. Add your Solr server on page `admin/config/search/apachesolr/settings/add` with following server url: 
 
-    Solr server URL: `http://solr.<project_name>.docksal:8983/solr`
+    Solr server URL: `http://solr:8983/solr`

--- a/docs/db-access.md
+++ b/docs/db-access.md
@@ -1,28 +1,28 @@
 # MySQL DB access for external tools
 
 MySQL service in the `db` container is exposed at a random port by default.
-This is done to avoid port conflicts if running multiple Docksal powered projects (multisites don't count).
+This is done to avoid port conflicts when running multiple Docksal powered projects (multisites don't count).
 
-To view the randomly assigned port value run `fin config` and look for `MYSQL_PORT:`.  
-You can connect to MySQL in the db container on `192.168.64.100:<random-port-value>`.  
-Keep in mind, that the random port value will change every time the DB container is restarted.
+To view the randomly assigned port value run `fin config` and look for `MYSQL_PORT`.  
+You can connect to MySQL in the `db` container on `192.168.64.100:<random-port-value>`.  
+Keep in mind, that the random port value will change every time the `db` container is restarted.
 
 ## Assigning static port
 
-To have a static port assigned, override MYSQL_PORT variable value using `.docksal/docksal-local.env` file.
+To have a static port assigned, add the following line in `.docksal/docksal.env` or `.docksal/docksal-local.env`:
+
+```
+MYSQL_PORT_MAPPING='<unique-static-port>:3306'
+```
 
 Replace `<unique-static-port>` with a **unique** port number (unique across all Docksal powered projects on your host):
-
-```
-MYSQL_PORT='<unique-static-port>:3306'
-```
 
 ## Examples
 
 **Project 1**
 
 ```
-MYSQL_PORT='33061:3306'
+MYSQL_PORT_MAPPING='33061:3306'
 ```
 
 MySQL endpoint: `192.168.64.100:33061`
@@ -30,7 +30,7 @@ MySQL endpoint: `192.168.64.100:33061`
 **Project 2**
 
 ```
-MYSQL_PORT='33062:3306'
+MYSQL_PORT_MAPPING='33062:3306'
 ```
 
 MySQL endpoint: `192.168.64.100:33062`
@@ -46,7 +46,7 @@ Password: root
 
 ## Root password
 
-Override default admin password by overriding value of `MYSQL_ROOT_PASSWORD` variable in `.docksal/docksal.env` or `.docksal/docksal-local.env`
+To override the default admin password, add the following line in `.docksal/docksal.env` or `.docksal/docksal-local.env`
 
 ```
 MYSQL_ROOT_PASSWORD="gue$$-me-not"

--- a/docs/docksal-stack.md
+++ b/docs/docksal-stack.md
@@ -114,7 +114,7 @@ You can always see files that were loaded for a project by running `fin config s
 Load order:
 
 1. `volumes-*.yml` - [optional] default is `volumes-bind.yml` ([volumes in Docksal](docksal-volumes.md))  
-2. `~/.docksal/stacks/stack-default.yml` - default stack, only loads if there is no `docksal.yml` configured for a project  
+2. `~/.docksal/stacks/stack-default.yml` - default stack, only loads if there is no `docksal.yml`  
 3. `docksal.yml`  
 4. `docksal.env`  
 5. `docksal-local.yml`  

--- a/docs/docksal-stack.md
+++ b/docs/docksal-stack.md
@@ -1,14 +1,14 @@
 # Docksal Stack
 
-This page explains some hidden mechanics of Docksal.
+This page explains how Docksal works under the hood.
 
 1. [System services](#docksal-system-services)
 2. [Project services](#docksal-project-services)
 3. [Understanding configuration](#understanding-configuration)
-    1. [What is docksal.yml?](#docksal-yml)
-    2. [What is docksal.env?](#docksal-env)
-    3. [What docksal-local files are for?](#docksal-local)
-    4. [Configuration files loading order](#loading-order)
+    1. [docksal.yml](#docksal-yml)
+    2. [docksal.env](#docksal-env)
+    3. [Local overrides](#docksal-local)
+    4. [Configuration files load order](#loading-order)
 4. [Customizing project configuration](#project-customization)
 
 ---
@@ -16,36 +16,39 @@ This page explains some hidden mechanics of Docksal.
 <a name="docksal-system-services"></a>
 ## System services
 
-When you run `fin update` for the first time Docksal installs you 3 system containers.
-You can see them in the list if you run `fin docker ps | grep docksal-`
+When you run `fin update` for the first time, Docksal installs several system containers.  
+To see the list run `fin docker ps --filter "label=io.docksal.group=system"`
 
 ### SSH Agent
 
-[docksal-ssh-agent](https://github.com/docksal/service-ssh-agent) service is required to store your SSH keys. If it didn't exist you would need to map your SSH keys into every project where you needed them and if your keys
-are password protected you would need to enter password each time as it's SSH Agent who does password caching on localhost.
+[docksal-ssh-agent](https://github.com/docksal/service-ssh-agent) service stores SSH keys and makes them available 
+to other projects and containers. Without it you would have to mount your SSH keys into every project where you needed them.  
+Also, if your keys are password protected, you would need to enter password each time they are used. ssh-agent takes care of that as well.
 
-So we created dockerized version of it. ssh-agent imports your keys only once and 
-allows their reuse throughout all running projects without a need to re-enter passphrase, 
-which could be especially annoying if you need ssh key to checkout/commit to repo.
+ssh-agent imports your keys only once and allows their reuse throughout all running projects without a need to re-enter 
+the passphrase, which can be especially annoying if you need an ssh key to checkout/commit to a repo.
 
 ### DNS
 
-[docksal-dns](https://github.com/docksal/service-dns) contains a running bind server that resolves `*.docksal` URI's into IP address
-of Docksal's VM (or localhost if you're running [native Docker app](env-setup-native.md)).
+[docksal-dns](https://github.com/docksal/service-dns) contains a running `bind` server that resolves `*.docksal` URI's 
+to the Docksal VM IP address (or localhost if you're running a [native Docker app](env-setup-native.md)).
 
 !!! warning "Windows users"
-    On macOS and Linux Docksal automatically configures itself to become a DNS resolver for `.docksal` domain. On Windows it is not get configured automatically because in case when VM freezes or stops Windows might temporarily lose ability to resolve internet addressess into IP's. You can manually set up `192.168.64.100` to be your primary DNS however it's recommended to update hosts file on per-project basis instead.
+    On macOS and Linux Docksal automatically configures itself to become a DNS resolver for `.docksal` domain. 
+    On Windows this is not configured automatically, because this may cause DNS resolution issues in case the VM is down or freezes.  
+    You can manually configure `192.168.64.100` to be your primary DNS and you ISP/office DNS to be the secondary one.
 
 ### Reverse proxy
 
-When you request `project.docksal` in your browser and Docksal's DNS re-routes your request, then next it gets
-to [docksal-vhost-proxy](https://github.com/docksal/service-vhost-proxy), Docksal's reverse proxy container, that determines to which project's `web` container
-should this request go to. It allows seamless work with multiple projects.
+When you request `project.docksal` in your browser, Docksal's DNS resolves it to Docksal's IP and your request hits the 
+[docksal-vhost-proxy](https://github.com/docksal/service-vhost-proxy) container. 
+This is Docksal's reverse proxy service, which routes the request to the appropriate project's `web` container. 
+This allows for a seamless work with multiple project stacks at the same time.
 
 <a name="docksal-project-services"></a>
 ## Project services
 
-Every Docksal project should contain at least 3 canonical services: web, db and cli.
+A standard Docksal project consists of 3 canonical services: `web`, `db` and `cli`. These services represent the LAMP stack.
 
 ### Web
 
@@ -57,8 +60,8 @@ Docksal's [DB service](https://github.com/docksal/service-db) runs MySQL 5.5, 5.
 
 ### CLI
 
-Docksal's [CLI service](https://github.com/docksal/service-cli) provides an environment to run php-fpm,
-that is used by web service, as well as for Behat, mysql, drush and other tools. Provides reliable automation
+Docksal's [CLI service](https://github.com/docksal/service-cli) provides an environment to run `php-fpm`,
+which is used by `web` service, as well as for Behat, mysql client, drush and other tools. It provides a reliable automation
 interface via `fin exec`.
 
 <a name="understanding-configuration"></a>
@@ -66,12 +69,12 @@ interface via `fin exec`.
 
 Docksal relies on [Docker Compose](https://docs.docker.com/compose/) to launch groups of related containers.
 You want to familiarize yourself with [basic concepts](https://docs.docker.com/compose/overview/) of Docker Compose
-before reading next chapters.
+before reading further sections.
 
 <a name="docksal-yml"></a>
-### What is docksal.yml?
+### docksal.yml
 
-`docksal.yml` is customly named [Compose file](https://docs.docker.com/compose/compose-file/).
+`docksal.yml` is a [Compose file](https://docs.docker.com/compose/compose-file/).
 It's a main configuration file for a project that controls it's services settings, so use it to
 modify settings, that are required for all team members.
 
@@ -80,7 +83,7 @@ Even if you don't have this file in your project folder, fin will load a default
 For more details on it's role check [loading order](#loading-order) and [customizing project configuration](project-customize.md).
 
 <a name="docksal-env"></a>
-### What is docksal.env?
+### docksal.env
 
 `docksal.env` is an [Environment file](https://docs.docker.com/compose/env-file/).
 
@@ -89,35 +92,36 @@ creating `docksal.yml` (for example to override MYSQL_ROOT_PASSWORD) or to provi
 variables to your automation scripts (see [custom commands](custom-commands.md)).
 
 <a name="docksal-local"></a>
-### What docksal-local files are for?
+### Local overrides
 
-`docksal-local.yml` and `docksal-local.env` are supposed to be used for customizations, that should not
-get committed to project's repository. For example [exposing custom port](expose-port.md) for local development needs.
+`docksal-local.yml` and `docksal-local.env` can be used those for customizations, which should not
+get committed into the project's repository. For example [exposing custom port](expose-port.md) for local development needs.
 
 <a name="loading-order"></a>
-## Configuration files loading order
+## Configuration files load order
 
-This swarm of configuration files that Docksal can use, provides a flexibility to setup your
-project in a way that works for your organisation needs, just like Bash configuration files
-(/etc/profile, bashrc, bash_profile, bash_logout) they provide flexibility to configure Docksal
+This swarm of configuration files that Docksal can use, provides flexibility to set up your
+project in a way that works for your team's needs. Just like Bash configuration files
+(/etc/profile, bashrc, bash_profile, bash_logout), they provide flexibility to configure Docksal
 project in dozens of ways.
 
-fin loads files in a certain order. Configuration files that are loaded later overwrite settings
-from files that had loaded earlier. The list below goes from earliest to latest in this queue.
+`fin` loads files in a certain order. Configuration files, that are loaded later, overwrite settings
+from files, that had been loaded earlier. The list below goes from earliest to latest in this queue.
 Files at the bottom load the latest.
 
-You can always see files that were loaded for project by running `fin config`.
+You can always see files that were loaded for a project by running `fin config show`.
 
-Loading order:
+Load order:
 
-**0.** `volumes-*.yml` - [optional] default is `volumes-bind.yml` ([volumes in Docksal](docksal-volumes.md))  
-**1.** `~/.docksal/stacks/stack-default.yml` - default stack, only loads if there is no `docksal.yml`  
-**2.** `docksal.yml` - prevents loading default stack  
-**3.** `docksal.env`  
-**4.** `docksal-local.yml`  
-**5.** `docksal-local.env`
+1. `volumes-*.yml` - [optional] default is `volumes-bind.yml` ([volumes in Docksal](docksal-volumes.md))  
+2. `~/.docksal/stacks/stack-default.yml` - default stack, only loads if there is no `docksal.yml` configured for a project  
+3. `docksal.yml`  
+4. `docksal.env`  
+5. `docksal-local.yml`  
+6. `docksal-local.env`
 
 <a name="project-customization"></a>
 ## Customizing project configuration
 
-If you are ready to customize Docksal settings for your project then check out  [customizing project configuration](project-customize.md) to learn about `docksal.yml` structure and differences between dynamic and static configurations for a project.
+If you are ready to customize Docksal settings for your project then check out [Customizing project configuration](project-customize.md) 
+to learn about `docksal.yml` structure and differences between dynamic and static configurations for a project.

--- a/docs/docksal-stack.md
+++ b/docs/docksal-stack.md
@@ -112,11 +112,11 @@ You can always see files that were loaded for project by running `fin config`.
 
 Loading order:
 
-**0.** `volumes-*.yml` - Optional. Default is `volumes-bind.yml`. See [volumes in Docksal](docksal-volumes.md) for details.
-**1.** `~/.docksal/stacks/stack-default.yml` - default stack, only loads if there is no `docksal.yml`
-**2.** `docksal.yml` - prevents loading default stack.
-**3.** `docksal.env`
-**4.** `docksal-local.yml`
+**0.** `volumes-*.yml` - [optional] default is `volumes-bind.yml` ([volumes in Docksal](docksal-volumes.md))  
+**1.** `~/.docksal/stacks/stack-default.yml` - default stack, only loads if there is no `docksal.yml`  
+**2.** `docksal.yml` - prevents loading default stack  
+**3.** `docksal.env`  
+**4.** `docksal-local.yml`  
 **5.** `docksal-local.env`
 
 ## Customizing project configuration

--- a/docs/docksal-stack.md
+++ b/docs/docksal-stack.md
@@ -1,0 +1,120 @@
+# Docksal Stack
+
+This page explains some hidden mechanics of Docksal.
+
+1. [System services](#docksal-system-services)
+2. [Project services](#docksal-project-services)
+3. [Project services advanced configuration](#advanced-configuration)
+    1. [What is docksal.yml?](#docksal-yml)
+    2. [What is docksal.env?](#docksal-env)
+    3. [What docksal-local files are for?](#docksal-local)
+    4. [Configuration files loading order](#loading-order)
+
+---
+
+<a name="docksal-system-services"></a>
+## System services
+
+When you run `fin update` for the first time Docksal installs you 3 system containers.
+These services are required to glue system pieces together.
+You can see them if you run `fin docker ps | grep docksal-`
+
+### SSH Agent
+
+[docksal-ssh-agent](https://github.com/docksal/service-ssh-agent) service is required to store your SSH keys. If not this service you would need
+to manually map your SSH keys to every project where you need them and if your keys
+are password protected you would need to enter password each time.
+
+Instead there's a conatiner with [ssh-agent](https://github.com/docksal/service-ssh-agent) running
+that imports your keys once and allows their reuse throughout all running projects
+without a need to re-enter passphrase, which could be especially annoying if you need
+ssh key to checkout/commit to repo.
+
+### DNS
+
+[docksal-dns](https://github.com/docksal/service-dns) contains a running bind server that resolves `*.docksal` URI's into IP address
+of Docksal's VM (or localhost if you're running [native Docker app](env-setup-native.md)).
+
+!!! warning "Windows users"
+    On macOS and Linux Docksal automatically configures itself to become a DNS resolver for `.docksal` domain. On Windows it is not get configured automatically because in case when VM freezes or stops Windows might temporarily lose ability to resolve internet addressess into IP's. You can manually set up `192.168.64.100` to be your primary DNS however it's recommended to update hosts file on per-project basis instead.
+
+### Reverse proxy
+
+When you request `project.docksal` in your browser and Docksal's DNS re-routes your request, then next it gets
+to [docksal-vhost-proxy](https://github.com/docksal/service-vhost-proxy), Docksal's reverse proxy container, that determines to which project's `web` container
+should this request go to. It allows seamless work with multiple projects.
+
+<a name="docksal-project-services"></a>
+## Project services
+
+Every Docksal project should contain at least 3 canonical services: web, db and cli.
+
+### Web
+
+Docksal's [Web service](https://github.com/docksal/service-web) runs Apache Server 2.2 or 2.4
+
+### DB
+
+Docksal's [DB service](https://github.com/docksal/service-db) runs MySQL 5.5, 5.6, 5.7 or 8.0
+
+### CLI
+
+Docksal's [CLI service](https://github.com/docksal/service-cli) provides an environment to run php-fpm,
+that is used by web service, Behat, mysql, drush and other tools, and provides reliable automation
+interface via `fin exec`.
+
+<a name="advanced-configuration"></a>
+## Project services advanced configuration
+
+Docksal relies on [Docker Compose](https://docs.docker.com/compose/) to launch groups of related containers.
+You want to familiarize yourself with [basic concepts](https://docs.docker.com/compose/overview/) of Docker Compose
+before reading next chapters.
+
+<a name="docksal-yml"></a>
+### What is docksal.yml?
+
+`docksal.yml` is customly named [Compose file](https://docs.docker.com/compose/compose-file/).
+It's a main configuration file for a project that controls it's services settings, so use it to
+modify settings, that are required for all team members.
+
+Even if you don't have this file in your project folder fin loads a default one providing a zero-configuration ability.
+
+For more details on it's role check [loading order](#loading-order) and [customize project configuration](project-customize.md).
+
+<a name="docksal-env"></a>
+### What is docksal.env?
+
+`docksal.env` is an [Environment file](https://docs.docker.com/compose/env-file/).
+
+It is meant to be used to easily override some default environment variables without a need of
+creating `docksal.yml` (For example to override mysql root password) or to provide additional environment
+variables to your automation scripts (see [custom commands](custom-commands.md)).
+
+<a name="docksal-local"></a>
+### What docksal-local files are for?
+
+`docksal-local.yml` and `docksal-local.env` are supposed to be used for customizations that should not
+get committed to project's repository. For example [exposing custom port](expose-port.md) for local development needs.
+
+<a name="loading-order"></a>
+## Configuration files loading order
+
+This swarm of configuration files that Docksal can use, provides a flexibility to setup your
+project in a way that works for your organisation needs, just like Bash configuration files
+(/etc/profile, bashrc, bash_profile, bash_logout) they provide flexibility to configure Docksal
+project in dozens of ways.
+
+fin loads files in a certain order. Configuration files that are loaded later overwrite settings
+from files that loaded earlier. The list below goes from earliest to latest in this queue.
+Files at the bottom load the latest.
+
+You can always see files that were loaded for project by running `fin config`.
+
+Loading order:
+
+**0.** `volumes-*.yml` - Optional. Default is `volumes-bind.yml`. See [volumes in Docksal](docksal-volumes.md) for details.
+**1.** `~/.docksal/stacks/stack-default.yml` - default stack, only loads if there is no `docksal.yml`
+**2.** `docksal.yml` - prevents loading default stack.
+**3.** `docksal.env`
+**4.** `docksal-local.yml`
+**5.** `docksal-local.env`

--- a/docs/docksal-stack.md
+++ b/docs/docksal-stack.md
@@ -9,6 +9,7 @@ This page explains some hidden mechanics of Docksal.
     2. [What is docksal.env?](#docksal-env)
     3. [What docksal-local files are for?](#docksal-local)
     4. [Configuration files loading order](#loading-order)
+4. [Customizing project configuration](#project-customization)
 
 ---
 
@@ -116,6 +117,7 @@ Loading order:
 **4.** `docksal-local.yml`  
 **5.** `docksal-local.env`
 
+<a name="project-customization"></a>
 ## Customizing project configuration
 
 If you are ready to customize Docksal settings for your project then check out  [customizing project configuration](project-customize.md) to learn about `docksal.yml` structure and differences between dynamic and static configurations for a project.

--- a/docs/docksal-stack.md
+++ b/docs/docksal-stack.md
@@ -16,19 +16,16 @@ This page explains some hidden mechanics of Docksal.
 ## System services
 
 When you run `fin update` for the first time Docksal installs you 3 system containers.
-These services are required to glue system pieces together.
-You can see them if you run `fin docker ps | grep docksal-`
+You can see them in the list if you run `fin docker ps | grep docksal-`
 
 ### SSH Agent
 
-[docksal-ssh-agent](https://github.com/docksal/service-ssh-agent) service is required to store your SSH keys. If not this service you would need
-to manually map your SSH keys to every project where you need them and if your keys
-are password protected you would need to enter password each time.
+[docksal-ssh-agent](https://github.com/docksal/service-ssh-agent) service is required to store your SSH keys. If it didn't exist you would need to map your SSH keys into every project where you needed them and if your keys
+are password protected you would need to enter password each time as it's SSH Agent who does password caching on localhost.
 
-Instead there's a conatiner with [ssh-agent](https://github.com/docksal/service-ssh-agent) running
-that imports your keys once and allows their reuse throughout all running projects
-without a need to re-enter passphrase, which could be especially annoying if you need
-ssh key to checkout/commit to repo.
+So we created dockerized version of it. ssh-agent imports your keys only once and 
+allows their reuse throughout all running projects without a need to re-enter passphrase, 
+which could be especially annoying if you need ssh key to checkout/commit to repo.
 
 ### DNS
 
@@ -60,11 +57,11 @@ Docksal's [DB service](https://github.com/docksal/service-db) runs MySQL 5.5, 5.
 ### CLI
 
 Docksal's [CLI service](https://github.com/docksal/service-cli) provides an environment to run php-fpm,
-that is used by web service, Behat, mysql, drush and other tools, and provides reliable automation
+that is used by web service, as well as for Behat, mysql, drush and other tools. Provides reliable automation
 interface via `fin exec`.
 
 <a name="understanding-configuration"></a>
-## Project services advanced configuration
+## Understanding configuration
 
 Docksal relies on [Docker Compose](https://docs.docker.com/compose/) to launch groups of related containers.
 You want to familiarize yourself with [basic concepts](https://docs.docker.com/compose/overview/) of Docker Compose
@@ -77,7 +74,7 @@ before reading next chapters.
 It's a main configuration file for a project that controls it's services settings, so use it to
 modify settings, that are required for all team members.
 
-Even if you don't have this file in your project folder fin loads a default one providing a zero-configuration ability.
+Even if you don't have this file in your project folder, fin will load a default one providing a zero-configuration ability.
 
 For more details on it's role check [loading order](#loading-order) and [customizing project configuration](project-customize.md).
 
@@ -87,13 +84,13 @@ For more details on it's role check [loading order](#loading-order) and [customi
 `docksal.env` is an [Environment file](https://docs.docker.com/compose/env-file/).
 
 It is meant to be used to easily override some default environment variables without a need of
-creating `docksal.yml` (For example to override mysql root password) or to provide additional environment
+creating `docksal.yml` (for example to override MYSQL_ROOT_PASSWORD) or to provide additional environment
 variables to your automation scripts (see [custom commands](custom-commands.md)).
 
 <a name="docksal-local"></a>
 ### What docksal-local files are for?
 
-`docksal-local.yml` and `docksal-local.env` are supposed to be used for customizations that should not
+`docksal-local.yml` and `docksal-local.env` are supposed to be used for customizations, that should not
 get committed to project's repository. For example [exposing custom port](expose-port.md) for local development needs.
 
 <a name="loading-order"></a>
@@ -105,7 +102,7 @@ project in a way that works for your organisation needs, just like Bash configur
 project in dozens of ways.
 
 fin loads files in a certain order. Configuration files that are loaded later overwrite settings
-from files that loaded earlier. The list below goes from earliest to latest in this queue.
+from files that had loaded earlier. The list below goes from earliest to latest in this queue.
 Files at the bottom load the latest.
 
 You can always see files that were loaded for project by running `fin config`.
@@ -121,4 +118,4 @@ Loading order:
 
 ## Customizing project configuration
 
-On details of docksal.yml structure and differences between dynamic and static configurations see [customizing project configuration](project-customize.md).
+If you are ready to customize Docksal settings for your project then check out  [customizing project configuration](project-customize.md) to learn about `docksal.yml` structure and differences between dynamic and static configurations for a project.

--- a/docs/docksal-stack.md
+++ b/docs/docksal-stack.md
@@ -4,7 +4,7 @@ This page explains some hidden mechanics of Docksal.
 
 1. [System services](#docksal-system-services)
 2. [Project services](#docksal-project-services)
-3. [Project services advanced configuration](#advanced-configuration)
+3. [Understanding configuration](#understanding-configuration)
     1. [What is docksal.yml?](#docksal-yml)
     2. [What is docksal.env?](#docksal-env)
     3. [What docksal-local files are for?](#docksal-local)
@@ -63,7 +63,7 @@ Docksal's [CLI service](https://github.com/docksal/service-cli) provides an envi
 that is used by web service, Behat, mysql, drush and other tools, and provides reliable automation
 interface via `fin exec`.
 
-<a name="advanced-configuration"></a>
+<a name="understanding-configuration"></a>
 ## Project services advanced configuration
 
 Docksal relies on [Docker Compose](https://docs.docker.com/compose/) to launch groups of related containers.
@@ -79,7 +79,7 @@ modify settings, that are required for all team members.
 
 Even if you don't have this file in your project folder fin loads a default one providing a zero-configuration ability.
 
-For more details on it's role check [loading order](#loading-order) and [customize project configuration](project-customize.md).
+For more details on it's role check [loading order](#loading-order) and [customizing project configuration](project-customize.md).
 
 <a name="docksal-env"></a>
 ### What is docksal.env?
@@ -118,3 +118,7 @@ Loading order:
 **3.** `docksal.env`
 **4.** `docksal-local.yml`
 **5.** `docksal-local.env`
+
+## Customizing project configuration
+
+On details of docksal.yml structure and differences between dynamic and static configurations see [customizing project configuration](project-customize.md).

--- a/docs/docksal-volumes.md
+++ b/docs/docksal-volumes.md
@@ -1,0 +1,12 @@
+# Volumes in Docksal
+
+!!! warning "This documentation is incomplete"
+    Instructions in this document need to be finalized
+
+## Volumes bind
+
+`~/.docksal/stacks/volumes-bind.yml`
+
+## Volumes unison
+
+`~/.docksal/stacks/volumes-unison.yml`

--- a/docs/env-setup-native.md
+++ b/docs/env-setup-native.md
@@ -22,7 +22,7 @@ fin update
 export DOCKER_NATIVE=1
 ```
 
-This applies to a single terminal tab/session and has to be repeated for new ones).
+This applies to a single terminal tab/session and has to be repeated for the new ones).
 All further `fin` commands should be run within the same terminal tab/session.
 
 **4.** Check and confirm the switch
@@ -34,7 +34,7 @@ fin docker info | grep "Kernel Version"
 If you see something like `Kernel Version: 4.4.27-moby` in the output,
 then `fin` was able to communicate with your Docker for Mac/Windows instance.
 
-**5.** Re-create Docksal system containers
+**5.** Reset Docksal system containers
 
 ```
 fin reset system
@@ -59,9 +59,8 @@ If you see:
 - `Kernel Version: 4.4.27-boot2docker` means you switched back to the VirtualBox VM (TinyCore, boot2docker)
 - `Kernel Version: 4.4.27-moby` means you are still using Docker for Mac/Windows VM (Alpine Linux Moby)
 
-**3.** Re-create Docksal system containers
+**3.** Reset Docksal system containers
 
 ```
 fin reset system
 ```
-

--- a/docs/project-customize.md
+++ b/docs/project-customize.md
@@ -13,7 +13,7 @@ fin config
 
 You will see output similar to the following:
 
-```
+```yml
 COMPOSE_PROJECT_NAME: myproject
 COMPOSE_PROJECT_NAME_SAFE: myproject
 COMPOSE_FILE:

--- a/docs/project-customize.md
+++ b/docs/project-customize.md
@@ -2,10 +2,10 @@
 
 ## Checking the default configuration
 
-If you set up a project using the [simplified process](project-setup.md), then Docksal will handle all the configuration
+If you had setup a project using the [simplified process](project-setup.md), then Docksal will handle all the configuration
 behind the scenes.
 
-To review this configuration, in your project directory run
+To review configuration applied to your project run
 
 ```bash
 fin config
@@ -82,22 +82,39 @@ volumes:
 ---------------------
 ```
 
-Note that it displays the virtual host name it will use, which is based on your
-project's directory name, and it displays the MySQL user name and password if
-you need to setup additional databases (there is one by default).
+This output represents the very final containers configuration, composed of all your configuration files with all variables resolved to their values.
 
 ## Customizing a configuration
 
-If you need to customize your Docksal setup, there is a command to build the initial configuration files.
+Out-of-the box dynamic configuration is no different than static one. The only difference is how each of them handles future Docksal updates.
+
+### Dynamic configuration (recommended)
+
+Dynamic configuration is the one that can be generated with:
 
 ```bash
 fin config generate
 ```
 
-This will save the default dynamic configuration into files in the `.docksal` directory fo your project.
+It will create `docksal.yml` using `stack-default.yml` file. This type of configuration extends default `services.yml` file. Advantage is that your configuration is much more simple, which leaves less space for error (especially for unexperienced developers) and it will update to the latest version of Docksal images and practices automatically, while with static configuration manual updates might be required. Cons is that `services.yml` may change with Docksal updates, which is not always desirable with more complex projects. 
 
-- `docksal.yml` is for Docker specific configuration, like adding or removing services.
-- `docksal.env` is for environment specific configuration, like setting the document root or hostname.
+Dynamic configuration approach is recommended for majority projects with default setups. When you don't need anything more than webserver, database and some dev tools. This Drupal or Wordpress project of low to medium complexity. In majority of cases Docksal updates will not affect such project.
+
+**If you're not sure what to choose, this one is recommended. You can always switch to static one.**
+
+### Static configuration (advanced)
+
+When you start a larger project with customizations to defaults or non-default services, or with the big team of people, then you probably want to generate a static configuration, that will not depend on `services.yml`.
+
+This can be done with additional parameter:
+
+```bash
+fin config generate --static
+```
+
+It will create `docksal.yml` using `stack-default-static.yml` file. This file has static images' names and none of future changes to `services.yml` will affect it. 
+
+Which also means that if future Docksal update brings new features, that require a change to `services.yml`, then unlike with dynamic configuration, you might need to re-generate your static configuration or append those changes manually to your `docksal.yml` if you want to benefit from those new features.
 
 ## Automate the initialization process
 

--- a/docs/project-customize.md
+++ b/docs/project-customize.md
@@ -2,7 +2,7 @@
 
 ## Checking the default configuration
 
-If you had setup a project using the [simplified process](project-setup.md), then Docksal will handle all the configuration
+If you set up a project using the [simplified process](project-setup.md), then Docksal will handle all the configuration
 behind the scenes.
 
 To review this configuration, in your project directory run
@@ -84,7 +84,7 @@ volumes:
 
 Note that it displays the virtual host name it will use, which is based on your
 project's directory name, and it displays the MySQL user name and password if
-you need to setup a database.
+you need to setup additional databases (there is one by default).
 
 ## Customizing a configuration
 
@@ -94,7 +94,7 @@ If you need to customize your Docksal setup, there is a command to build the ini
 fin config generate
 ```
 
-This will save the default dynamic configuration to files in the `.docksal` directory.
+This will save the default dynamic configuration into files in the `.docksal` directory fo your project.
 
 - `docksal.yml` is for Docker specific configuration, like adding or removing services.
 - `docksal.env` is for environment specific configuration, like setting the document root or hostname.

--- a/docs/project-setup.md
+++ b/docs/project-setup.md
@@ -1,12 +1,13 @@
 # Configure a project to use Docksal
 
-Docksal is capable of running a project without specifying a configuration for a project. 
-It has a default configuration it will use to build containers and setup a virtual host.
+With Docksal you can initialize a basic LAMP stack with no configuration.   
+In this case the default configuration will be used to provision containers and set up a virtual host.
 
 Initial configuration is done once per project (e.g. by a team lead) and committed into the project repo. 
-Presence of the `.docksal` folder in the project directory is a good indicator a project is already using Docksal.
+Presence of the `.docksal` folder in the project directory is a good indicator the project is using Docksal.
 
-## 1. Create a project directory 
+
+## 1. Create a directory structure for the project
 
 ```bash
 mkdir ~/projects/myproject
@@ -14,9 +15,8 @@ mkdir ~/projects/myproject/docroot
 mkdir ~/projects/myproject/.docksal
 ```
 
-You can checkout existing project into the `docroot` of this new directory. In the docroot folder you can add any project files you want whether it's a plain HTML, PHP-based CMS or pure PHP project.
-
-All project specific Docksal configurations and commands will be stored inside `.docksal`.
+`docroot` directory is mounted as the web server document root.  
+`.docksal` directory is where all Docksal configuration and commands for the project are stored.
 
 !!! note "Version control" 
     Git does not commit empty directories. To commit `.docksal` directory into Git repo create an empty `.gitkeep` file inside it.
@@ -28,7 +28,7 @@ cd ~/projects/myproject
 fin start
 ```
 
-You should see output like the following:
+You will see an output similar to the following:
 
 ```
 Starting services...
@@ -44,8 +44,14 @@ Restarting php daemon...
 Connected vhost-proxy to "myproject_default" network.
 ```
 
-!!! tip "SSH key password"
-    If you are being asked for password to SSH keys `id_dsa` or `id_rsa`, please know that these are **your** keys that were copied over from your `~/.ssh` folder into SSH Agent's container. Their paths looks like `/root/.ssh/...` because that's the path **inside container**. Please provide password(s) to your keys if you want to use git or drush commands that require your SSH keys within Docksal (e.g. often project init script or composer script contains repository checkout that would require your key).
+!!! tip "SSH key passphrase"
+    **Note: SSH keys passphrase** 
+    If you are being asked for an SSH key passphrase for `id_dsa` or `id_rsa`, 
+    remember, that these are **your** keys loaded from your `~/.ssh` folder into the `ssh-agent` container.  
+    That's why their paths look like `/root/.ssh/...`. That is the path **inside the ssh-agent container**.  
+    Provide password(s) if you want to use git or drush commands, that require ssh access within Docksal 
+    (e.g. often a project init script or a composer script contains a repository checkout, 
+    which would require an ssh key for access).
 
 ## 3. Your project is ready
 

--- a/docs/update-dde.md
+++ b/docs/update-dde.md
@@ -1,8 +1,8 @@
-# Updating from Drude to Docksal
+# Updating from Drude (DDE) to Docksal
 
 Drude used to rely on Vagrant and vagrant-boot2docker for running Docker.
 Docksal uses Docker Machine, which is more native and supports seamless (non-destructive) Docker version updates.
-Vagrant machine is not going to be used anymore and should be deleted.
+Drude's Vagrant machine is not going to be used anymore and should be deleted (follow instructions below).
 
 ## Create backups
 

--- a/examples/.docksal/docksal.yml
+++ b/examples/.docksal/docksal.yml
@@ -9,10 +9,10 @@
 # Docksal stiches several docker-compose configuration files together.
 # Run "fin config" to see which files are involved and the resulting configration.
 
-version: "2"
+version: "2.1"
 
 services:
-  # Web node
+  # Web
   web:
     hostname: web
     image: docksal/web:1.0-apache2.2
@@ -28,30 +28,30 @@ services:
     depends_on:
       - cli
 
-  # DB node
+  # DB
   db:
     hostname: db
     image: docksal/db:1.0-mysql-5.5
     ports:
-      - ${MYSQL_PORT}
+      - "${MYSQL_PORT_MAPPING:-3306}"
     volumes:
       # MySQL configuration overrides
       - ${PROJECT_ROOT}/.docksal/etc/mysql/my.cnf:/opt/mysql.conf.d/z_my.cnf:ro
     environment:
-      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
-      - MYSQL_USER=${MYSQL_USER}
-      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
-      - MYSQL_DATABASE=${MYSQL_DATABASE}
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-root}
+      - MYSQL_USER=${MYSQL_USER:-user}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD:-user}
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-default}
 
   # CLI node
   # Used for all console commands and tools.
   cli:
     hostname: cli
-    image: docksal/cli:1.0-php5
+    image: docksal/cli:1.0-php7
     volumes:
       # Project root folder mapping
       - ${PROJECT_ROOT}/:/var/www:rw
-      # Host home directory mapping (for SSH keys and ther credentials).
+      # Host home directory mapping (for SSH keys and other credentials).
       - ${HOME}/:/.home:ro
       # PHP FPM configuration overrides
       - ${PROJECT_ROOT}/.docksal/etc/php/php.ini:/etc/php5/fpm/conf.d/z_php.ini:ro
@@ -61,4 +61,4 @@ services:
     volumes_from:
       - container:docksal-ssh-agent
     environment:
-      - XDEBUG_ENABLED=${XDEBUG_ENABLED}
+      - XDEBUG_ENABLED=${XDEBUG_ENABLED:-0}

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -2,7 +2,7 @@
 # To use any service extend it from this file located at ${HOME}/.docksal/stacks/services.yml.
 # See ${HOME}/.docksal/stacks/default.yml for a basic LAMP stack extending from web, db and cli services in this file.
 
-version: "2"
+version: "2.1"
 
 services:
   # Web
@@ -16,18 +16,20 @@ services:
       - io.docksal.virtual-host=${VIRTUAL_HOST}
       - io.docksal.project-root=${PROJECT_ROOT}
     environment:
-      - APACHE_DOCUMENTROOT=/var/www/${DOCROOT}
+      - APACHE_DOCUMENTROOT=/var/www/${DOCROOT:-docroot}
       - VIRTUAL_HOST=${VIRTUAL_HOST}
 
   # DB
   db:
     hostname: db
     image: docksal/db:1.0-mysql-5.5
+    ports:
+      - "${MYSQL_PORT_MAPPING:-3306}"
     environment:
-      - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_USER=user
-      - MYSQL_PASSWORD=user
-      - MYSQL_DATABASE=default
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-root}
+      - MYSQL_USER=${MYSQL_USER:-user}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD:-user}
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-default}
 
   # CLI
   # Used for all console commands and tools.
@@ -58,4 +60,4 @@ services:
     image: memcached
     environment:
       # Memcached memory limit in megabytes
-      - MEMCACHED_MEMORY_LIMIT=128
+      - MEMCACHED_MEMORY_LIMIT=${MEMCACHED_MEMORY_LIMIT:-128}

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -61,3 +61,8 @@ services:
     environment:
       # Memcached memory limit in megabytes
       - MEMCACHED_MEMORY_LIMIT=${MEMCACHED_MEMORY_LIMIT:-128}
+
+  # Solr
+  solr:
+    hostname: solr
+    image: docksal/solr:4.x-stable

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -43,6 +43,8 @@ services:
       - host_home:/.home:ro
       # Shared ssh-agent socket
       - docksal_ssh_agent:/.ssh-agent:ro
+    environment:
+      - XDEBUG_ENABLED=${XDEBUG_ENABLED:-0}
 
   # Varnish
   varnish:

--- a/stacks/stack-acquia-static.yml
+++ b/stacks/stack-acquia-static.yml
@@ -23,7 +23,6 @@ services:
     environment:
       - APACHE_DOCUMENTROOT=/var/www/${DOCROOT:-docroot}
       - VIRTUAL_HOST=${VIRTUAL_HOST}
-    # cli has to be up before web
     depends_on:
       - cli
 
@@ -51,6 +50,8 @@ services:
       - host_home:/.home:ro
       # Shared ssh-agent socket
       - docksal_ssh_agent:/.ssh-agent:ro
+    environment:
+      - XDEBUG_ENABLED=${XDEBUG_ENABLED:-0}
 
   # Varnish
   varnish:
@@ -61,7 +62,6 @@ services:
     environment:
       - VARNISH_BACKEND_HOST=web
       - VIRTUAL_HOST=varnish.${VIRTUAL_HOST}
-    # web has to be up before varnish
     depends_on:
       - web
 

--- a/stacks/stack-acquia-static.yml
+++ b/stacks/stack-acquia-static.yml
@@ -1,0 +1,79 @@
+# Acquia alike stack
+#
+# - Apache 2.2
+# - MySQL 5.5
+# - PHP 5.6 / PHP 7.0
+# - Varnish 3
+# - Memcached 1.4
+# - ApacheSolr 4.x
+
+version: "2.1"
+
+services:
+  # Web
+  web:
+    hostname: web
+    image: docksal/web:1.0-apache2.2
+    volumes:
+      # Project root volume
+      - project_root:/var/www:ro
+    labels:
+      - io.docksal.virtual-host=${VIRTUAL_HOST}
+      - io.docksal.project-root=${PROJECT_ROOT}
+    environment:
+      - APACHE_DOCUMENTROOT=/var/www/${DOCROOT:-docroot}
+      - VIRTUAL_HOST=${VIRTUAL_HOST}
+    # cli has to be up before web
+    depends_on:
+      - cli
+
+  # DB
+  db:
+    hostname: db
+    image: docksal/db:1.0-mysql-5.5
+    ports:
+      - "${MYSQL_PORT_MAPPING:-3306}"
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-root}
+      - MYSQL_USER=${MYSQL_USER:-user}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD:-user}
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-default}
+
+  # CLI
+  # Used for all console commands and tools.
+  cli:
+    hostname: cli
+    image: docksal/cli:1.0-php7
+    volumes:
+      # Project root volume
+      - project_root:/var/www:rw
+      # Host home volume (for SSH keys and other credentials).
+      - host_home:/.home:ro
+      # Shared ssh-agent socket
+      - docksal_ssh_agent:/.ssh-agent:ro
+
+  # Varnish
+  varnish:
+    hostname: varnish
+    image: docksal/varnish:3.0-stable
+    labels:
+      - io.docksal.virtual-host=varnish.${VIRTUAL_HOST}
+    environment:
+      - VARNISH_BACKEND_HOST=web
+      - VIRTUAL_HOST=varnish.${VIRTUAL_HOST}
+    # web has to be up before varnish
+    depends_on:
+      - web
+
+  # Memcached
+  memcached:
+    hostname: memcached
+    image: memcached
+    environment:
+      # Memcached memory limit in megabytes
+      - MEMCACHED_MEMORY_LIMIT=${MEMCACHED_MEMORY_LIMIT:-128}
+
+  # Solr
+  solr:
+    hostname: solr
+    image: docksal/solr:4.x-stable

--- a/stacks/stack-acquia.yml
+++ b/stacks/stack-acquia.yml
@@ -15,7 +15,6 @@ services:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml
       service: web
-    # cli has to be up before web
     depends_on:
       - cli
 
@@ -36,7 +35,6 @@ services:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml
       service: varnish
-    # web has to be up before varnish
     depends_on:
       - web
 

--- a/stacks/stack-acquia.yml
+++ b/stacks/stack-acquia.yml
@@ -6,7 +6,7 @@
 # - Varnish 3
 # - Memcached 1.4
 
-version: "2"
+version: "2.1"
 
 services:
   # Web

--- a/stacks/stack-acquia.yml
+++ b/stacks/stack-acquia.yml
@@ -5,6 +5,7 @@
 # - PHP 5.6 / PHP 7.0
 # - Varnish 3
 # - Memcached 1.4
+# - ApacheSolr 4.x
 
 version: "2.1"
 
@@ -44,3 +45,9 @@ services:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml
       service: memcached
+
+  # Solr
+  solr:
+    extends:
+      file: ${HOME}/.docksal/stacks/services.yml
+      service: solr

--- a/stacks/stack-default-static.yml
+++ b/stacks/stack-default-static.yml
@@ -1,0 +1,46 @@
+# Basic LAMP stack
+
+version: "2.1"
+
+services:
+  # Web
+  web:
+    hostname: web
+    image: docksal/web:1.0-apache2.2
+    volumes:
+      # Project root volume
+      - project_root:/var/www:ro
+    labels:
+      - io.docksal.virtual-host=${VIRTUAL_HOST}
+      - io.docksal.project-root=${PROJECT_ROOT}
+    environment:
+      - APACHE_DOCUMENTROOT=/var/www/${DOCROOT:-docroot}
+      - VIRTUAL_HOST=${VIRTUAL_HOST}
+    # cli has to be up before web
+    depends_on:
+      - cli
+
+  # DB
+  db:
+    hostname: db
+    image: docksal/db:1.0-mysql-5.5
+    ports:
+      - "${MYSQL_PORT_MAPPING:-3306}"
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-root}
+      - MYSQL_USER=${MYSQL_USER:-user}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD:-user}
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-default}
+
+  # CLI
+  # Used for all console commands and tools.
+  cli:
+    hostname: cli
+    image: docksal/cli:1.0-php7
+    volumes:
+      # Project root volume
+      - project_root:/var/www:rw
+      # Host home volume (for SSH keys and other credentials).
+      - host_home:/.home:ro
+      # Shared ssh-agent socket
+      - docksal_ssh_agent:/.ssh-agent:ro

--- a/stacks/stack-default-static.yml
+++ b/stacks/stack-default-static.yml
@@ -16,7 +16,6 @@ services:
     environment:
       - APACHE_DOCUMENTROOT=/var/www/${DOCROOT:-docroot}
       - VIRTUAL_HOST=${VIRTUAL_HOST}
-    # cli has to be up before web
     depends_on:
       - cli
 
@@ -44,3 +43,5 @@ services:
       - host_home:/.home:ro
       # Shared ssh-agent socket
       - docksal_ssh_agent:/.ssh-agent:ro
+    environment:
+      - XDEBUG_ENABLED=${XDEBUG_ENABLED:-0}

--- a/stacks/stack-default.yml
+++ b/stacks/stack-default.yml
@@ -1,24 +1,24 @@
 # Basic LAMP stack
 
-version: "2"
+version: "2.1"
 
 services:
-  # Web node
+  # Web
   web:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml
       service: web
-    # cli has to be up first for web to start
+    # cli has to be up before web
     depends_on:
       - cli
 
-  # DB node
+  # DB
   db:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml
       service: db
 
-  # CLI node
+  # CLI
   cli:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml

--- a/stacks/stack-default.yml
+++ b/stacks/stack-default.yml
@@ -8,7 +8,6 @@ services:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml
       service: web
-    # cli has to be up before web
     depends_on:
       - cli
 

--- a/stacks/volumes-bind.yml
+++ b/stacks/volumes-bind.yml
@@ -1,7 +1,7 @@
 # Bind mount project volumes
 # Same as mounting host folders, but via named volumes.
 
-version: "2"
+version: "2.1"
 
 volumes:
 # Bind volumes

--- a/stacks/volumes-nfs.yml
+++ b/stacks/volumes-nfs.yml
@@ -3,7 +3,7 @@
 # Pros: very good performance, almost realtime file sync 
 # Cons: no inotify/fs watchers
 
-version: "2"
+version: "2.1"
 
 volumes:
 # NFS volumes

--- a/stacks/volumes-unison.yml
+++ b/stacks/volumes-unison.yml
@@ -3,7 +3,7 @@
 # Pros: native fs performance, fast file sync, inotify/fs watchers support.
 # Cons: 2x space usage (a mirror of the code base is maintained in a Docker volume), initial sync delay
 
-version: "2"
+version: "2.1"
 
 volumes:
   project_root:


### PR DESCRIPTION
- Switched to Docker Compose v1.9 and updated config files to compose file format v2.1
- Enabled project volumes provisioning by default. Experimental, but does not break anything for any existing projects. Used in docksal/drupal8
- `fin generate --static` to generate a standalone project stack config, which will not be updated with a new version of Docksal
- Documentation updates
