### PR TITLE
Enable osxfs:cached automatically on Docker for Mac. Fixes #249

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-FIN_VERSION=1.31.0
+FIN_VERSION=1.32.0
 
 # Console colors
 red='\033[0;91m'

--- a/bin/fin
+++ b/bin/fin
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-FIN_VERSION=1.30.3
+FIN_VERSION=1.31.0
 
 # Console colors
 red='\033[0;91m'
@@ -48,7 +48,7 @@ is_mac ()
 DOCKSAL_VERSION="${DOCKSAL_VERSION:-master}"
 
 REQUIREMENTS_DOCKER='17.09.0-ce'
-REQUIREMENTS_DOCKER_COMPOSE='1.16.1'
+REQUIREMENTS_DOCKER_COMPOSE='1.17.1'
 REQUIREMENTS_DOCKER_MACHINE='0.13.0'
 REQUIREMENTS_VBOX='5.1.28'  # Remember to update the download URLs below
 REQUIREMENTS_WINPTY='0.4.3'
@@ -4215,6 +4215,12 @@ load_configuration ()
 					"You may need to run ${yellow}fin update${NC} to download volume definitions."
 				exit 1
 			fi
+		fi
+
+		# Enable osxfs:cached for cli on Docker for Mac
+		overrides_osxfs_file="$(get_config_dir_dc)/stacks/overrides-osxfs.yml"
+		if is_mac && is_docker_native && [[ -f "${overrides_osxfs_file}" ]]; then
+			COMPOSE_FILE="${overrides_osxfs_file}${SEPARATOR}${COMPOSE_FILE}"
 		fi
 	fi
 	export COMPOSE_FILE

--- a/docs/advanced/volumes.md
+++ b/docs/advanced/volumes.md
@@ -75,7 +75,7 @@ volumes:
 In the example above, `project_root` and `docksal_ssh_agent` are "named volumes". The first one is a project level one,
 while the second one is a global volume and is used by all projects.
 
-See [stacks/volumes-bind.yml](https://github.com/docksal/docksal/blob/master/stacks/stacks/volumes-bind.yml)
+See [stacks/volumes-bind.yml](https://github.com/docksal/docksal/blob/master/stacks/volumes-bind.yml)
 
 Defining volumes this way makes it much easier to override volume settings in one place (`volumes` section) vs multiple 
 places in the yaml file. We can now swap bind mounting with something else. See below.
@@ -97,7 +97,7 @@ volumes:
     external: true
 ```
 
-See [stacks/volumes-bind.yml](https://github.com/docksal/docksal/blob/master/stacks/stacks/volumes-nfs.yml).
+See [stacks/volumes-bind.yml](https://github.com/docksal/docksal/blob/master/stacks/volumes-nfs.yml).
 
 This is what the file sharing chain looks like with a NFS volume. 
 
@@ -119,7 +119,7 @@ with Docker for Mac, for testing and performance comparison purposes.
 We can also do more advanced and pretty interesting solutions, like using Unison to synchronize files between the host 
 and the `project_root` volume. 
 
-See [stacks/volumes-unison.yml](https://github.com/docksal/docksal/blob/master/stacks/stacks/volumes-unison.yml)
+See [stacks/volumes-unison.yml](https://github.com/docksal/docksal/blob/master/stacks/volumes-unison.yml)
 
 Unison volumes make the most sense for Docker for Mac users as an alternative to the (still slow) `osxfs` file sharing.
 
@@ -160,3 +160,10 @@ configure Docksal for use with Docker for Mac. Make sure you have the most recen
 Currently there is no good way to know when unison is done with the initial file sync. This makes it difficult to script 
 the project provisioning process with `fin init`. The script will proceed with site install/etc. steps before the code 
 base is ready.
+
+
+## osxfs:cached mode with Docker for Mac
+
+Docksal automatically enables the `osxfs:cached` mode on Docker for Mac.
+
+See [stacks/volumes-unison.yml](https://github.com/docksal/docksal/blob/master/stacks/overrides-osxfs.yml)

--- a/docs/getting-started/env-setup-native.md
+++ b/docs/getting-started/env-setup-native.md
@@ -2,9 +2,15 @@
 
 On Mac and Windows, you can use native Docker applications instead of VirtualBox.
 
-!!! danger "Experimental support"
-    Docker for Mac/Windows support is experimental and is not recommended for regular use due to low filesystem performance.
-    Please report any issues in the [issue queue](https://github.com/docksal/docksal/issues).
+!!! info "Soon to be mainstream"
+    Docker for Mac/Windows will soon become the recommended way of working with Docksal on Mac and Windows.
+    VirtualBox will still be supported, however the focus will shit towards using the native Docker apps. 
+
+On Mac, `osxfs:cached` mode for Docker for Mac provides a decent read performance (still not as fast as NFS, but 
+getting there). See [docksal/docksal#249](https://github.com/docksal/docksal/issues/249)
+
+On Windows, Windows 10 Fall Creators Update 1709 disables SMBv1, which is necessary for SMB sharing support with 
+VirtualBox/boo2docker. See [docksal/docksal#382](https://github.com/docksal/docksal/issues/382) for more details.
 
 
 ## Switching to Docker for Mac/Windows
@@ -36,11 +42,16 @@ fin reset system
 **6.** Configure file sharing as necessary (see below).
 
 
-### File sharing
+### File sharing Mac
 
 Docker for Mac automatically shares most commonly used volumes/directories. 
 See [here](https://docs.docker.com/docker-for-mac/#file-sharing) for details.  
 It is usually not necessary to adjust these settings.
+
+Docksal automatically enables the `osxfs:cached` mode on Docker for Mac, which improves the file system read performance 
+substantially.
+
+### File sharing Windows
 
 Docker for Windows does NOT share drives automatically. This has to be done manually. 
 See [here](https://docs.docker.com/docker-for-windows/#shared-drives) for details.  

--- a/stacks/overrides-osxfs.yml
+++ b/stacks/overrides-osxfs.yml
@@ -1,0 +1,9 @@
+# Enabled osxfs:cached mode
+# This adjustment makes no difference on non Docker for Mac setups
+
+version: "2.1"
+
+services:
+  cli:
+    volumes:
+      - ${PROJECT_ROOT}:/var/www:rw,cached


### PR DESCRIPTION
- This will automatically enabled osxfs:cached mode for the project root volume in cli
- The volume has to be defined using the host path. The cached flag cannot yet be used with named volumes. See https://github.com/docker/for-mac/issues/1899
- Docker Compose update in necessary due to a bug older versions have with merging same volume definitions from multiple yml files
