### PR TITLE
1.40.0. Enrich <project> commands subset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ For custom configurations (using `docksal.yml`), if you are getting:
 ERROR: Named volume "host_home:/.home:ro" is used in service "cli" but no declaration was found in the volumes section.
 ```
 
-Remove `host_home:/.home:ro` from `docksal.yml` and do a `fin up`.
+Remove `host_home:/.home:ro` from `docksal.yml` and do a `fin project start`.
 
 ## New software versions
 

--- a/bin/fin
+++ b/bin/fin
@@ -784,7 +784,7 @@ check_project_unique ()
 		if [[ "$_project_name" == "$COMPOSE_PROJECT_NAME_SAFE" ]] && [[ "$_project_root" != "$PROJECT_ROOT" ]]; then
 			echo-error "Another project is already using the name '${COMPOSE_PROJECT_NAME_SAFE}'" \
 				"Change the name of the current project by renaming the project folder (folder name defines the project name and has to be unique)" \
-				"or remove the other project's stack by running ${yellow}fin rm${NC} in ${yellow}$_project_root${NC}"
+				"or remove the other project's stack by running ${yellow}fin project remove${NC} in ${yellow}$_project_root${NC}"
 			exit 1
 		fi
 
@@ -793,7 +793,7 @@ check_project_unique ()
 		if [[ "$_project_vhost" =~ ^$VIRTUAL_HOST ]] && [[ "$_project_root" != "$PROJECT_ROOT" ]]; then
 			echo-error "Another project is already using the virtual hostname '${VIRTUAL_HOST}'" \
 				"Use a different hostname for this project by overriding the VIRTUAL_HOST variable in docksal.env" \
-				"or remove the other project's stack by running ${yellow}fin rm${NC} in ${yellow}$_project_root${NC}"
+				"or remove the other project's stack by running ${yellow}fin project remove${NC} in ${yellow}$_project_root${NC}"
 			exit 1
 		fi
 	done
@@ -1294,21 +1294,21 @@ show_help_project() {
 	printh "fin project <command> [params]" "" "yellow"
 	echo
 	echo-green "Commands:"
-	printh "start" "Start project services (shorthand: fin start)"
-	printh "up" "Forces re-read of configuration and start project services (shorthand: fin up)"
-	printh "stop [-a (--all)]" "Stop project services (-a stops all services on all projects) (shorthand: fin stop)"
-	printh "status" "List project services (shorthand: fin ps)"
-	printh "restart" "Restart project services (shorthand: fin restart)"
-	printh "reset" "Recreate project services and containers (${yellow}fin help reset${NC}) (shorthand: fin reset)"
+	printh "start" "Start project services (alias: fin start)"
+	printh "up" "Forces re-read of configuration and start project services (alias: fin up)"
+	printh "stop [-a (--all)]" "Stop project services (-a stops all services on all projects) (alias: fin stop)"
+	printh "status" "List project services (alias: fin ps)"
+	printh "restart" "Restart project services (alias: fin restart)"
+	printh "reset" "Recreate project services and containers (${yellow}fin help reset${NC}) (alias: fin reset)"
 	printh "remove or rm" "Stop project services and remove their containers (${yellow}fin help remove${NC})"
 	printh "config" "Show project configuration"
 	printh "build" "Build or rebuild services (alias for 'docker-compose build')"
-	printh "list [-a (--all)]" "List running Docksal projects (-a to show stopped as well) (shorthand: fin pl)"
+	printh "list [-a (--all)]" "List running Docksal projects (-a to show stopped as well) (alias: fin pl)"
 	printh "create" "Project wizard to create new Drupal, Wordpress, Magento or empty static project."
 	echo
 	echo-green "Examples:"
 	printh "fin pl -a" "List all known Docksal projects, including stopped ones"
-	printh "fin reset db" "Reset only DB service to start with DB from scratch"
+	printh "fin project reset db" "Reset only DB service to start with DB from scratch"
 	printh "fin project create" "Start a new project wizard"
 	echo
 }
@@ -1521,7 +1521,7 @@ show_help_cleanup ()
 	echo
 	printh "Removes unused docker images to save disk space on VM."
 	printh "Removes orphaned containers. Orphaned are those, which folders were deleted on filesystem"
-	printh "without removing their containers with 'fin rm' first."
+	printh "without removing their containers with 'fin project remove' first."
 	echo-green "Parameters:"
 	printh "--hard" "Also remove all stopped containers (potentially destructive operation)"
 	echo
@@ -3965,7 +3965,7 @@ reset ()
 		remove "$@"
 	fi
 	# Return here if there are errors with remove
-	# This also helps with cases when there was a typo in the reset command, like "fin reset ssystem"
+	# This also helps with cases when there was a typo in the reset command, like "fin reset system"
 	[[ "$?" != 0 ]] && return $?
 
 	# Run ssh_add here, since there is no better place to get it triggered on Linux and Docker for Mac/Win

--- a/bin/fin
+++ b/bin/fin
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-FIN_VERSION=1.33.0
+FIN_VERSION=1.40.0
 
 # Console colors
 red='\033[0;91m'
@@ -1071,27 +1071,18 @@ show_help ()
 
 	printh "Docksal Fin v$FIN_VERSION commands:" "" "green"
 
-	printh "start (up)" "Start project services ('up' forces re-read of configuration)"
-	printh "stop [-a (--all)]" "Stop project services (-a stops all services on all projects)"
-	printh "restart" "Restart project services"
-	printh "reset" "Recreate project services and containers (${yellow}fin help reset${NC})"
-	printh "remove (rm)" "Stop project services and remove their containers (${yellow}fin help remove${NC})"
-	printh "status (ps)" "List project services"
-	printh "logs [service]" "Show service logs (e.g. Apache logs, MySQL logs)"
-	printh "config [command]" "Show project configuration (See ${yellow}fin help config${NC} for generate)"
-	printh "build" "Build or rebuild services (alias for 'docker-compose build')"
-
 	echo
-	printh "db <command>" "DB commands: import, dump, list, cli (${yellow}fin help db${NC})" "yellow"
-	printh "project <command>" "Projects management commands: list, create (${yellow}fin help project${NC})" "yellow"
+	printh "project <command>" "Project commands: start, stop, status and more... (${yellow}fin help project${NC})" "yellow"
 	if ! is_linux && ! is_docker_native; then
-		printh "vm <command>" "VM commands: start, stop, restart and more. See ${yellow}fin help vm${NC}" "yellow"
+		printh "vm <command>" "VM commands: start, stop, restart and more... (${yellow}fin help vm${NC})" "yellow"
 	fi
+	printh "db <command>" "DB commands: import, dump, list, cli (${yellow}fin help db${NC})" "yellow"
 
 	echo
 	printh "bash [service]" "Open shell into service's container. Defaults to ${yellow}cli${NC}"
+	printh "logs [service]" "Show service logs (e.g. Apache logs, MySQL logs)"
 	printh "exec <command|file>" "Execute a command or a script in ${yellow}cli${NC}"
-	printh "ssh-add [-lD] [key]" "Adds ssh private key to the authentication agent (${yellow}fin help ssh-add${NC})"
+	printh "config [command]" "Show or generate configuration (${yellow}fin help config${NC})"
 
 	echo
 	printh "drush [command]" "Execute Drush command (Drupal)"
@@ -1099,7 +1090,8 @@ show_help ()
 	printh "wp [command]" "Execute WP-CLI command (WordPress)"
 
 	echo
-	printh "addon <name>" "Addons management commands"
+	printh "addon <command>" "Addons management commands: install, remove (${yellow}fin help addon${NC})"
+	printh "ssh-add [-lD] [key]" "Adds ssh private key to the authentication agent (${yellow}fin help ssh-add${NC})"
 	printh "alias" "Manage aliases that allow ${yellow}fin @alias${NC} execution (${yellow}fin help alias${NC})"
 	printh "cleanup [--hard]" "Remove unused Docker images and projects (saves disk space)"
 	printh "share" "Create temporary public url for current project using ngrok"
@@ -1240,10 +1232,10 @@ show_help_exec ()
 
 show_help_reset ()
 {
-	printh "fin reset" "" "yellow"
+	printh "fin project reset" "" "yellow"
 	echo
-	echo-green "Recreate services/containers. Equal to fin rm followed by fin start"
-	echo "By default recreates project containers deleting all changes that were made to them."
+	echo-green "Recreate project services/containers. Equal to 'fin project remove' followed by 'fin project start'"
+	echo "Resets all file system changes that were made to the containers."
 	echo
 	echo-green "System services"
 	echo -e "Docksal has several system services."
@@ -1291,15 +1283,25 @@ show_help_image() {
 
 show_help_project() {
 	echo-green "Project management"
-	printh "fin project <command>" "" "yellow"
+	printh "fin project <command> [params]" "" "yellow"
 	echo
 	echo-green "Commands:"
-	printh "list (pl) [-a (--all)]" "List running Docksal projects (-a to show stopped as well)"
-	printh "create" "Create and install new Drupal, Wordpress or Magento project."
+	printh "start" "Start project services (shorthand: fin start)"
+	printh "up" "Forces re-read of configuration and start project services (shorthand: fin up)"
+	printh "stop [-a (--all)]" "Stop project services (-a stops all services on all projects) (shorthand: fin stop)"
+	printh "status" "List project services (shorthand: fin ps)"
+	printh "restart" "Restart project services (shorthand: fin restart)"
+	printh "reset" "Recreate project services and containers (${yellow}fin help reset${NC}) (shorthand: fin reset)"
+	printh "remove or rm" "Stop project services and remove their containers (${yellow}fin help remove${NC})"
+	printh "config" "Show project configuration"
+	printh "build" "Build or rebuild services (alias for 'docker-compose build')"
+	printh "list [-a (--all)]" "List running Docksal projects (-a to show stopped as well) (shorthand: fin pl)"
+	printh "create" "Project wizard to create new Drupal, Wordpress, Magento or empty static project."
 	echo
 	echo-green "Examples:"
 	printh "fin pl -a" "List all known Docksal projects, including stopped ones"
-	printh "fin project create" "Start project wizard"
+	printh "fin reset db" "Reset only DB service to start with DB from scratch"
+	printh "fin project create" "Start a new project wizard"
 	echo
 }
 
@@ -1498,7 +1500,7 @@ show_help_config ()
 	printh "fin config [command]" "" "yellow"
 	echo
 	echo-green "Config commands:"
-	printh "show" "Display full effective configuration for the project"
+	printh "show" "Display configuration for the current project"
 	printh "env" "Display only environment variables section"
 	printh "generate" "Generate Docksal configuration for the project"
 	echo
@@ -4826,6 +4828,19 @@ case "$1" in
 		shift
 		restart "$@"
 		;;
+	reset)
+		shift
+		# Make sure docker daemon is accessible
+		check_docker_running
+		# do not load configuration for resetting of dns, proxy, ssh-agent, network, system.
+		[[ ! "dns proxy ssh-agent network system" =~ "$1" ]] && load_configuration
+		reset "$@"
+		;;
+	remove|rm)
+		load_configuration
+		shift
+		remove "$@"
+		;;
 	image)
 		# no load_configuration
 		shift
@@ -4849,7 +4864,7 @@ case "$1" in
 			;;
 		esac
 		;;
-	project)
+	project|p)
 		# no load_configuration
 		shift
 		case "$1" in
@@ -4861,8 +4876,59 @@ case "$1" in
 				project_list "$@"
 				;;
 			'')
-				echo -e "See ${yellow}fin help project${NC}"
+				echo -e "start stop list status ... (${yellow}fin help project${NC})"
 				exit 1
+				;;
+			status|st)
+				load_configuration
+				check_for_updates
+				project_status
+				;;
+			start)
+				load_configuration
+				check_for_updates
+				shift
+				up
+				;;
+			up)
+				# Force re-reading of configuration files
+				COMPOSE_FILE="" load_configuration
+				check_for_updates
+				shift
+				up
+				;;
+			stop)
+				shift
+				# load_configuration is called later in _stop_containers
+				stop "$@"
+				;;
+			restart)
+				load_configuration
+				shift
+				restart "$@"
+				;;
+			reset)
+				shift
+				# Make sure docker daemon is accessible
+				check_docker_running
+				# do not load configuration for resetting of dns, proxy, ssh-agent, network, system.
+				[[ ! "dns proxy ssh-agent network system" =~ "$1" ]] && load_configuration
+				reset "$@"
+				;;
+			remove|rm)
+				load_configuration
+				shift
+				remove "$@"
+				;;
+			config)
+				load_configuration
+				check_for_updates
+				config_show "$@"
+				;;
+			build)
+				load_configuration
+				shift
+				docker-compose build "$@"
 				;;
 			help)
 				show_help_project
@@ -4884,19 +4950,6 @@ case "$1" in
 		check_for_updates
 		shift
 		project_list "$@"
-		;;
-	reset)
-		shift
-		# Make sure docker daemon is accessible
-		check_docker_running
-		# do not load configuration for resetting of dns, proxy, ssh-agent, network, system.
-		[[ ! "dns proxy ssh-agent network system" =~ "$1" ]] && load_configuration
-		reset "$@"
-		;;
-	remove|rm)
-		load_configuration
-		shift
-		remove "$@"
 		;;
 	vm)
 		# no load_configuration

--- a/bin/fin
+++ b/bin/fin
@@ -1008,7 +1008,7 @@ _healthcheck_wait ()
 		if ((elapsed > timeout)); then
 			echo-error "$container_name heathcheck failed" \
 				"Container did not enter a healthy state within the expected amount of time." \
-				"Try ${yellow}fin restart${NC}"
+				"Try ${yellow}fin project restart${NC}"
 			exit 1
 		fi
 	done
@@ -1245,6 +1245,7 @@ show_help_reset ()
 	echo -e "Docksal has several system services."
 	echo -e "Names ${yellow}'dns'${NC}, ${yellow}'proxy'${NC}, ${yellow}'ssh-agent'${NC} and ${yellow}'system'${NC} are reserved and should not be used in projects."
 	echo
+	printh "fin project reset" "Recreate project containers"
 	printh "fin reset dns" "Recreate Docksal DNS service"
 	printh "fin reset proxy" "Recreate Docksal HTTP/HTTPS reverse proxy service (resolves ${yellow}*.docksal${NC} domain names into container IPs)"
 	printh "fin reset ssh-agent" "Recreate Docksal ssh-agent service"
@@ -1255,7 +1256,7 @@ show_help_reset ()
 show_help_rm ()
 {
 	echo-green "Remove services"
-	printh "fin remove" "" "yellow"
+	printh "fin project remove" "" "yellow"
 	echo
 	echo "Removes project containers and frees up space consumed by them."
 	echo
@@ -3970,7 +3971,7 @@ _set_cli_uid ()
 	container_uid_gid=$(docker exec -u docker ${cli} bash -c 'echo -n $(id -u):$(id -g)')
 	if [[ ! $? -eq 0 ]]; then
 		echo-error "Error getting uid from cli container" \
-			"You might need to recreate containers with ${yellow}fin reset${NC}"
+			"You might need to recreate containers with ${yellow}fin project reset${NC}"
 		return
 	fi
 
@@ -4355,7 +4356,7 @@ config_generate ()
 	fi
 
 	if [[ $? == 0 ]]; then
-		echo-green "Configuration was generated. You can start it with ${yellow}fin start${NC}"
+		echo-green "Configuration was generated. You can start it with ${yellow}fin project start${NC}"
 	else
 		echo-error "Something went wrong. Check error messages above."
 	fi

--- a/docs/advanced/db-import.md
+++ b/docs/advanced/db-import.md
@@ -21,7 +21,7 @@ db:
   ...
 ```
 
