### PR TITLE
fin run-cli

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -711,6 +711,7 @@ _start_containers ()
 		# Give time for startup.sh in CLI to execute otherwise UID is changed too quickly
 		# which prevents xdebug from loading properly
 		sleep 1 && \
+		# TODO: remove in September 2017, as this functionality was ported inside docksal/cli
 		_set_cli_uid && \
 		_vhost_proxy_connect
 }
@@ -2796,19 +2797,51 @@ _run ()
 		return
 	fi
 
-	# Source $HOME/.docksalrc in cli.
-	# Commands in this file will be sourced for both interactive and non-interactive sessions.
-	DOCKSALRC='source $HOME/.docksalrc >/dev/null 2>&1'
+	if [[ "$CONTAINER_NAME" == "cli" ]]; then
+		# Source $HOME/.docksalrc in cli.
+		# Commands in this file will be sourced for both interactive and non-interactive sessions.
+		DOCKSALRC='source $HOME/.docksalrc >/dev/null 2>&1'
+	fi
+
 	# Enter project containers
+	# Use the docker user in cli (-u docker) instead of root (default user).
 	if is_tty && [[ "$no_tty" != true ]]; then
 		# interactive
 		# (exit \$?) is a hack to return correct exit codes when docker exec is run with tty (-t).
-		${winpty} docker exec -it "$container_id" bash -ic "$DOCKSALRC; $cmd; (exit \$?)"
+		${winpty} docker exec -it -u docker "$container_id" bash -ic "$DOCKSALRC; $cmd; (exit \$?)"
 	else
 		# non-interactive
-		docker exec "$container_id" bash -c "$DOCKSALRC; $cmd"
+		docker exec -u docker "$container_id" bash -c "$DOCKSALRC; $cmd"
 	fi
 	# ------------------------------------------------ #
+}
+
+# Run a command in a standalone cli container (outside of any project).
+# The current directory on the host is mapped to /var/www inside the container.
+# @param $* command with it's params to run.
+run_cli ()
+{
+	# Allow disabling TTY mode.
+	# Useful for non-interactive commands when output is saved into a variable for further comparison.
+	# In a TTY mode the output may contain unexpected control symbols/etc.
+	[[ $1 == "-T" ]] && \
+		local no_tty=true && shift
+	# Set default image
+	local IMAGE="${IMAGE:-docksal/cli}"
+	local cmd="$@"
+
+	# Source $HOME/.docksalrc in cli.
+	# Commands in this file will be sourced for both interactive and non-interactive sessions.
+	DOCKSALRC='source $HOME/.docksalrc >/dev/null 2>&1'
+
+	if is_tty && [[ "$no_tty" != true ]]; then
+		# interactive
+		# (exit \$?) is a hack to return correct exit codes when docker exec is run with tty (-t).
+		${winpty} docker run --rm -it -v $(pwd):/var/www -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) ${IMAGE} bash -ic "$DOCKSALRC; $cmd; (exit \$?)"
+	else
+		# non-interactive
+		docker run --rm -v $(pwd):/var/www -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) ${IMAGE} bash -c "$DOCKSALRC; $cmd"
+	fi
 }
 
 # Start interactive mysql shell
@@ -3009,6 +3042,7 @@ logs ()
 	docker-compose logs "$@"
 }
 
+# TODO: remove in September 2017, as this functionality was ported inside docksal/cli
 # Set uid of the primary "docker" user in the cli container
 # Useful to match the host uid with the uid in the cli container and avoid file permission issues this way.
 _set_cli_uid ()
@@ -3024,7 +3058,7 @@ _set_cli_uid ()
 	fi
 
 	local container_uid
-	container_uid=$(docker exec ${cli} id -u)
+	container_uid=$(docker exec ${cli} id -u docker)
 	if [[ ! $? -eq 0 ]]; then
 		echo-red 'Error getting uid from cli container'
 		echo "You might need to recreate containers with fin reset"
@@ -3035,11 +3069,13 @@ _set_cli_uid ()
 		return
 	fi
 
+	# TODO: output a note to the user about updating their custom yml configuration (point to the docs).
 	if [[ "$host_uid" != "0" ]] ; then
 		echo-green "Changing user id in cli to $host_uid to match host user id..."
 		docker exec -u root ${cli} usermod -u "$host_uid" -o docker
