### PR TITLE
DNS resolver refactoring. Fixes #242

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -105,10 +105,11 @@ DOCKSAL_NATIVE_IP="192.168.64.100"
 DOCKSAL_DEFAULT_IP="192.168.64.100"
 DOCKSAL_DEFAULT_SUBNET="192.168.64.1/24"
 
-DOCKSAL_DNS_VBOX="10.0.2.3"
-DOCKSAL_DNS_EXT="${DOCKSAL_DNS_EXT:-8.8.8.8}"
-DOCKSAL_DNS_UPSTREAM="${DOCKSAL_DNS_UPSTREAM}"
+# For environments, where access to external DNS servers is blocked, DOCKSAL_DNS_UPSTREAM should be set to the LAN DNS server
+DOCKSAL_DNS_UPSTREAM="${DOCKSAL_DNS_UPSTREAM:-8.8.8.8}"
 DOCKSAL_DNS_DOMAIN="${DOCKSAL_DNS_DOMAIN:-docksal}"
+# Allow disabling the DNS resolver configuration (in case there are issues with it). Set to "true" to activate.
+DOCKSAL_NO_DNS_RESOLVER="${DOCKSAL_NO_DNS_RESOLVER}"
 
 # Declaring possible vhost-proxy settings overrides
 DOCKSAL_VHOST_PROXY_IP="${DOCKSAL_VHOST_PROXY_IP}"
@@ -2265,19 +2266,9 @@ install_proxy_service ()
 # Start system-wide dns service
 install_dns_service ()
 {
-	# Allow overriding DNS upstream via DOCKSAL_DNS_UPSTREAM
-	# Use VBox/host resolver when VBox is used
-	local dns
-	# Forward DNS requests to DOCKSAL_DNS_EXT on Docker for Mac/Win and on Linux
-	if is_docker_native || is_linux; then
-		dns=${DOCKSAL_DNS_UPSTREAM:-${DOCKSAL_DNS_EXT}}
-	else
-		dns=${DOCKSAL_DNS_UPSTREAM:-${DOCKSAL_DNS_VBOX}}
-	fi
-
 	docker rm -f docksal-dns >/dev/null 2>&1 || true
 	docker run -d --name docksal-dns --label "io.docksal.group=system" --restart=always \
-		-p "${DOCKSAL_IP}:53:53/udp" --cap-add=NET_ADMIN --dns="$dns" \
+		-p "${DOCKSAL_IP}:53:53/udp" --cap-add=NET_ADMIN --dns="$DOCKSAL_DNS_UPSTREAM" \
 		-e DNS_IP="$DOCKSAL_IP" -e DNS_DOMAIN="$DOCKSAL_DNS_DOMAIN" \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		"${IMAGE_DNS}" >/dev/null
@@ -2344,9 +2335,26 @@ configure_resolver_windows () {
 # Configure system-wide *.docksal resolver (Windows is not supported)
 configure_resolver ()
 {
-	is_mac && configure_resolver_mac && return $?
-	is_linux && configure_resolver_linux && return $?
-	is_windows && configure_resolver_windows && return $?
+	# Do not configure the resolver if asked so
+	[[ "$DOCKSAL_NO_DNS_RESOLVER" != "" ]] && return
+
+	# Probing the upstream DNS server
+	# We want to make sure the upstream DNS server is reachable before configuring the host to use our DNS service.
+	# If it's not reachable, hosts DNS resolution may be affected or stop working entirely.
+	# nslookup returns 0 exit code regardless of the results, so have to pipe it ot grep
+	nslookup -tymeout=1 google.com "$DOCKSAL_DNS_UPSTREAM" 2>/dev/null | grep google.com >/dev/null
+	if [[ $? == 0 ]]; then
+		is_mac && configure_resolver_mac && return $?
+		is_linux && configure_resolver_linux && return $?
+		is_windows && configure_resolver_windows && return $?
+	else
+		echo-error "The upstream DNS server ($DOCKSAL_DNS_UPSTREAM) is not reachable." \
+			"You are either not connected to the internet or DNS requests to $DOCKSAL_DNS_UPSTREAM are blocked." \
+			"You can proceed with the current operation. When it's done:" \
+			"  1. Open ${yellow}~/.docksal/docksal.env${NC} and set ${yellow}DOCKSAL_DNS_UPSTREAM${NC} to your local network DNS server" \
+			"  2. Run ${yellow}fin reset dns${NC} to see if it works"
+		_confirm "Do you want to continue?"
+	fi
 }
 
 install_sshagent_service ()
@@ -3878,11 +3886,11 @@ fi
 if is_docker_native; then
 	export DOCKSAL_IP=${DOCKSAL_NATIVE_IP}
 	export DOCKSAL_DNS1=${DOCKSAL_IP}
-	export DOCKSAL_DNS2=${DOCKSAL_DNS_UPSTREAM:-$DOCKSAL_DNS_EXT}
+	export DOCKSAL_DNS2=${DOCKSAL_DNS_UPSTREAM}
 else
 	export DOCKSAL_IP=${DOCKSAL_DEFAULT_IP}
 	export DOCKSAL_DNS1=${DOCKSAL_IP}
-	export DOCKSAL_DNS2=${DOCKSAL_DNS_UPSTREAM:-$DOCKSAL_DNS_EXT}
+	export DOCKSAL_DNS2=${DOCKSAL_DNS_UPSTREAM}
 fi
 
 # Export environment variables to properly reach Docker server

--- a/bin/fin
+++ b/bin/fin
@@ -1906,6 +1906,8 @@ vm ()
 			docker-machine status "$machine_name"
 			;;
 		stop)
+			# Disable resolver configuration before machine is turned off
+			configure_resolver off
 			docker_machine_stop
 			;;
 		ssh)