-Run `fin reset db` to reinitialize the `db` service.
+Run `fin project reset db` (`fin p reset db`) to reinitialize the `db` service.
 
 It may take some time for the database server to initialize and import the dump.  
 Check container logs for progress and/or issues if necessary (`fin logs db`).

--- a/docs/advanced/db-sandbox.md
+++ b/docs/advanced/db-sandbox.md
@@ -23,12 +23,12 @@ db:
   command: "--datadir /var/lib/mysql-sandbox"
 ```
 
-3) Reset the db service: `fin reset db`  
+3) Reset the db service: `fin project reset db`
 4) Import the database: `fin sqli db.sql`  
 5) Create a snapshot image from the `db` container
 
 ```bash
-fin stop
+fin project stop
 fin docker commit $(fin docker-compose ps -q db) <tag>
 ```
 
@@ -44,11 +44,11 @@ db:
   command: "--datadir /var/lib/mysql-sandbox"
 ```
 
-7) Update the stack configuration: `fin up`
+7) Update the stack configuration: `fin project start` (`fin p start` for short)
 
 Now the `db` service container is using an ephemeral storage for the database (changes) - `/var/lib/mysql-sandbox`.
 
-To reset it to the snapshot you took in step 1 run `fin reset db`.  
+To reset it to the snapshot you took in step 1 run `fin project reset db` (`fin p reset db`).
 
 ## Disabling sandbox mode
 