-		echo-green "Resetting permissions on /var/www..."
-		docker exec -u root ${cli} chown -R docker:users /var/www
+		# TODO: remove once confirmed this is no longer necessary
+		#echo-green "Resetting permissions on /var/www..."
+		#docker exec -u root ${cli} chown -R -h docker:users /var/www
 	else
 		echo -e "${green}Changing user id in cli to 0 to match host user id ${NC}${yellow}(running as root is not recommended)...${NC}"
 		docker exec -u root ${cli} usermod -u 0 -o docker
@@ -3271,6 +3307,10 @@ load_configuration ()
 	is_windows && export PROJECT_ROOT_WIN="$(get_project_path_dc)"
 	# Set this to 0 to account for docker-compose bug https://github.com/docker/compose/pull/4294
 	export COMPOSE_CONVERT_WINDOWS_PATHS=0
+
+	# Export host user uid/gid
+	export HOST_UID=$(id -u)
+	export HOST_GID=$(id -g)
 
 	if is_docker_running; then
 		export DOCKER_RUNNING="true"
@@ -3538,6 +3578,7 @@ fi
 	[[ "$*" != "reset ssh-agent" ]] &&
 	[[ "$*" != "reset system" ]] &&
 	[[ "$1" != "projects" ]] &&
+	[[ "$1" != "rc" ]] &&
 	load_configuration &&
 	[[ "$NO_UPDATES" != "1" ]] && check_for_updates
 
@@ -3636,6 +3677,10 @@ case "$1" in
 		else
 			_run "$@"
 		fi
+		;;
+	run-cli|rc)
+		shift
+		run_cli "$@"
 		;;
 	mysql|sqlc)
 		shift

--- a/bin/fin
+++ b/bin/fin
@@ -958,6 +958,7 @@ show_help ()
 
 	echo
 	printh "config" "Display/generate project configuration (${yellow}fin help config${NC})"
+	printh "run-cli (rc) <command>" "Run a command in a standalone cli container in the current directory"
 	printh "share" "Share web server of the current project on the internet using ngrok"
 	printh "sysinfo" "Show diagnostics information for bug reporting"
 	printh "alias" "Create/remove folder aliases (${yellow}fin help alias${NC})"

--- a/bin/fin
+++ b/bin/fin
@@ -2757,7 +2757,7 @@ _exec ()
 		local no_tty=true && shift
 
 	# CONTAINER_NAME can be used to override where to run. Used in _bash()
-	if [[ "$CONTAINER_NAME" == "" ]]; then CONTAINER_NAME='cli'; fi
+	CONTAINER_NAME=${CONTAINER_NAME:-cli}
 	container_id=$(get_container_id "$CONTAINER_NAME")
 
 	# ------------------------------------------------ #
@@ -2800,7 +2800,9 @@ _exec ()
 	if [[ "$CONTAINER_NAME" == "cli" ]]; then
 		# Source $HOME/.docksalrc in cli.
 		# Commands in this file will be sourced for both interactive and non-interactive sessions.
-		DOCKSALRC='source $HOME/.docksalrc >/dev/null 2>&1'
+		local DOCKSALRC='source $HOME/.docksalrc >/dev/null 2>&1'
+		# Commands in cli should be run using the docker user, not root.
+		local container_user='-u docker'
 	fi
 
 	# Enter project containers
@@ -2808,10 +2810,10 @@ _exec ()
 	if is_tty && [[ "$no_tty" != true ]]; then
 		# interactive
 		# (exit \$?) is a hack to return correct exit codes when docker exec is run with tty (-t).
-		${winpty} docker exec -it -u docker "$container_id" bash -ic "$DOCKSALRC; $cmd; (exit \$?)"
+		${winpty} docker exec -it $container_user "$container_id" bash -ic "$DOCKSALRC; $cmd; (exit \$?)"
 	else
 		# non-interactive
-		docker exec -u docker "$container_id" bash -c "$DOCKSALRC; $cmd"
+		docker exec $container_user "$container_id" bash -c "$DOCKSALRC; $cmd"
 	fi
 	# ------------------------------------------------ #
 }

--- a/bin/fin
+++ b/bin/fin
@@ -2800,7 +2800,7 @@ _exec ()
 	if [[ "$CONTAINER_NAME" == "cli" ]]; then
 		# Source $HOME/.docksalrc in cli.
 		# Commands in this file will be sourced for both interactive and non-interactive sessions.
