### PR TITLE
Install ifup/ifdown if they are missing. Relates to #321

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -3033,7 +3033,7 @@ install_tools_ubuntu ()
 	fi
 
 	# Install ifup/ifdown if they are missing
-	if ! (which ifup >/dev/null 2>&1) || ! (which ifdown >/dev/null 2>&1); then
+	if ! (which ifup >/dev/null 2>&1) || ! (which ifdown >/dev/null 2>&1) || ! (which resolvconf >/dev/null 2>&1); then
 		sudo apt-get update
 		sudo apt-get install ifupdown resolvconf -y
 	fi

--- a/bin/fin
+++ b/bin/fin
@@ -3032,6 +3032,12 @@ install_tools_ubuntu ()
 		if_failed "Docker Compose installation/upgrade has failed."
 	fi
 
+	# Install ifup/ifdown if they are missing
+	if ! (which ifup >/dev/null 2>&1) || ! (which ifdown >/dev/null 2>&1); then
+		sudo apt-get update
+		sudo apt-get install ifupdown resolvconf -y
+	fi
+
 	# Install docker-machine
 	#	if ! is_docker_machine_version; then
 	#		echo-green "Installing docker-machine v${REQUIREMENTS_DOCKER_MACHINE}..."


### PR DESCRIPTION
Starting from Ubuntu 17.04 ifup/ifdown are not available out of the box.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docksal/docksal/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Write a short summary that describes the changes in this pull request:
-->
