### PR TITLE
Add fin zsh command

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -872,7 +872,7 @@ show_help ()
 	printh "rm [service]" "Remove project services (${yellow}fin help rm${NC})"
 
 	echo
-	printh "bash [service]" "Open shell into container. Defaults to ${yellow}cli${NC}"
+	printh "bash [service]" "Open bash shell into container. Defaults to ${yellow}cli${NC}"
 	printh "zsh" "Open zsh shell into ${yellow}cli${NC}"
 	printh "exec <command> [params]" "Execute a command in ${yellow}cli${NC}"
 	printh "exec-url <url>" "Download script from URL and run it on host (URL should be public)"

--- a/bin/fin
+++ b/bin/fin
@@ -873,6 +873,7 @@ show_help ()
 
 	echo
 	printh "bash [service]" "Open shell into container. Defaults to ${yellow}cli${NC}"
+	printh "zsh" "Open zsh shell into ${yellow}cli${NC}"
 	printh "exec <command> [params]" "Execute a command in ${yellow}cli${NC}"
 	printh "exec-url <url>" "Download script from URL and run it on host (URL should be public)"
 	printh "logs [service]" "Show Docker logs for service container (e.g. Apache logs)"
@@ -2510,6 +2511,20 @@ _bash ()
 	CONTAINER_NAME=$1 _run bash -i
 }
 
+# Start an interactive zsh session in a container
+_zsh ()
+{
+	check_docker_running
+	# Interactive shell requires a tty.
+	# On Windows we assume we run interactively via winpty.
+	if ! is_tty; then
+		echo "Interactive zsh console in a non-interactive enveronment!? Nope, won't happen."
+		return 1
+	fi
+
+	_run zsh -i
+}
+
 # Run a command in the cli container changing dir to the same folder
 # @param $* command with it's params to run
 _run ()
@@ -3348,6 +3363,10 @@ case "$1" in
 	bash)
 		shift
 		_bash "$@"
+		;;
+	zsh)
+		shift
+		_zsh
 		;;
 	exec|run)
 		shift


### PR DESCRIPTION
The Docksal CLI container has Zsh available, but using it requires opening a bash shell first, like so:

```
breakfast@tiffanys:~/docksal-projects/drupal8$ fin bash
WARNING: No swap limit support
docker@cli:/var/www$ zsh

docker at cli in /var/www (master●)
$ 
```

This PR adds a `fin zsh` command to complement `fin bash`. 

Since Zsh is only installed in the CLI container, `fin zsh` doesn't accept a service name. `fin zsh db` wouldn't work, for example. 