@@ -56,7 +56,7 @@ You will need a DB dump to revert.
 Either use the one created before enabling the sandbox mode or create a new one.
 
 1) Revert the changes done to the `db` service in `docksal.yml`.  
-2) Reset the `db` service: `fin reset db`  
+2) Reset the `db` service: `fin project reset db`
 3) Import the DB dump.
 
 Now the `db` service container is using a persistent storage volume for the database - `/var/lib/mysql`.

--- a/docs/advanced/extend-images.md
+++ b/docs/advanced/extend-images.md
@@ -107,7 +107,7 @@ Following the previous example, here's what it would look like for `cli`:
 
 ## Building
 
-Building a customized image happens automatically with `fin up`.  
+Building a customized image happens automatically with `fin project start`.
 The built image will be stored locally and used as the service image from there on.
 
 Additionally, `fin build` command is a proxy command to [docker-compose build](https://docs.docker.com/compose/reference/build/) 

--- a/docs/advanced/multiple-projects.md
+++ b/docs/advanced/multiple-projects.md
@@ -38,7 +38,7 @@ VIRTUAL_HOST: custom-domain.docksal
 VIRTUAL_HOST_ALIASES: *.custom-domain.docksal
 ````
 
-Apply configuration changes with `fin up`.
+Apply configuration changes with `fin project start` (`fin p start` for short).
 
 
 ## Using arbitrary custom domains
@@ -59,7 +59,7 @@ services:
 
 `io.docksal.virtual-host=${VIRTUAL_HOST},*.${VIRTUAL_HOST}` is the default value.
 
-Apply configuration changes with `fin up`.
+Apply configuration changes with `fin project start` (`fin p start` for short).
 
 Please note, that non `.docksal` domains (e.g. `example.com`) will not be resolved automatically.
 You can use [fin hosts](advanced/fin.md#fin-help-hosts) command to add and manage additional domain names via the system's `hosts` file. 

--- a/docs/advanced/networking.md
+++ b/docs/advanced/networking.md
@@ -32,7 +32,7 @@ version: "2"
 
 **Note the quotes.** Yaml interprets some numbers with a colon as base64 numbers, so you need quotes here.
 
-**3.** Run `fin up` to apply the new configuration.
+**3.** Run `fin project start` to apply the new configuration.
 
 **4.** Now you can see that your port is exposed.
 

--- a/docs/advanced/ssh-agent.md
+++ b/docs/advanced/ssh-agent.md
@@ -4,7 +4,7 @@ The ssh-agent service allows adding multiple keys (including the ones protected 
 ssh keys, which can be shared across multiple projects.
 
 The default ssh keys (`~/.ssh/id_rsa`, `~/.ssh/id_dsa`, `~/.ssh/id_ecdsa`) are loaded into the agent automatically.  
-On macOS and Windows this happens when the Docksal VM is (re)started, on Linux - whenever `fin up` is used.
+On macOS and Windows this happens when the Docksal VM is (re)started, on Linux - whenever `fin project start` is used.
 
 
 ## Project setup
@@ -22,7 +22,7 @@ cli:
   ...
 ```
 
-Reset the `cli` container `fin reset cli`.
+Reset the `cli` container `fin project reset cli`.
 
 
 ## Command line reference

--- a/docs/advanced/stack-config.md
+++ b/docs/advanced/stack-config.md
@@ -34,8 +34,8 @@ Please read the documentation to understand their main sections.
     Some containers and their parameters are required for Docksal to work properly. 
     **Please see [Don't break your Docksal setup!](#warning) section.**
 
-You have to run `fin start` to apply configuration changes. 
-If you remove services or volumes you have to remove them with `fin rm [service]`.
+You have to run `fin project start` (`fin p start` for short) to apply configuration changes.
+If you remove services or volumes you have to remove them with `fin project rm [service]`.
 
 ## Project configuration files
 <a name="docksal-yml"></a>
@@ -112,7 +112,7 @@ To see the files loaded for a particular project run `fin config show`.
 <a name="zero-configuration"></a>
 ## Zero-configuration
 
-You can simply create a `.docksal` folder in your project root and run `fin start`.
+You can simply create a `.docksal` folder in your project root and run `fin project start` (`fin start` for short).
 The default stack (`~/.docksal/stacks/stack-default.yml`) will be loaded and used to create containers in this case.
 
 This is a great way to start developing a new project. This approach can also be used on a permanent basis, 
@@ -122,7 +122,7 @@ so you'll be getting the latest stack versions with every Docksal update.
 ### Zero-configuration stacks
 
 You can switch between pre-created zero-configuration stacks by adding the following line to your `docksal.env` file 
-and running `fin reset`.
+and running `fin project reset`.
 
 ```
 DOCKSAL_STACK="acquia"
@@ -131,7 +131,7 @@ DOCKSAL_STACK="acquia"
 The following stacks are available:
 
 - `default` - web, db, cli (assumed, when none specified.)
-- `acquia` - web, db, cli, varnish, memcached, solr (used specifically for [Acqui](https://www.acquia.com/) hosted projects.)
+- `acquia` - web, db, cli, varnish, memcached, solr (used specifically for [Acquia](https://www.acquia.com/) hosted projects.)
 
 <a name="custom-configuration"></a>
 ## Custom configuration

--- a/docs/advanced/stack-settings.md
+++ b/docs/advanced/stack-settings.md
@@ -12,11 +12,7 @@ When the following settings files are added to the project, they can be used to 
 Copy `examples/.docksal/etc` from the [Docksal](https://github.com/docksal/docksal) project repo into the `.docksal` 
 folder in your project repo and modify as necessary.
 
-!!! important "Applying the settings changes"
-    When adding the settings files initially into a project a reset is necessary for containers to pick them up properly.  
-    Run `fin reset cli` for PHP and `fin reset db` for MySQL (**WARNING: this will destroy your database!**).  
-    When the settings files are already in place, configuration changes can be propagated by restarting the containers 
-    with `fin restart`.
+Apply changes with `fin project restart` (`fin p restart`).
 
 <a name="php-versions"></a>
 ## Using different PHP versions
@@ -30,7 +26,7 @@ via the `CLI_IMAGE` variable in `.docksal/docksal.env`.
 CLI_IMAGE='docksal/cli:1.3-php7'
 ```
 
-Remember to run `fin up` to apply the configuration.
+Remember to run `fin project start` (`fin p start`) to apply the configuration.
 
 Available images:
 
@@ -49,11 +45,11 @@ via the `DB_IMAGE` variable in `.docksal/docksal.env`.
 DB_IMAGE='docksal/db:1.1-mysql-5.6'
 ```
 
-Remember to run `fin up` to apply the configuration.
+Remember to run `fin project start` (`fin p start`) to apply the configuration.
 
 !!! warning "MySQL versions compatibility"
 
-    Different MySQL versions may not be fully compatible. A complete `db` service reset (`fin reset db`) might be necessary 
+    Different MySQL versions may not be fully compatible. A complete `db` service reset (`fin project reset db`) might be necessary
     followed by a DB re-import.
 
 Available images:

--- a/docs/advanced/vm.md
+++ b/docs/advanced/vm.md
@@ -15,7 +15,7 @@ For hosts with limited RAM (less than 8GB) it may be necessary to limit the VM m
 When working with multiple projects, it is best to limit the number of active projects to 1 or 2. 
 Trying to launch more than 2 at the same time may result in unpredictable issues.
 
-Use `fin stop --all` to stop all projects, then `fin start` to restart the one you plan to work with.
+Use `fin stop --all` to stop all projects, then `fin project start` to restart the one you plan to work with.
 
 ## Increasing Docksal's Virtualbox VM disk size (HDD)
 

--- a/docs/advanced/volumes.md
+++ b/docs/advanced/volumes.md
@@ -111,7 +111,7 @@ with Docker for Mac, for testing and performance comparison purposes.
 ### Using NFS volumes
 
 - Add `DOCKSAL_VOLUMES=nfs` in `.docksal/docksal.env` in a project
-- `fin reset`
+- `fin project reset`
 
 
 ## Unison volumes
@@ -154,7 +154,7 @@ The downsides:
 - Follow instructions [here](http://docs.docksal.io/en/master/getting-started/env-setup-native/) to properly 
 configure Docksal for use with Docker for Mac. Make sure you have the most recent fin version installed.
 - Add `DOCKSAL_VOLUMES=unison` in `.docksal/docksal.env` in a project
-- `fin reset`
+- `fin project reset`
 - Wait until the osxfs process on you Mac "cools down" - that's how you know unison is done with the initial sync.
 
 Currently there is no good way to know when unison is done with the initial file sync. This makes it difficult to script 

--- a/docs/advanced/web-http-auth.md
+++ b/docs/advanced/web-http-auth.md
@@ -10,7 +10,7 @@ APACHE_BASIC_AUTH_PASS=password
 ```
 
 If using custom configuration, modify your `.docksal/docksal.yml` or `.docksal/docksal-local.yml`.  
-Add following two lines to for the `web` service and run `fin up` to apply changes.
+Add following two lines to for the `web` service and run `fin project start` to apply changes.
 
 ```yaml
   web:

--- a/docs/getting-started/project-setup.md
+++ b/docs/getting-started/project-setup.md
@@ -27,7 +27,7 @@ The `.docksal` directory is where all Docksal configurations and commands for th
 
 ```bash
 cd ~/projects/myproject
-fin start
+fin project start
 ```
 
 You will see output similar to the following:

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -79,7 +79,7 @@ First, try these quick fix steps in the order listed below. Check if the issue h
 
 - Update Docksal to the latest version. See the [updates](#updates) section.
 - (Mac and Windows) Restart the Docksal VM: `fin vm restart`
-- Reset Docksal system services with `fin reset system` and restart project containers with `fin up`
+- Reset Docksal system services with `fin reset system` and restart project containers with `fin project restart`
 - Reboot the host (your computer or remote server)
 - (Mac and Windows) Re-create Docksal VM: `fin vm remove` then `fin vm start` (**WARNING**: backup your DB data before doing this)
 

--- a/docs/tools/apache-solr.md
+++ b/docs/tools/apache-solr.md
@@ -12,7 +12,7 @@ solr:
   image: docksal/solr:1.0-solr4
 ```
 
-Run `fin up` to apply the new configuration.
+Apply new configuration with `fin project start` (`fin p start`).
 
 
 ## Drupal configuration
@@ -55,7 +55,7 @@ solr:
     - ${PROJECT_ROOT}/.docksal/etc/solr/conf:/var/lib/solr/conf:ro
 ```
 
-Apply configuration changes with `fin up`
+Apply configuration changes with `fin project start` (`fin p start`)
 
 
 ## Versions

--- a/docs/tools/behat.md
+++ b/docs/tools/behat.md
@@ -132,7 +132,7 @@ cli:
  ...
 ```
 
-2) Update the container configuration with `fin up`.  
+2) Update the container configuration with `fin project start` (`fin p start`).
 3) You should now be able to connect to the `cli` container via ssh. Use username `docker` and password `docker`:
 
 ```bash

--- a/docs/tools/blackfire.md
+++ b/docs/tools/blackfire.md
@@ -77,7 +77,7 @@ Replace `<Server ID>`, `<Server Token>` (`<Client ID>`, `<Client Token>`) with t
 
 ---
 
-Apply the new configuration with `fin up`.
+Apply the new configuration with `fin project start` (`fin p start`).
 
 
 ## Usage

--- a/docs/tools/mailhog.md
+++ b/docs/tools/mailhog.md
@@ -25,7 +25,7 @@ mail:
   user: root
 ```
 
-Apply new configuration with `fin up`.
+Apply new configuration with `fin project start` (`fin p start`).
 
 ### PHP settings
 

--- a/docs/tools/memcached.md
+++ b/docs/tools/memcached.md
@@ -37,7 +37,7 @@ Use it when maintaining a static stack configuration, that is fully defined in t
       - ${DOCKSAL_DNS2}
 ```
 
-Apply new configuration with `fin up`.
+Apply new configuration with `fin project start` (`fin p start`).
 
 Use `memcached:11211` as the memcached endpoint.
 
@@ -55,4 +55,4 @@ This can be overridden via the command arguments in the service definition.
     command: ["-m", "128"]
     ...
 ```
-Add and adjust as necessary in `docksal.yml`. Apply new configuration with `fin up`.
+Add and adjust as necessary in `docksal.yml`. Apply new configuration with `fin project start` (`fin p start`).

--- a/docs/tools/varnish.md
+++ b/docs/tools/varnish.md
@@ -13,7 +13,7 @@ varnish:
     - VARNISH_BACKEND_HOST=web
 ```
 
-Apply new configuration with `fin up`.
+Apply new configuration with `fin project start` (`fin p start`).
 
 Use `http://varnish.<VIRTUAL_HOST>` to access the site via Varnish.
  

--- a/docs/tools/xdebug.md
+++ b/docs/tools/xdebug.md
@@ -25,7 +25,7 @@ You can also pick from the [list](https://confluence.jetbrains.com/display/PhpSt
 XDEBUG_ENABLED=1
 ```
 
-2) Update container configuration with `fin up`  
+2) Apply container configuration with `fin project start` (`fin p start`)
 
 3) Open your project in PHPStorm  
 
@@ -60,7 +60,7 @@ services:
       - PHP_IDE_CONFIG=serverName=${VIRTUAL_HOST}
 ```
 
-2) Update container configuration with `fin up`
+2) Apply container configuration with `fin project start` (`fin p start`)
 
 3) Configure PHPStorm to be able to handle drush debugging
 ![Screenshot](../_img/xdebug-phpstorm-drush.png)
@@ -107,7 +107,7 @@ To configure debugging in browser follow **Prerequisites** and **Setup**.
 XDEBUG_ENABLED=1
 ```
 
-2) Update container configuration with `fin up`  
+2) Apply container configuration with `fin project start` (`fin p start`)
 
 3) Open NetBeans Debugging configuration (follow menu "Tools" -> "Options" -> "PHP" -> "Debugging") and set "DebuggerPort" to 9000
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -181,7 +181,7 @@ Errors like this appear when your Apache is misconfigured. Most often it happens
 
 ### How to resolve
 
-Check `docksal.yml` and `.htaccess` files for configuration errors, fix them and run `fin start`.
+Check `docksal.yml` and `.htaccess` files for configuration errors, fix them and run `fin project start` (`fin start` for short).
 
 ## Issue 10. SMB share creation, share mounting and related issues on Windows
 


### PR DESCRIPTION
From now on the default way to launch commands against project is via `fin project` commands subset. E.g. `fin project start` or `fin p start`.

Old shorthands like `fin start` still work for legacy compatibility.

That's how new help will look

```
$ fin
  Docksal Fin v1.40.0 commands:	

  project <command>        	Project commands: start, stop, status and more... (fin help project)
  vm <command>             	VM commands: start, stop, restart and more... (fin help vm)
  db <command>             	DB commands: import, dump, list, cli (fin help db)

  bash [service]           	Open shell into service's container. Defaults to cli
  logs [service]           	Show service logs (e.g. Apache logs, MySQL logs)
  exec <command|file>      	Execute a command or a script in cli
  config [command]         	Show or generate configuration (fin help config)

  drush [command]          	Execute Drush command (Drupal)
  drupal [command]         	Execute Drupal Console command (Drupal 8)
  wp [command]             	Execute WP-CLI command (WordPress)

  addon <command>          	Addons management commands: install, remove (fin help addon)
  ssh-add [-lD] [key]      	Adds ssh private key to the authentication agent (fin help ssh-add)
  alias                    	Manage aliases that allow fin @alias execution (fin help alias)
  cleanup [--hard]         	Remove unused Docker images and projects (saves disk space)
  share                    	Create temporary public url for current project using ngrok
  exec-url <url>           	Download script from URL and run it on host (URL should be public)
  run-cli (rc) <command>   	Run a command in a standalone cli container in the current directory
  image <command>          	Image management commands: registry, save, load (fin help image)
  hosts <command>          	Hosts file commands: add, remove, list (fin help hosts)
  vhosts                   	List all virtual *.docksal hosts registered in docksal proxy
  sysinfo                  	Show system information for bug reporting
  diagnose                 	Show statistics for troubleshooting and bug reporting
  version (v, -v)          	Print fin version. [v, -v] prints short version
  update                   	Update Docksal
```

New help for project command:

```
$ fin help project
Project management
  fin project <command> [params]	

Commands:
  start                    	Start project services (shorthand: fin start)
  up                       	Forces re-read of configuration and start project services (shorthand: fin up)
  stop [-a (--all)]        	Stop project services (-a stops all services on all projects) (shorthand: fin stop)
  status                   	List project services (shorthand: fin ps)
  restart                  	Restart project services (shorthand: fin restart)
  reset                    	Recreate project services and containers (fin help reset) (shorthand: fin reset)
  remove or rm             	Stop project services and remove their containers (fin help remove)
  config                   	Show project configuration
  build                    	Build or rebuild services (alias for 'docker-compose build')
  list [-a (--all)]        	List running Docksal projects (-a to show stopped as well) (shorthand: fin pl)
  create                   	Project wizard to create new Drupal, Wordpress, Magento or empty static project.

Examples:
  fin pl -a                	List all known Docksal projects, including stopped ones
  fin reset db             	Reset only DB service to start with DB from scratch
  fin project create       	Start a new project wizard
```