### PR TITLE
Fix #200 - VBox installer path on Windows

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -2586,7 +2586,8 @@ update_virtualbox () {
 
 	# Download and install Win
 	is_windows && (
-		cmd /c start "$vbox_pkg"
+		# Using cygpath -w here to get a Windows native path to the installer, so that cmd will understand it.
+		cmd /c start "$(cygpath -w $vbox_pkg)"
 	)
 
 	# Wait for installation to finish


### PR DESCRIPTION
This will fix #200, where VirtualBox installer path was passed to cmd.exe in Linux format instead of Windows.