@@ -1916,6 +1918,8 @@ vm ()
 			vm-stats
 			;;
 		kill)
+			# Disable resolver configuration before machine is turned off
+			configure_resolver off
 			shift
 			local machine_name="${1:-$DOCKER_MACHINE_NAME}"
 			docker-machine kill "$machine_name"
@@ -1924,6 +1928,8 @@ vm ()
 			docker-machine ls
 			;;
 		remove|rm)
+			# Disable resolver configuration before machine is turned off
+			configure_resolver off
 			shift
 			local machine_name="${1:-$DOCKER_MACHINE_NAME}"
 			docker_machine_remove "$machine_name"
@@ -2276,15 +2282,22 @@ install_dns_service ()
 
 # Configure system-wide *.docksal resolver using /etc/resolver
 configure_resolver_mac () {
-	# Check whether resolver is already configured
-	if ! (grep "^nameserver $DOCKSAL_IP$" /etc/resolver/$DOCKSAL_DNS_DOMAIN >/dev/null 2>&1); then
-		sudo mkdir -p /etc/resolver
-		# deleting old resolver is the only way to get mac to update config
+	local mode="$1"
+
+	if [[ "$mode" != "off" ]]; then
+		# Check whether resolver is already configured
+		if ! (grep "^nameserver $DOCKSAL_IP$" /etc/resolver/$DOCKSAL_DNS_DOMAIN >/dev/null 2>&1); then
+			sudo mkdir -p /etc/resolver
+			# deleting old resolver is the only way to get mac to update config
+			sudo rm -r "/etc/resolver/$DOCKSAL_DNS_DOMAIN" >/dev/null 2>&1
+			# NO \n at the beginning of line here!
+			echo -e "# .$DOCKSAL_DNS_DOMAIN domain resolution\nnameserver $DOCKSAL_IP" | \
+				sudo tee 1>/dev/null "/etc/resolver/$DOCKSAL_DNS_DOMAIN"
+		fi
+	else
 		sudo rm -r "/etc/resolver/$DOCKSAL_DNS_DOMAIN" >/dev/null 2>&1
-		# NO \n at the beginning of line here!
-		echo -e "# .$DOCKSAL_DNS_DOMAIN domain resolution\nnameserver $DOCKSAL_IP" | \
-			sudo tee 1>/dev/null "/etc/resolver/$DOCKSAL_DNS_DOMAIN"
 	fi
+
 	# Flush DNS cache
 	sudo dscacheutil -flushcache
 	# to check: scutil --dns
@@ -2292,6 +2305,12 @@ configure_resolver_mac () {
 
 # Configure system-wide *.docksal resolver using custom subnet and dns-nameservers instruction
 configure_resolver_linux () {
+	local mode="$1"
+
+	# TODO: implement the off/disabled mode on Linux
+	[[ "$mode" == "off" ]] && return
+
+	# TODO: split resolver and network configuration into different functions
 	# Adding a subnet for Docksal. Make sure we don't do this twice
 	if ! grep -q "$DOCKSAL_DEFAULT_SUBNET" /etc/network/interfaces; then
 		echo-green "Adding a subnet for Docksal..."
@@ -2309,7 +2328,19 @@ EOF
 }
 
 # Configure system-wide *.docksal resolver
+# @param $1 mode, set to "off" to disable/revert settings, leave empty to enable
 configure_resolver_windows () {
+	local mode="$1"
+
+	local dns_ip="$DOCKSAL_IP"
+	# 10 is used increase the adapter's priority. 75 to - deprioritize it
+	local metric=10
+	# Enable resolver by default
+	if [[ "$mode" == "off" ]]; then
+		dns_ip="none"
+		metric=75
+	fi
+
 	local network_id
 	if is_docker_native; then
 		# Use the default DockerNAT adapter
@@ -2319,18 +2350,16 @@ configure_resolver_windows () {
 		network_id=$("$vboxmanage" showvminfo ${DOCKER_MACHINE_NAME} --machinereadable | grep hostonlyadapter | cut -d'"' -f2 | sed 's/Ethernet Adapter/Network/')
 	fi
 
-	# Check whether DNS resolver is already configured
-	if ! (netsh interface ip show dns \"${network_id}\" | grep ${DOCKSAL_IP} >/dev/null 2>&1); then
-		if [[ "$network_id" != "" ]]; then
-			# Set DNS server to Docksal IP on the VM's VBox adapter
-			local command1="netsh interface ip set dnsservers \"${network_id}\" static ${DOCKSAL_IP} none"
-			# Set the adapter metric (priority) to 10, so its DNS settings will take over other adapters
-			local command2="netsh interface ip set interface \"${network_id}\" metric=10"
-			winsudo "$command1 && $command2"
-		else
-			echo-error "DNS resolver configuration failed"
-		fi
+	if [[ "$network_id" == "" ]]; then
+		echo-error "DNS resolver configuration failed"
+		return 1
 	fi
+
+	# Set DNS server to Docksal IP on the VM's VBox adapter
+	local command1="netsh interface ip set dnsservers \"${network_id}\" static ${dns_ip} none"
+	# Set the adapter metric (priority) to 10, so its DNS settings will take over other adapters
+	local command2="netsh interface ip set interface \"${network_id}\" metric=${metric}"
+	winsudo "$command1 && $command2"
 
 	# Flush DNS cache
 	ipconfig /flushdns >/dev/null 2>&1
@@ -2342,23 +2371,33 @@ configure_resolver ()
 	# Do not configure the resolver if asked so
 	[[ "$DOCKSAL_NO_DNS_RESOLVER" != "" ]] && return
 
-	# Probing the upstream DNS server
-	# We want to make sure the upstream DNS server is reachable before configuring the host to use our DNS service.
-	# If it's not reachable, hosts DNS resolution may be affected or stop working entirely.
-	# nslookup returns 0 exit code regardless of the results, so have to pipe it ot grep
-	nslookup -tymeout=1 google.com "$DOCKSAL_DNS_UPSTREAM" 2>/dev/null | grep google.com >/dev/null
-	if [[ $? == 0 ]]; then
-		is_mac && configure_resolver_mac && return $?
-		is_linux && configure_resolver_linux && return $?
-		is_windows && configure_resolver_windows && return $?
+	local mode="$1"
+
+	if [[ "$mode" != "off" ]]; then
+		echo-green "Enabling automatic *.$DOCKSAL_DNS_DOMAIN DNS resolver..."
+
+		# Probing the upstream DNS server
+		# We want to make sure the upstream DNS server is reachable before configuring the host to use our DNS service.
+		# If it's not reachable, hosts DNS resolution may be affected or stop working entirely.
+		# nslookup returns 0 exit code regardless of the results, so have to pipe it ot grep
+		nslookup -tymeout=1 google.com "$DOCKSAL_DNS_UPSTREAM" 2>/dev/null | grep google.com >/dev/null
+		local ret=$?
+
+		if [[ "$ret" != "0" ]]; then
+			echo-error "The upstream DNS server ($DOCKSAL_DNS_UPSTREAM) is not reachable." \
+				"You are either offline, $DOCKSAL_DNS_UPSTREAM is not a valid DNS server or DNS requests to $DOCKSAL_DNS_UPSTREAM are blocked." \
+				"Once the current operation completes, follow the steps below:" \
+				"  1. Open ${yellow}~/.docksal/docksal.env${NC} and set ${yellow}DOCKSAL_DNS_UPSTREAM${NC} to your local network DNS server" \
+				"  2. Run ${yellow}fin reset dns${NC} to see if it works"
+			_confirm "Continue?"
+		fi
 	else
-		echo-error "The upstream DNS server ($DOCKSAL_DNS_UPSTREAM) is not reachable." \
-			"You are either not connected to the internet or DNS requests to $DOCKSAL_DNS_UPSTREAM are blocked." \
-			"You can proceed with the current operation. When it's done:" \
-			"  1. Open ${yellow}~/.docksal/docksal.env${NC} and set ${yellow}DOCKSAL_DNS_UPSTREAM${NC} to your local network DNS server" \
-			"  2. Run ${yellow}fin reset dns${NC} to see if it works"
-		_confirm "Do you want to continue?"
+		echo-green "Disabling automatic *.$DOCKSAL_DNS_DOMAIN DNS resolver..."
 	fi
+
+	is_mac && configure_resolver_mac "$mode" && return $?
+	is_linux && configure_resolver_linux "$mode" && return $?
+	is_windows && configure_resolver_windows "$mode" && return $?
 }
 
 install_sshagent_service ()

--- a/bin/fin
+++ b/bin/fin
@@ -110,6 +110,8 @@ DOCKSAL_DNS_UPSTREAM="${DOCKSAL_DNS_UPSTREAM:-8.8.8.8}"
 DOCKSAL_DNS_DOMAIN="${DOCKSAL_DNS_DOMAIN:-docksal}"
 # Allow disabling the DNS resolver configuration (in case there are issues with it). Set to "true" to activate.
 DOCKSAL_NO_DNS_RESOLVER="${DOCKSAL_NO_DNS_RESOLVER}"
+# Set to "true" to enable logging DNS queries in docksal-dns. View logs via "fin docker logs docksal-dns"
+DOCKSAL_DNS_DEBUG="${DOCKSAL_DNS_DEBUG}"
 
 # Declaring possible vhost-proxy settings overrides
 DOCKSAL_VHOST_PROXY_IP="${DOCKSAL_VHOST_PROXY_IP}"
@@ -2275,7 +2277,7 @@ install_dns_service ()
 	docker rm -f docksal-dns >/dev/null 2>&1 || true
 	docker run -d --name docksal-dns --label "io.docksal.group=system" --restart=always \
 		-p "${DOCKSAL_IP}:53:53/udp" --cap-add=NET_ADMIN --dns="$DOCKSAL_DNS_UPSTREAM" \
-		-e DNS_IP="$DOCKSAL_IP" -e DNS_DOMAIN="$DOCKSAL_DNS_DOMAIN" \
+		-e DNS_IP="$DOCKSAL_IP" -e DNS_DOMAIN="$DOCKSAL_DNS_DOMAIN" -e LOG_QUERIES="$DOCKSAL_DNS_DEBUG" \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		"${IMAGE_DNS}" >/dev/null
 }

--- a/bin/fin
+++ b/bin/fin
@@ -2380,7 +2380,7 @@ configure_resolver ()
 		# We want to make sure the upstream DNS server is reachable before configuring the host to use our DNS service.
 		# If it's not reachable, hosts DNS resolution may be affected or stop working entirely.
 		# nslookup returns 0 exit code regardless of the results, so have to pipe it ot grep
-		nslookup -tymeout=1 google.com "$DOCKSAL_DNS_UPSTREAM" 2>/dev/null | grep google.com >/dev/null
+		nslookup -timeout=1 google.com "$DOCKSAL_DNS_UPSTREAM" 2>/dev/null | grep google.com >/dev/null
 		local ret=$?
 
 		if [[ "$ret" != "0" ]]; then

--- a/bin/fin
+++ b/bin/fin
@@ -2322,7 +2322,8 @@ configure_resolver_windows () {
 	# Check whether DNS resolver is already configured
 	if ! (netsh interface ip show dns \"${network_id}\" | grep ${DOCKSAL_IP} >/dev/null 2>&1); then
 		if [[ "$network_id" != "" ]]; then
-			winsudo "netsh interface ip set dns \"${network_id}\" static ${DOCKSAL_IP}"
+			winsudo "netsh interface ip set dnsservers \"${network_id}\" static ${DOCKSAL_IP} none &&
+					netsh interface ip set interface \"${network_id}\" metric=10"
 		else
 			echo-error "DNS resolver configuration failed"
 		fi

--- a/bin/fin
+++ b/bin/fin
@@ -2322,8 +2322,11 @@ configure_resolver_windows () {
 	# Check whether DNS resolver is already configured
 	if ! (netsh interface ip show dns \"${network_id}\" | grep ${DOCKSAL_IP} >/dev/null 2>&1); then
 		if [[ "$network_id" != "" ]]; then
-			winsudo "netsh interface ip set dnsservers \"${network_id}\" static ${DOCKSAL_IP} none &&
-					netsh interface ip set interface \"${network_id}\" metric=10"
+			# Set DNS server to Docksal IP on the VM's VBox adapter
+			local command1="netsh interface ip set dnsservers \"${network_id}\" static ${DOCKSAL_IP} none"
+			# Set the adapter metric (priority) to 10, so its DNS settings will take over other adapters
+			local command2="netsh interface ip set interface \"${network_id}\" metric=10"
+			winsudo "$command1 && $command2"
 		else
 			echo-error "DNS resolver configuration failed"
 		fi
@@ -3974,6 +3977,7 @@ fi
 	[[ "$*" != "reset dns" ]] &&
 	[[ "$*" != "reset proxy" ]] &&
 	[[ "$*" != "reset ssh-agent" ]] &&
+	[[ "$*" != "reset network" ]] &&
 	[[ "$*" != "reset system" ]] &&
 	[[ "$1" != "projects" ]] &&
 	[[ "$1" != "run-cli" ]] &&

--- a/docs/advanced/dns-resolver.md
+++ b/docs/advanced/dns-resolver.md
@@ -1,0 +1,49 @@
+# DNS resolver
+
+Docksal runs a system service called `docksal-dns`.
+
+This service is responsible for the wildcard `*.docksal` domain resolution to the Docksal IP (`192.168.64.100`).  
+It also forwards all other DNS requests to the upstream DNS server, which is Google's Public DNS (`8.8.8.8`) by default. 
+
+Project containers are configured to use `docksal-dns` as their DNS server by default.
+
+Docksal configures network settings on Linux, Mac and Windows to tell the host machine to use `docksal-dns` as well.
+
+On Mac only `*.docksal` DNS queries are routed through `docksal-dns`.
+
+On Linux and Windows DNS all DNS queries are routed through `docksal-dns`, as there is no way to configure this 
+selectively (like on Mac). 
+
+In cases when the Docksal VM is stopped or the `docksal-dns` service is down, the OS picks the next available DNS server 
+configured on the host (which would be you LAN/WiFi connection). This way there is always a fallback.
+
+
+## Disabling the resolver
+
+If you run into issues with DNS resolution, try disabling the automatic resolver.
+
+1. Stop the VM with `fin vm stop`
+2. Open `~/.docksal/docksal.env` and add `DOCKSAL_NO_DNS_RESOLVER=true` 
+3. Start the VM again `fin vm start`   
+
+Without the automatic resolver, you can use `fin hosts` command to manage name resolution via the `hosts` file.
+
+
+## Override the default upstream DNS settings
+
+Some restricted network environments (e.g. corp networks) may be blocking direct access to external DNS services, 
+this making `8.8.8.8` inaccessible. In such cases Docksal will output a warning with the instructions to override the
+default upstream DNS settings.
+
+1. Open `~/.docksal/docksal.env` and set `DOCKSAL_DNS_UPSTREAM` to your local network DNS server
+
+    Example:
+    
+    ```
+    DOCKSAL_DNS_UPSTREAM=192.168.0.1
+    ```
+
+2. Run `fin reset dns`
+
+Inspect you LAN or WiFi interface settings and connection status to figure out the DNS server your network is using.
+

--- a/docs/advanced/dns-resolver.md
+++ b/docs/advanced/dns-resolver.md
@@ -47,3 +47,17 @@ default upstream DNS settings.
 
 Inspect you LAN or WiFi interface settings and connection status to figure out the DNS server your network is using.
 
+
+## Enable DNS query logging (for debugging) 
+
+Enable logging
+
+```
+DOCKSAL_DNS_DEBUG=true fin reset dns
+```
+
+View logs
+
+```
+fin docker logs docksal-dns
+```

--- a/docs/advanced/multiple-projects.md
+++ b/docs/advanced/multiple-projects.md
@@ -3,7 +3,7 @@
 Docksal has a built-in reverse proxy container that adds support for running multiple projects or using multiple (arbitrary domains).  
 The container binds to `192.168.64.100:80` and routes web requests based on the host name.
 
-DNS resolution and routing for `*.docksal` domains is automatically configured upon the first `fin update`. 
+DNS resolution and routing for `*.docksal` domains is automatically configured. 
 
 
 ## Default virtual host / domain name

--- a/docs/advanced/stack.md
+++ b/docs/advanced/stack.md
@@ -20,13 +20,10 @@ See [Using ssh-agent service](../advanced/ssh-agent.md) for more information.
 
 ### DNS
 
-[docksal-dns](https://github.com/docksal/service-dns) contains a running `bind` server that resolves `*.docksal` URI's 
+[docksal-dns](https://github.com/docksal/service-dns) contains a running `dnsmasq` server that resolves `*.docksal` URI's 
 to the Docksal VM IP address (or localhost if you're running a [native Docker app](../getting-started/env-setup-native.md)).
 
-!!! warning "Windows users"
-    On macOS and Linux Docksal automatically configures itself to become a DNS resolver for `.docksal` domain. 
-    On Windows this is not configured automatically, because this may cause DNS resolution issues in case the VM is down or freezes.  
-    You can manually configure `192.168.64.100` to be your primary DNS and you ISP/office DNS to be the secondary one.
+See [DNS resolver](../advanced/dns-resolver.md) for more information.
 
 ### Reverse proxy
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ pages:
       - Multiple projects/domains: advanced/multiple-projects.md
       - VM resources: advanced/vm.md
       - Networking: advanced/networking.md
+      - DNS resolver: advanced/dns-resolver.md
     - SSH agent: advanced/ssh-agent.md
     - Database:
       - Database access: advanced/db-access.md


### PR DESCRIPTION
- Refactoring DNS settings
  - Doing a DNS probe to make sure the upstream DNS server is reachable
  - Using 8.8.8.8 a the default upstream DNS on all platforms
  - Allow disabling the automatic DNS resolver via `DOCKSAL_NO_DNS_RESOLVER=true
- Set interface metric on Windows
  - This makes sure our VBox adapters is the first in the list and thus it's DNS server settings will be used by Windows
- Adding configure_resolver "off" mode
  - This will revert resolver settings when the VM is stopped, killed, removed
- Update docs regarding the DNS resolver