-		local DOCKSALRC='source $HOME/.docksalrc >/dev/null 2>&1'
+		local DOCKSALRC='source $HOME/.docksalrc >/dev/null 2>&1;'
 		# Commands in cli should be run using the docker user, not root.
 		local container_user='-u docker'
 	fi
@@ -2810,10 +2810,10 @@ _exec ()
 	if is_tty && [[ "$no_tty" != true ]]; then
 		# interactive
 		# (exit \$?) is a hack to return correct exit codes when docker exec is run with tty (-t).
-		${winpty} docker exec -it $container_user "$container_id" bash -ic "$DOCKSALRC; $cmd; (exit \$?)"
+		${winpty} docker exec -it $container_user "$container_id" bash -ic "$DOCKSALRC $cmd; (exit \$?)"
 	else
 		# non-interactive
-		docker exec $container_user "$container_id" bash -c "$DOCKSALRC; $cmd"
+		docker exec $container_user "$container_id" bash -c "$DOCKSALRC $cmd"
 	fi
 	# ------------------------------------------------ #
 }

--- a/bin/fin
+++ b/bin/fin
@@ -2742,7 +2742,7 @@ _bash ()
 }
 
 # Run a command in the cli container changing dir to the same folder
-# @param $* command with it's params to run
+# @param $* command with its params to run
 _exec ()
 {
 	[[ $1 == "" ]] && \
@@ -2820,7 +2820,7 @@ _exec ()
 
 # Run a command in a standalone cli container (outside of any project).
 # The current directory on the host is mapped to /var/www inside the container.
-# @param $* command with it's params to run.
+# @param $* command with its params to run.
 run_cli ()
 {
 	# Allow disabling TTY mode.
@@ -2836,13 +2836,16 @@ run_cli ()
 	# Commands in this file will be sourced for both interactive and non-interactive sessions.
 	DOCKSALRC='source $HOME/.docksalrc >/dev/null 2>&1'
 
+	# Debug mode off by default
+	DEBUG=${DEBUG:-0}
+
 	if is_tty && [[ "$no_tty" != true ]]; then
 		# interactive
 		# (exit \$?) is a hack to return correct exit codes when docker exec is run with tty (-t).
-		${winpty} docker run --rm -it -v $(pwd):/var/www -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) ${IMAGE} bash -ic "$DOCKSALRC; $cmd; (exit \$?)"
+		${winpty} docker run --rm -it -v $(pwd):/var/www -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) -e DEBUG="$DEBUG" ${IMAGE} bash -ic "$DOCKSALRC; $cmd; (exit \$?)"
 	else
 		# non-interactive
-		docker run --rm -v $(pwd):/var/www -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) ${IMAGE} bash -c "$DOCKSALRC; $cmd"
+		docker run --rm -v $(pwd):/var/www -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) -e DEBUG="$DEBUG" ${IMAGE} bash -c "$DOCKSALRC; $cmd"
 	fi
 }
 
