### PR TITLE
Host IP alias on Docker for Mac/Win and xdebug adjustments. Fixes #389

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-FIN_VERSION=1.30.2
+FIN_VERSION=1.31.0
 
 # Console colors
 red='\033[0;91m'
@@ -104,9 +104,11 @@ DOCKSAL_ENVIRONMENT="${DOCKSAL_ENVIRONMENT:-local}"
 # Network settings
 ## Docker for Mac/Win
 DOCKSAL_NATIVE_IP="192.168.64.100"
+DOCKSAL_NATIVE_HOST_IP="192.168.64.1"
 
 ## Default (Linux, boot2docker/VirtualBox on Mac and Win)
 DOCKSAL_DEFAULT_IP="192.168.64.100"
+DOCKSAL_DEFAULT_HOST_IP="192.168.64.1"
 DOCKSAL_DEFAULT_SUBNET="192.168.64.1/24"
 
 # For environments, where access to external DNS servers is blocked, DOCKSAL_DNS_UPSTREAM should be set to the LAN DNS server
@@ -2542,11 +2544,13 @@ configure_network ()
 	if is_mac; then
 	 	# Docker for Mac
 	 	if is_docker_native; then
-			# Add Docksal IP alias on the local loopback adapter
+			# Add Docksal IP aliases on the local loopback adapter
 			sudo ifconfig lo0 alias ${DOCKSAL_NATIVE_IP} 255.255.255.0
+			sudo ifconfig lo0 alias ${DOCKSAL_NATIVE_HOST_IP} 255.255.255.0
 		else
 			# Remove Docksal IP alias from the local loopback adapter
 			sudo ifconfig lo0 -alias ${DOCKSAL_NATIVE_IP} >/dev/null 2>&1
+			sudo ifconfig lo0 -alias ${DOCKSAL_NATIVE_HOST_IP} >/dev/null 2>&1
 		fi
 		# Wait 5s for network configuration to apply
 		sleep 5
@@ -2555,11 +2559,15 @@ configure_network ()
 	if is_windows; then
 		# Docker for Win
 		if is_docker_native; then
-			# Add Docksal IP alias on the DockerNAT adapter
-			winsudo "netsh interface ip add address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_NATIVE_IP} mask=255.255.255.0"
+			# Add Docksal IP aliases on the DockerNAT adapter
+			local command1="netsh interface ip add address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_NATIVE_IP} mask=255.255.255.0"
+			local command2="netsh interface ip add address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_NATIVE_HOST_IP} mask=255.255.255.0"
+			winsudo "$command1 && $command2"
 		else
-			# Remove Docksal IP alias on the DockerNAT adapter
-			winsudo "netsh interface ip delete address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_NATIVE_IP}"
+			# Remove Docksal IP aliases on the DockerNAT adapter
+			local command1="netsh interface ip delete address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_NATIVE_IP}"
+			local command1="netsh interface ip delete address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_NATIVE_HOST_IP}"
+			winsudo "$command1 && $command2"
 		fi
 		# Wait 5s for network configuration to apply
 		sleep 5
@@ -4664,10 +4672,12 @@ fi
 # DOCKSAL_DNS2 - a backup external DNS server
 if is_docker_native; then
 	export DOCKSAL_IP=${DOCKSAL_NATIVE_IP}
+	export DOCKSAL_HOST_IP=${DOCKSAL_NATIVE_HOST_IP}
 	export DOCKSAL_DNS1=${DOCKSAL_IP}
 	export DOCKSAL_DNS2=${DOCKSAL_DNS_UPSTREAM}
 else
 	export DOCKSAL_IP=${DOCKSAL_DEFAULT_IP}
+	export DOCKSAL_HOST_IP=${DOCKSAL_DEFAULT_HOST_IP}
 	export DOCKSAL_DNS1=${DOCKSAL_IP}
 	export DOCKSAL_DNS2=${DOCKSAL_DNS_UPSTREAM}
 fi

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -56,6 +56,10 @@ services:
       - HOST_GID
       - DOCROOT
       - XDEBUG_ENABLED=${XDEBUG_ENABLED:-0}
+      # Point xdebug to the host IP
+      - XDEBUG_CONFIG=remote_connect_back=0 remote_host=${DOCKSAL_HOST_IP}
+      # This helps with console scripts debugging in PHPStorm
+      - PHP_IDE_CONFIG=serverName=${VIRTUAL_HOST}
     dns:
       - ${DOCKSAL_DNS1}
       - ${DOCKSAL_DNS2}

--- a/stacks/stack-acquia-static.yml
+++ b/stacks/stack-acquia-static.yml
@@ -63,6 +63,10 @@ services:
       - HOST_GID
       - DOCROOT
       - XDEBUG_ENABLED=${XDEBUG_ENABLED:-0}
+      # Point xdebug to the host IP
+      - XDEBUG_CONFIG=remote_connect_back=0 remote_host=${DOCKSAL_HOST_IP}
+      # This helps with console scripts debugging in PHPStorm
+      - PHP_IDE_CONFIG=serverName=${VIRTUAL_HOST}
     dns:
       - ${DOCKSAL_DNS1}
       - ${DOCKSAL_DNS2}

--- a/stacks/stack-acquia-static.yml
+++ b/stacks/stack-acquia-static.yml
@@ -1,9 +1,9 @@
 # Acquia alike stack
 #
-# - Apache 2.2
-# - MySQL 5.5
+# - Apache 2.4
+# - MySQL 5.6
 # - PHP 5.6 / PHP 7.0
-# - Varnish 3
+# - Varnish 4
 # - Memcached 1.4
 # - ApacheSolr 4.x
 

--- a/stacks/stack-acquia.yml
+++ b/stacks/stack-acquia.yml
@@ -1,9 +1,9 @@
 # Acquia alike stack
 #
-# - Apache 2.2
+# - Apache 2.4
 # - MySQL 5.6
 # - PHP 5.6 / PHP 7.0
-# - Varnish 3
+# - Varnish 4
 # - Memcached 1.4
 # - ApacheSolr 4.x
 

--- a/stacks/stack-default-static.yml
+++ b/stacks/stack-default-static.yml
@@ -56,6 +56,10 @@ services:
       - HOST_GID
       - DOCROOT
       - XDEBUG_ENABLED=${XDEBUG_ENABLED:-0}
+      # Point xdebug to the host IP
+      - XDEBUG_CONFIG=remote_connect_back=0 remote_host=${DOCKSAL_HOST_IP}
+      # This helps with console scripts debugging in PHPStorm
+      - PHP_IDE_CONFIG=serverName=${VIRTUAL_HOST}
     dns:
       - ${DOCKSAL_DNS1}
       - ${DOCKSAL_DNS2}


### PR DESCRIPTION
- 1.31.0 Set host IP alias for Docker for Mac/Win
- xdebug settings adjustment for cli
  - Point xdebug to the host IP
  - Also set `PHP_IDE_CONFIG=serverName=${VIRTUAL_HOST}` - this helps with debugging console PHP applications (as per our own docs).

    These settings, being set via env variables, take precedence over settings in php.ini.
    Long term this will be include in the cli image.
