### PR TITLE
Docs: workaround for search not working see rtfd/readthedocs.org#1088

### DIFF
--- a/docs/custom_theme/searchbox.html
+++ b/docs/custom_theme/searchbox.html
@@ -1,0 +1,5 @@
+<div role="search">
+  <form id ="rtd-search-form-alt" class="wy-form" action="{{ base_url }}/search.html" method="get">
+    <input type="text" name="q" placeholder="Search docs" />
+  </form>
+</div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Docksal Documentation
 theme: readthedocs
+theme_dir: 'docs/custom_theme'
 repo_url: https://github.com/docksal/docksal
 extra_css:
   - css/extra.css


### PR DESCRIPTION
Issue: search is not working at http://docksal.readthedocs.io

Steps to reproduce the issues:
* open http://docksal.readthedocs.io
* try to search for something, e.g. "zero" (I was looking for instructions for zero configuration setup)

Expected result:
* search results should be shown (as I know that zero configuration setup is documented)

Current result::
* nothing found
* search url looks like: https://readthedocs.org/search/?q=zero&check_keywords=yes&area=default&project=docksal&version=master&type=file

After some research I found these threads below and that workaround is to change the search result URL to, e.g. http://docksal.readthedocs.io/en/master/search.html?q=zero

Referenced issues:
https://github.com/rtfd/readthedocs.org/issues/1487
https://github.com/rtfd/readthedocs.org/issues/1088

This PR contains workaround commit that has been copied from rtfd/readthedocs.org#1088