@@ -3051,6 +3054,7 @@ _set_cli_uid ()
 {
 	# Let uid to be set with the FIN_SET_UID env variable
 	local host_uid=${FIN_SET_UID:-$(id -u)}
+	local host_gid=${FIN_SET_GID:-$(id -g)}
 	local cli=$(get_container_id cli || true)
 
 	# If there is no cli, move on.
@@ -3060,28 +3064,29 @@ _set_cli_uid ()
 	fi
 
 	local container_uid
-	container_uid=$(docker exec ${cli} id -u docker)
+	# Get both uid and gid in one shot to save time
+	container_uid_gid=$(docker exec -u docker ${cli} bash -c 'echo -n $(id -u):$(id -g)')
 	if [[ ! $? -eq 0 ]]; then
 		echo-red 'Error getting uid from cli container'
 		echo "You might need to recreate containers with fin reset"
 		return
 	fi
 
-	if [[ "$container_uid" == "$host_uid" ]]; then
+	if [[ "$container_uid_gid" == "$host_uid:$host_gid" ]]; then
 		return
 	fi
 
 	# TODO: output a note to the user about updating their custom yml configuration (point to the docs).
 	if [[ "$host_uid" != "0" ]] ; then
-		echo-green "Changing user id in cli to $host_uid to match host user id..."
-		docker exec -u root ${cli} usermod -u "$host_uid" -o docker
-		# TODO: remove once confirmed this is no longer necessary
-		#echo-green "Resetting permissions on /var/www..."
-		#docker exec -u root ${cli} chown -R -h docker:users /var/www
+		echo-green "Changing uid/gid in cli to $host_uid/$host_gid to match the host"
 	else
 		echo -e "${green}Changing user id in cli to 0 to match host user id ${NC}${yellow}(running as root is not recommended)...${NC}"
-		docker exec -u root ${cli} usermod -u 0 -o docker
 	fi
+	docker exec -u root ${cli} usermod -u "$host_uid" -o docker >/dev/null 2>&1
+	docker exec -u root ${cli} groupmod -g "$host_gid" -o users >/dev/null 2>&1
+	# TODO: remove once confirmed this is no longer necessary
+	#echo-green "Resetting permissions on /var/www..."
+	#docker exec -u root ${cli} chown -R -h docker:users /var/www
 
 	echo-green "Restarting php daemon..."
 	docker exec -u root ${cli} supervisorctl restart php-fpm >/dev/null

--- a/bin/fin
+++ b/bin/fin
@@ -2829,7 +2829,8 @@ run_cli ()
 	[[ $1 == "-T" ]] && \
 		local no_tty=true && shift
 	# Set default image
-	local IMAGE="${IMAGE:-docksal/cli}"
+	# TODO: set the defaul image to docksal/cli once cli v1.2.0 is released
+	local IMAGE="${IMAGE:-docksal/cli:edge-php7}"
 	local cmd="$@"
 
 	# Source $HOME/.docksalrc in cli.

--- a/bin/fin
+++ b/bin/fin
@@ -324,7 +324,7 @@ get_current_relative_path ()
 get_mysql_connect ()
 {
 	# Run drush forcing tty to false to avoid colored output string from drush.
-	cleaned_string=$(echo $(_run drush sql-connect) | sed -e 's/[^a-zA-Z0-9_-]$//')
+	cleaned_string=$(echo $(_exec drush sql-connect) | sed -e 's/[^a-zA-Z0-9_-]$//')
 	echo "$cleaned_string"
 }
 
@@ -2738,12 +2738,12 @@ _bash ()
 	fi
 
 	# Pass container name to _run
-	CONTAINER_NAME=$1 _run bash -i
+	CONTAINER_NAME=$1 _exec bash -i
 }
 
 # Run a command in the cli container changing dir to the same folder
 # @param $* command with it's params to run
-_run ()
+_exec ()
 {
 	[[ $1 == "" ]] && \
 		show_help_exec && exit
@@ -2874,7 +2874,7 @@ mysql_list ()
 
 	# -N parameter suppresses columns header
 	_RUN_NO_CDIR=1 CONTAINER_NAME="db" \
-		_run "echo 'show databases' | mysql -N -u $__dump_user -p${__dump_password}"
+		_exec "echo 'show databases' | mysql -N -u $__dump_user -p${__dump_password}"
 }
 
 # Truncate db and import from sql dump
@@ -2909,7 +2909,7 @@ mysql_import ()
 	local TRUNCATE_DATABASE_COMMAND="mysqldump -u$__dump_user -p$__dump_password --add-drop-table --no-data $__database | grep -e '^DROP \| FOREIGN_KEY_CHECKS' | mysql -u$__dump_user -p$__dump_password $__database"
 
 	_RUN_NO_CDIR=1 CONTAINER_NAME="db" \
-		_run "${TRUNCATE_DATABASE_COMMAND}"
+		_exec "${TRUNCATE_DATABASE_COMMAND}"
 
 	if [[ ! $? -eq 0 ]] && (exit ${confirm}); then
 		_confirm "There were errors during truncation. Continue anyways?"
@@ -3673,9 +3673,9 @@ case "$1" in
 		if [ -f "$1" ]; then
 			# if a file is passed then run it inside cli container
 			[ "$(get_project_path)" == "" ] && echo "Should be run inside a project" && exit 1
-			_run "PROJECT_ROOT=/var/www DOCROOT=$DOCROOT VIRTUAL_HOST=$VIRTUAL_HOST /bin/bash $1"
+			_exec "PROJECT_ROOT=/var/www DOCROOT=$DOCROOT VIRTUAL_HOST=$VIRTUAL_HOST /bin/bash $1"
 		else
