### PR TITLE
SSH agent refactoring. Fixes #223

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -2230,6 +2230,8 @@ ssh_add () {
 	fi
 
 	local ssh_path="$HOME/.ssh"
+	# On Windows docker and docker-compose expect a Windows style path
+	is_windows && ssh_path=$(cygpath -w "$ssh_path")
 
 	# Copy all keys from the host to the ssh-agent container
 	docker cp "$ssh_path" docksal-ssh-agent:/

--- a/bin/fin
+++ b/bin/fin
@@ -2219,26 +2219,35 @@ ssh_add () {
 
 	# Check if ssh-agent container is running
 	local running=$(docker inspect --format="{{ .State.Running }}" docksal-ssh-agent 2>/dev/null)
-	[[ "$running" != "true" ]] && return
+	# Start the ssh-agent if not running
+	if [[ "$running" != "true" ]]; then
+		echo-error "docksal-ssh-agent is not running" \
+			"Please report this issue, as this should not usually happen." \
+			"Run ${yellow}fin reset ssh-agent${NC} to start the service."
+		# We could automatically run install_sshagent_service here, however that may lead to an endless recursion
+		# if something is terribly wrong. So it's better to alret the user and ask them to try a manual fix.
+		return 1
+	fi
 
 	local ssh_path="$HOME/.ssh"
-	local key_path=""
 
-	# When no arguments provided, check if ssh-agent already has at least one identity. If so, stop here.
-	docker exec docksal-ssh-agent ssh-add -l >/dev/null
-	if [[ $1 == "" && $? == 0 ]]; then return; fi
+	# Copy all keys from the host to the ssh-agent container
+	docker cp "$ssh_path" docksal-ssh-agent:/
 
-	# $ssh_path should be mounted as /.ssh in the ssh-agent containers.
-	# When $key_path is empty, ssh-agent will be looking for both id_rsa and id_dsa in the home directory.
+	# Load the requested key. If no key provided, ssh-add will load all default keys (id_rsa, id_dsa, id_ecdsa)
 	if is_tty; then
 		# Run ssh-add interactively to allow entering a passphrase for ssh keys (if set)
-		${winpty} docker run --rm -it -v=docksal_ssh_agent:/.ssh-agent -v "$ssh_path:/.ssh:ro" "${IMAGE_SSH_AGENT}" ssh-add "$@"
+		${winpty} docker exec -it docksal-ssh-agent /run.sh ssh-add "$@"
 	else
 		# In a non-interactive environment (e.g. CI) run non-interactively. Keys with passphrases cannot be used!
 		echo-yellow "Running in a non-interactive environment. SSH keys with passphrases cannot be used."
-		docker run --rm -v=docksal_ssh_agent:/.ssh-agent -v "$ssh_path:/.ssh:ro" "${IMAGE_SSH_AGENT}" ssh-add "$@"
+		docker exec docksal-ssh-agent /run.sh ssh-add "$@"
 	fi
-	return $?
+	local ret=$?
+
+	# Remove copied keys from the ssh-agent container after loading into the ssh-agent
+	docker exec docksal-ssh-agent rm -rf /.ssh /root/.ssh
+	return "$ret"
 }
 
 #----- Installations and updates -----

--- a/bin/fin
+++ b/bin/fin
@@ -67,8 +67,6 @@ if is_windows; then
 	# Cannot use cygpath_abs_unix here as it's being defined much later
 	HOME="/$(cygpath -m $HOME | sed 's/^\/cygdrive//' | sed 's/\([A-Z]\)\:/\l\1/')"
 fi
-# DO NOT REMOVE HOST_HOME. It is used in some stack yml files and is necessary on Windows.
-export HOST_HOME="$HOME"
 OLD_CONFIG_DIR="$HOME/.drude"
 CONFIG_DIR="$HOME/.docksal"
 CONFIG_ENV="$CONFIG_DIR/docksal.env"

--- a/bin/fin
+++ b/bin/fin
@@ -2215,6 +2215,7 @@ project_create ()
 # Add key to ssh-agent or run ssh-add with provided @param
 # @param $1 -D, -l or path to custom key
 ssh_add () {
+	check_docker_running
 	check_winpty_found
 
 	# Check if ssh-agent container is running
@@ -2234,7 +2235,8 @@ ssh_add () {
 	is_windows && ssh_path=$(cygpath -w "$ssh_path")
 
 	# Copy all keys from the host to the ssh-agent container
-	docker cp "$ssh_path" docksal-ssh-agent:/
+	# Only do this when given an argument (key name) or nothing, but not for options (e.g. -l)
+	[[ "${1#-}" == "$1" ]] && docker cp "$ssh_path" docksal-ssh-agent:/
 
 	# Load the requested key. If no key provided, ssh-add will load all default keys (id_rsa, id_dsa, id_ecdsa)
 	if is_tty; then
@@ -2248,7 +2250,8 @@ ssh_add () {
 	local ret=$?
 
 	# Remove copied keys from the ssh-agent container after loading into the ssh-agent
-	docker exec docksal-ssh-agent rm -rf /.ssh /root/.ssh
+	# Only do this when given an argument (key name) or nothing, but not for options (e.g. -l)
+	[[ "${1#-}" == "$1" ]] && docker exec docksal-ssh-agent rm -rf /.ssh /root/.ssh
 	return "$ret"
 }
 

--- a/docs/advanced/stack-config.md
+++ b/docs/advanced/stack-config.md
@@ -183,8 +183,6 @@ In the `cli` service there is the `volumes` section. You should not remove or ch
     volumes:
       # Project root volume
       - project_root:/var/www:rw,nocopy
-      # Host home volume (for SSH keys and other credentials).
-      - host_home:/.home:ro
       # Shared ssh-agent socket
       - docksal_ssh_agent:/.ssh-agent:ro
 ```
@@ -229,7 +227,6 @@ services:
     hostname: cli
     image: docksal/cli:1.2-php7
     volumes:
-    - host_home:/.home:ro
     - docksal_ssh_agent:/.ssh-agent:ro
     - project_root:/var/www:rw,nocopy
   db:
@@ -257,12 +254,6 @@ volumes:
   docksal_ssh_agent:
     external: true
     external_name: docksal_ssh_agent
-  host_home:
-    driver: local
-    driver_opts:
-      device: /Users/testuser
-      o: bind
-      type: none
   project_root:
     driver: local
     driver_opts:
@@ -323,7 +314,6 @@ services:
     hostname: cli
     image: docksal/cli:1.2-php5
     volumes:
-    - host_home:/.home:ro
     - docksal_ssh_agent:/.ssh-agent:ro
     - project_root:/var/www:rw,nocopy
 ```

--- a/docs/getting-started/project-setup.md
+++ b/docs/getting-started/project-setup.md
@@ -36,13 +36,9 @@ You will see output similar to the following:
 Starting services...
 Creating network "myproject_default" with the default driver
 Creating volume "myproject_project_root" with local driver
-Creating volume "myproject_host_home" with local driver
 Creating myproject_cli_1
 Creating myproject_db_1
 Creating myproject_web_1
-Changing user id in cli to 501 to match host user id...
-Resetting permissions on /var/www...
-Restarting php daemon...
 Connected vhost-proxy to "myproject_default" network.
 ```
 

--- a/examples/.docksal/docksal.yml
+++ b/examples/.docksal/docksal.yml
@@ -56,8 +56,6 @@ services:
     volumes:
       # Project root volume
       - project_root:/var/www:rw,nocopy
-      # Host home volume (for SSH keys and other credentials).
-      - host_home:/.home:ro
       # Shared ssh-agent socket
       - docksal_ssh_agent:/.ssh-agent:ro
     environment:

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -47,8 +47,6 @@ services:
     volumes:
       # Project root volume
       - project_root:/var/www:rw,nocopy
-      # Host home volume (for SSH keys and other credentials).
-      - host_home:/.home:ro
       # Shared ssh-agent socket
       - docksal_ssh_agent:/.ssh-agent:ro
     environment:

--- a/stacks/stack-acquia-static.yml
+++ b/stacks/stack-acquia-static.yml
@@ -51,8 +51,6 @@ services:
     volumes:
       # Project root volume
       - project_root:/var/www:rw,nocopy
-      # Host home volume (for SSH keys and other credentials).
-      - host_home:/.home:ro
       # Shared ssh-agent socket
       - docksal_ssh_agent:/.ssh-agent:ro
     environment:

--- a/stacks/stack-default-static.yml
+++ b/stacks/stack-default-static.yml
@@ -44,8 +44,6 @@ services:
     volumes:
       # Project root volume
       - project_root:/var/www:rw,nocopy
-      # Host home volume (for SSH keys and other credentials).
-      - host_home:/.home:ro
       # Shared ssh-agent socket
       - docksal_ssh_agent:/.ssh-agent:ro
     environment:

--- a/stacks/volumes-bind.yml
+++ b/stacks/volumes-bind.yml
@@ -5,14 +5,6 @@ version: "2.1"
 
 volumes:
 # Bind volumes
-  host_home:
-    driver: local
-    driver_opts:
-      type: none
-      # $HOST_HOME is a cross-platform version of $HOME. It is exported by fin.
-      # It returns a Unix style path on Windows (which is what we need here), while $HOME return a Windows style path.
-      device: ${HOST_HOME}
-      o: bind
   project_root:
     driver: local
     driver_opts:

--- a/stacks/volumes-nfs.yml
+++ b/stacks/volumes-nfs.yml
@@ -7,12 +7,6 @@ version: "2.1"
 
 volumes:
 # NFS volumes
-  host_home:
-    driver: local
-    driver_opts:
-      type: nfs
-      device: :${HOME}
-      o: addr=${DOCKSAL_HOST_IP},vers=3,nolock,noacl,nocto,noatime,nodiratime,tcp,actimeo=1
   project_root:
     driver: local
     driver_opts:

--- a/stacks/volumes-unison.yml
+++ b/stacks/volumes-unison.yml
@@ -7,16 +7,6 @@ version: "2.1"
 
 volumes:
   project_root:
-
-  # Bind mount host_home
-  host_home:
-    driver: local
-    driver_opts:
-      type: none
-      # $HOST_HOME is a cross-platform version of $HOME. It is exported by fin.
-      # It returns a Unix style path on Windows (which is what we need here), while $HOME return a Windows style path.
-      device: ${HOST_HOME}
-      o: bind
   # Shared ssh-agent volume
   docksal_ssh_agent:
     external: true


### PR DESCRIPTION
Removes dependency on the host's $HOME directory mount.
Keys are copied into the `docksal-ssh-agent` container with `docker cp`, loaded into the ssh-agent, then removed from the container.