### PR TITLE
Allow another port for vhost-proxy service

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -66,6 +66,8 @@ DOCKSAL_DEFAULT_SUBNET="192.168.64.1/24"
 DOCKSAL_DEFAULT_DNS="10.0.2.3"
 DOCKSAL_DEFAULT_DNS_NIX="8.8.8.8"
 DOCKSAL_DNS_DOMAIN="${DOCKSAL_DNS_DOMAIN:-docksal}"
+DOCKSAL_VHOST_PROXY_PORT_HTTP="${DOCKSAL_VHOST_PROXY_PORT_HTTP:-80}"
+DOCKSAL_VHOST_PROXY_PORT_HTTPS="${DOCKSAL_VHOST_PROXY_PORT_HTTPS:-443}"
 
 DEFAULT_MACHINE_NAME='docksal'
 DEFAULT_MACHINE_PROVIDER='virtualbox'
@@ -1903,7 +1905,7 @@ install_proxy_service ()
 	# PROJECT_INACTIVITY_TIMEOUT, PROJECT_DANGLING_TIMEOUT and PROJECTS_ROOT (docksal_projects volume) are used in CI
 	# and are inactive unless configured.
 	docker run -d --name docksal-vhost-proxy --label "io.docksal.group=system" --restart=always --privileged --userns=host \
-		-p 80:80 -p 443:443 \
+		-p "${DOCKSAL_VHOST_PROXY_PORT_HTTP:-80}":80 -p "${DOCKSAL_VHOST_PROXY_PORT_HTTPS:-443}":443 \
 		-e PROJECT_INACTIVITY_TIMEOUT="${PROJECT_INACTIVITY_TIMEOUT:-0}" \
 		-e PROJECT_DANGLING_TIMEOUT="${PROJECT_DANGLING_TIMEOUT:-0}" \
 		-v docksal_projects:/projects \


### PR DESCRIPTION
to be able to avoid port conflicts with already running apache or nginx server.