-			_run "$@"
+			_exec "$@"
 		fi
 		;;
 	run-cli|rc)
@@ -3701,25 +3701,25 @@ case "$1" in
 	drush)
 		shift
 		if [[ $1 == "" ]]; then
-			_run drush
+			_exec drush
 		else
-			_run drush "$@"
+			_exec drush "$@"
 		fi
 		;;
 	drupal)
 		shift
 		if [[ "$1" == "" ]]; then
-			_run drupal
+			_exec drupal
 		else
-			_run drupal "$@"
+			_exec drupal "$@"
 		fi
 		;;
 	wp)
 		shift
 		if [[ "$1" == "" ]]; then
-			_run wp
+			_exec wp
 		else
-			_run wp "$@"
+			_exec wp "$@"
 		fi
 		;;
 	ssh-add)

--- a/bin/fin
+++ b/bin/fin
@@ -3085,8 +3085,8 @@ _set_cli_uid ()
 	docker exec -u root ${cli} usermod -u "$host_uid" -o docker >/dev/null 2>&1
 	docker exec -u root ${cli} groupmod -g "$host_gid" -o users >/dev/null 2>&1
 	# TODO: remove once confirmed this is no longer necessary
-	#echo-green "Resetting permissions on /var/www..."
-	#docker exec -u root ${cli} chown -R -h docker:users /var/www
+	echo-green "Resetting permissions on /var/www..."
+	docker exec -u root ${cli} chown -R -h $host_uid:$host_gid /var/www
 
 	echo-green "Restarting php daemon..."
 	docker exec -u root ${cli} supervisorctl restart php-fpm >/dev/null

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -52,6 +52,8 @@ services:
       # Shared ssh-agent socket
       - docksal_ssh_agent:/.ssh-agent:ro
     environment:
+      - HOST_UID=${HOST_UID}
+      - HOST_GID=${HOST_GID}
       - XDEBUG_ENABLED=${XDEBUG_ENABLED:-0}
     dns:
       - ${DOCKSAL_DNS1}

--- a/tests/smoke-test-cli-tools.bats
+++ b/tests/smoke-test-cli-tools.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+# Debugging
+teardown() {
+	echo "Status: $status"
+	echo "Output:"
+	echo "================================================================"
+	for line in "${lines[@]}"; do
+		echo $line
+	done
+	echo "================================================================"
+}
+
+# Global skip
+# Uncomment below, then comment skip in the test you want to debug. When done, reverse.
+#SKIP=1
+
+@test "fin drush" {
+	[[ $SKIP == 1 ]] && skip
+
+	# Default drush (8)
+	run fin drush --version
+	echo "$output" | egrep "Drush Version   :  8\..+"
+
+	# Drush 6
+	run fin exec drush6 --version
+	echo "$output" | egrep "Drush Version   :  6\..+"
+
+	# Drush 7
+	run fin exec drush7 --version
+	echo "$output" | egrep "Drush Version   :  7\..+"
+}
+
+@test "fin drupal" {
+	[[ $SKIP == 1 ]] && skip
+
+	run fin drupal --version
+	echo "$output" | egrep "Drupal Console Launcher version 1\..+"
+}

--- a/tests/smoke-test-duplicates.bats
+++ b/tests/smoke-test-duplicates.bats
@@ -1,6 +1,23 @@
 #!/usr/bin/env bats
 
+# Debugging
+teardown() {
+	echo "Status: $status"
+	echo "Output:"
+	echo "================================================================"
+	for line in "${lines[@]}"; do
+		echo $line
+	done
+	echo "================================================================"
+}
+
+# Global skip
+# Uncomment below, then comment skip in the test you want to debug. When done, reverse.
+#SKIP=1
+
 @test "Start project1" {
+	[[ $SKIP == 1 ]] && skip
+
 	mkdir -p 'project1/.docksal'
 	cd 'project1'
 	fin start
@@ -10,6 +27,8 @@
 
 # create project name conflict
 @test "Try starting project1 duplicate" {
+	[[ $SKIP == 1 ]] && skip
+
 	mkdir -p 'duplicate/project1/.docksal'
 	cd 'duplicate/project1'
 	run fin start
@@ -18,6 +37,8 @@
 
 # create VIRTUAL_HOST conflict
 @test "Try starting project1 VIRTUAL_HOST conflict" {
+	[[ $SKIP == 1 ]] && skip
+
 	mkdir -p 'project2/.docksal'
 	echo 'VIRTUAL_HOST=project1.docksal' > 'project2/.docksal/docksal.env'
 	cd 'project2'

--- a/tests/smoke-test-general.bats
+++ b/tests/smoke-test-general.bats
@@ -215,6 +215,7 @@ teardown() {
 	# Test output in TTY vs no-TTY mode.
 	[[ "$(fin exec echo)" != "$(fin exec -T echo)" ]]
 
+	# Test the no-TTY output is a "clean" string (does not have extra control characters and can be compared)
 	run fin exec -T pwd
 	[[ "$output" == "/var/www" ]]
 
@@ -222,6 +223,14 @@ teardown() {
 	cd docroot
 	run fin exec -T pwd
 	[[ "$output" == "/var/www/docroot" ]]
+
+	# fin exec uses the docker user
+	run fin exec -T id -un
+	[[ "$output" == "docker" ]]
+
+	# docker user uid/gid in cli matches the host user uid/gid
+	run fin exec -T 'echo $(id -u):$(id -g)'
+	[[ "$output" == "$(id -u):$(id -g)" ]]
 }
 
 @test "fin rm -f" {

--- a/tests/smoke-test-general.bats
+++ b/tests/smoke-test-general.bats
@@ -236,9 +236,8 @@ teardown() {
 @test "fin run-cli" {
 	[[ $SKIP == 1 ]] && skip
 
-	# TODO: remove the image override once the new version of cli is released
-	export IMAGE=docksal/cli:edge-php7
-	fin docker pull ${IMAGE} >/dev/null
+	# Dummy command to pre-pull the image run-cli is using.
+	fin rc uname
 
 	# Test output in TTY vs no-TTY mode.
 	[[ "$(fin rc echo)" != "$(fin rc -T echo)" ]]

--- a/tests/smoke-test-general.bats
+++ b/tests/smoke-test-general.bats
@@ -233,6 +233,25 @@ teardown() {
 	[[ "$output" == "$(id -u):$(id -g)" ]]
 }
 
+@test "fin run-cli" {
+	[[ $SKIP == 1 ]] && skip
+
+	# TODO: remove the image override once the new version of cli is released
+	export IMAGE=docksal/cli:edge-php7
+	fin docker pull ${IMAGE} >/dev/null
+
+	# Test output in TTY vs no-TTY mode.
+	[[ "$(fin rc echo)" != "$(fin rc -T echo)" ]]
+
+	# fin rc uses the docker user
+	run fin rc -T id -un
+	[[ "$output" == "docker" ]]
+
+	# docker user uid/gid in cli matches the host user uid/gid
+	run fin rc -T 'echo $(id -u):$(id -g)'
+	[[ "$output" == "$(id -u):$(id -g)" ]]
+}
+
 @test "fin rm -f" {
 	[[ $SKIP == 1 ]] && skip
 	

--- a/tests/smoke-test-general.bats
+++ b/tests/smoke-test-general.bats
@@ -224,23 +224,6 @@ teardown() {
 	[[ "$output" == "/var/www/docroot" ]]
 }
 
-@test "fin drush" {
-	[[ $SKIP == 1 ]] && skip
-	
-	# Default drush (8)
-	run fin drush --version
-	echo "$output" | egrep "Drush Version   :  8.*"
-
-	# Drush 6
-	run fin exec drush6 --version
-	echo "$output" | egrep "Drush Version   :  6.*"
-
-	# Drush 7
-	run fin exec drush7 --version
-	echo "$output" | egrep "Drush Version   :  7.*"
-}
-
-
 @test "fin rm -f" {
 	[[ $SKIP == 1 ]] && skip
 	


### PR DESCRIPTION
This new commands allows running a command in a standalone cli container (outside of any project). The current directory on the host is mapped to /var/www inside the container.

Host user uid/gid are mapped during container startup. This is now handled by the cli container itself: https://github.com/docksal/service-cli/commit/857a91d77d10ca20ded7a7006270e293a7d2ef87
Backward compatibility is preserved - fin will still run _set_cli_uid() when starting a project stack.