### PR TITLE
fin system. Fixes #387

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -2669,7 +2669,7 @@ install_proxy_service ()
 	# PROJECT_INACTIVITY_TIMEOUT - defines the timeout of inactivity after which the project stack will be stopped (e.g. 0.5h)
 	# PROJECT_DANGLING_TIMEOUT - defines the timeout of inactivity after which the project stack and code base will be
 	# entirely wiped out from the host (e.g. 168h). WARNING: use at your own risk!
-	docker run -d --name docksal-vhost-proxy --label "io.docksal.group=system" --restart=always \
+	docker run -d --name docksal-vhost-proxy --label "io.docksal.group=system" --restart=unless-stopped \
 		-p "${DOCKSAL_VHOST_PROXY_IP:-$DOCKSAL_IP}:${DOCKSAL_VHOST_PROXY_PORT_HTTP:-80}":80 -p "${DOCKSAL_VHOST_PROXY_IP:-$DOCKSAL_IP}:${DOCKSAL_VHOST_PROXY_PORT_HTTPS:-443}":443 \
 		-e PROJECT_INACTIVITY_TIMEOUT="${PROJECT_INACTIVITY_TIMEOUT:-0}" \
 		-e PROJECT_DANGLING_TIMEOUT="${PROJECT_DANGLING_TIMEOUT:-0}" \
@@ -2686,7 +2686,7 @@ install_dns_service ()
 	# container for DNS resolution (Windows and Linux), so we will get into a recursion.
 	# DOCKSAL_DNS_UPSTREAM can be set to the controlled network DNS server address (VPN/LAN) in the global docksal.env file.
 	# When user disconnects from that network, the backup DNS will handle name resolution (assuming 8.8.4.4 is reachable).
-	docker run -d --name docksal-dns --label "io.docksal.group=system" --restart=always \
+	docker run -d --name docksal-dns --label "io.docksal.group=system" --restart=unless-stopped \
 		-p "${DOCKSAL_IP}:53:53/udp" --cap-add=NET_ADMIN --dns="$DOCKSAL_DNS_UPSTREAM" --dns="8.8.4.4" \
 		-e DNS_IP="$DOCKSAL_IP" -e DNS_DOMAIN="$DOCKSAL_DNS_DOMAIN" -e LOG_QUERIES="$DOCKSAL_DNS_DEBUG" \
 		-v /var/run/docker.sock:/var/run/docker.sock \
@@ -2852,7 +2852,7 @@ install_sshagent_service ()
 	docker volume rm docksal_ssh_agent >/dev/null 2>&1 || true
 
 	docker volume create --name docksal_ssh_agent >/dev/null 2>&1
-	docker run -d --name docksal-ssh-agent --label "io.docksal.group=system" --restart=always \
+	docker run -d --name docksal-ssh-agent --label "io.docksal.group=system" --restart=unless-stopped \
 		-v docksal_ssh_agent:/.ssh-agent \
 		"${IMAGE_SSH_AGENT}" >/dev/null
 	# Add default keys. Using || true here to suppress errors if there are no keys on the host.

--- a/bin/fin
+++ b/bin/fin
@@ -1304,13 +1304,13 @@ show_help_system() {
 	printh "fin system <command> [params]" "" "yellow"
 	echo
 	echo-green "Commands:"
-	printh "reset" "Reset Docksal system services"
-	printh "start" "Start Docksal system services"
-	printh "stop" "Stop Docksal system services"
-	printh "status" "Check Docksal system services"
+	printh "reset" "Reset Docksal"
+	printh "start" "Start Docksal"
+	printh "stop" "Stop Docksal"
+	printh "status" "Check Docksal status"
 	echo
 	echo-green "Examples:"
-	printh "fin system reset" "Reset all Docksal system services"
+	printh "fin system reset" "Reset all Docksal system services and settings"
 	printh "fin system reset dns" "Reset Docksal DNS service"
 	printh "fin system reset vhost-proxy" "Reset Docksal HTTP/HTTPS reverse proxy service (resolves ${yellow}*.docksal${NC} domain names into container IPs)"
 	printh "fin system reset ssh-agent" "Reset Docksal ssh-agent service"
@@ -2611,25 +2611,27 @@ system_status ()
 }
 
 # Starts all Docksal related things
+# TODO: add projects, network, /etc/exports, etc. here for a complete shutdown of Docksal
 system_start ()
 {
-	# TODO: add projects, network, /etc/exports, etc. here for a complete shutdown of Docksal
-	echo-green "Starting Docksal..."
-	
-	system_reset
+	if ! is_linux && ! is_docker_native && ! is_wsl; then
+		echo "Starting Docksal VM..."
+		vm start
+	else
+		echo "Starting Docksal system services..."
+		system_reset
+	fi
 }
 
 # Stops/disables all Docksal things
+# TODO: add projects, network, /etc/exports, etc. here for a complete shutdown of Docksal
 system_stop ()
 {
-	# TODO: add projects, network, /etc/exports, etc. here for a complete shutdown of Docksal
-	echo-green "Stopping Docksal..."
-	
-	configure_resolver off
-	if [[ ! is_linux && ! is_docker_native && ! is_wsl ]]; then
+	if ! is_linux && ! is_docker_native && ! is_wsl; then
 		echo-green "Stopping Docksal VM..."
-		docker_machine_stop
+		vm stop
 	else
+		configure_resolver off
 		echo-green "Stopping Docksal system services..."
 		docker ps -q --filter "label=io.docksal.group=system" | xargs docker stop >/dev/null
 	fi

--- a/bin/fin
+++ b/bin/fin
@@ -3620,8 +3620,7 @@ update ()
 	# This is needed to re-append restarted vhost-proxy to containers networks
 	if [[ ${UPGRADE_IN_PROGRESS} == 1 ]] && [[ "$BOOT2DOCKER_NEEDS_AN_UPGRADE" != "1" ]]; then
 		echo-green "[STEP 6/$TOTAL_STEPS] Restarting running projects..."
-		running_projects=$(docker ps --all \
-			--filter 'status=running' \
+		running_projects=$(docker ps \
 			--filter 'label=com.docker.compose.service=web' \
 			--format '{{.Label "io.docksal.project-root"}}'
 		)

--- a/bin/fin
+++ b/bin/fin
@@ -2765,7 +2765,7 @@ install_proxy_service ()
 	# PROJECT_INACTIVITY_TIMEOUT - defines the timeout of inactivity after which the project stack will be stopped (e.g. 0.5h)
 	# PROJECT_DANGLING_TIMEOUT - defines the timeout of inactivity after which the project stack and code base will be
 	# entirely wiped out from the host (e.g. 168h). WARNING: use at your own risk!
-	docker run -d --name docksal-vhost-proxy --label "io.docksal.group=system" --restart=unless-stopped \
+	docker run -d --name docksal-vhost-proxy --label "io.docksal.group=system" --restart=always \
 		-p "${DOCKSAL_VHOST_PROXY_IP:-$DOCKSAL_IP}:${DOCKSAL_VHOST_PROXY_PORT_HTTP:-80}":80 -p "${DOCKSAL_VHOST_PROXY_IP:-$DOCKSAL_IP}:${DOCKSAL_VHOST_PROXY_PORT_HTTPS:-443}":443 \
 		-e PROJECT_INACTIVITY_TIMEOUT="${PROJECT_INACTIVITY_TIMEOUT:-0}" \
 		-e PROJECT_DANGLING_TIMEOUT="${PROJECT_DANGLING_TIMEOUT:-0}" \
@@ -2782,7 +2782,7 @@ install_dns_service ()
 	# container for DNS resolution (Windows and Linux), so we will get into a recursion.
 	# DOCKSAL_DNS_UPSTREAM can be set to the controlled network DNS server address (VPN/LAN) in the global docksal.env file.
 	# When user disconnects from that network, the backup DNS will handle name resolution (assuming 8.8.4.4 is reachable).
-	docker run -d --name docksal-dns --label "io.docksal.group=system" --restart=unless-stopped \
+	docker run -d --name docksal-dns --label "io.docksal.group=system" --restart=always \
 		-p "${DOCKSAL_IP}:53:53/udp" --cap-add=NET_ADMIN --dns="$DOCKSAL_DNS_UPSTREAM" --dns="8.8.4.4" \
 		-e DNS_IP="$DOCKSAL_IP" -e DNS_DOMAIN="$DOCKSAL_DNS_DOMAIN" -e LOG_QUERIES="$DOCKSAL_DNS_DEBUG" \
 		-v /var/run/docker.sock:/var/run/docker.sock \
@@ -2948,7 +2948,7 @@ install_sshagent_service ()
 	docker volume rm docksal_ssh_agent >/dev/null 2>&1 || true
 
 	docker volume create --name docksal_ssh_agent >/dev/null 2>&1
-	docker run -d --name docksal-ssh-agent --label "io.docksal.group=system" --restart=unless-stopped \
+	docker run -d --name docksal-ssh-agent --label "io.docksal.group=system" --restart=always \
 		-v docksal_ssh_agent:/.ssh-agent \
 		"${IMAGE_SSH_AGENT}" >/dev/null
 	# Add default keys. Using || true here to suppress errors if there are no keys on the host.

--- a/bin/fin
+++ b/bin/fin
@@ -2633,7 +2633,7 @@ system_stop ()
 	else
 		configure_resolver off
 		echo-green "Stopping Docksal system services..."
-		docker ps -q --filter "label=io.docksal.group=system" | xargs docker stop >/dev/null
+		docker ps -q --filter "label=io.docksal.group=system" | xargs docker rm -vf >/dev/null
 	fi
 }
 

--- a/bin/fin
+++ b/bin/fin
@@ -686,7 +686,7 @@ check_docksal_running ()
 	if ! is_docksal_running; then
 		echo-alert "Some Docksal services were not running" "Restarting Docksal system services..."
 		sleep 1
-		reset system
+		system_reset
 	fi
 }
 
@@ -1065,16 +1065,21 @@ show_help ()
 			fi
 	fi
 
-	printh "Docksal Fin v$FIN_VERSION commands:" "" "green"
-
+	echo "Docksal control cli utility v$FIN_VERSION"
 	echo
-	printh "project <command>" "Project commands: start, stop, status and more... (${yellow}fin help project${NC})" "yellow"
+	echo "Usage: fin <command>"
+	echo
+
+	echo-green "Management Commands:"
+	printh "db <command>" "Manage databases (${yellow}fin help db${NC})" "yellow"
+	printh "project <command>" "Manage project(s) (${yellow}fin help project${NC})" "yellow"
+	printh "system <command>" "Manage Docksal (${yellow}fin help system${NC})" "yellow"
 	if ! is_linux && ! is_docker_native; then
-		printh "vm <command>" "VM commands: start, stop, restart and more... (${yellow}fin help vm${NC})" "yellow"
+		printh "vm <command>" "Manage Docksal VM (${yellow}fin help vm${NC})" "yellow"
 	fi
-	printh "db <command>" "DB commands: import, dump, list, cli (${yellow}fin help db${NC})" "yellow"
-
 	echo
+
+	echo-green "Commands:"
 	printh "bash [service]" "Open shell into service's container. Defaults to ${yellow}cli${NC}"
 	printh "logs [service]" "Show service logs (e.g. Apache logs, MySQL logs) and Unison logs (${yellow}fin help logs${NC})"
 	printh "exec <command|file>" "Execute a command or a script in ${yellow}cli${NC}"
@@ -1105,7 +1110,7 @@ show_help ()
 	load_global_configuration
 	if ! empty_dir "$PROJECT_ROOT/$DOCKSAL_ADDONS_PATH" || ! empty_dir "$HOME/$DOCKSAL_ADDONS_PATH"; then
 		echo
-		echo-green "  Addons:"
+		echo-green "Addons:"
 	fi
 	if [[ ! -z "$(get_project_path)" ]]; then
 		show_help_list_addons_in_help 'project'
@@ -1117,7 +1122,7 @@ show_help ()
 	# Show list of custom commands and their help if available
 	if ! empty_dir "$PROJECT_ROOT/$DOCKSAL_COMMANDS_PATH" || ! empty_dir "$HOME/$DOCKSAL_COMMANDS_PATH"; then
 		echo
-		echo-green "  Custom commands:"
+		echo-green "Custom commands:"
 	fi
 	if [[ ! -z "$(get_project_path)" ]]; then
 		show_help_list_commands_in_help 'project'
@@ -1233,15 +1238,7 @@ show_help_reset ()
 	echo-green "Recreate project services/containers. Equal to 'fin project remove' followed by 'fin project start'"
 	echo "Resets all file system changes that were made to the containers."
 	echo
-	echo-green "System services"
-	echo -e "Docksal has several system services."
-	echo -e "Names ${yellow}'dns'${NC}, ${yellow}'proxy'${NC}, ${yellow}'ssh-agent'${NC} and ${yellow}'system'${NC} are reserved and should not be used in projects."
-	echo
 	printh "fin project reset" "Recreate project containers"
-	printh "fin reset dns" "Recreate Docksal DNS service"
-	printh "fin reset proxy" "Recreate Docksal HTTP/HTTPS reverse proxy service (resolves ${yellow}*.docksal${NC} domain names into container IPs)"
-	printh "fin reset ssh-agent" "Recreate Docksal ssh-agent service"
-	printh "fin reset system" "Recreate all Docksal system services"
 	echo
 }
 
@@ -1300,6 +1297,23 @@ show_help_project() {
 	printh "fin project reset db" "Reset only DB service to start with DB from scratch"
 	printh "fin project create" "Start a new project wizard"
 	echo
+}
+
+show_help_system() {
+	echo-green "Manage Docksal"
+	printh "fin system <command> [params]" "" "yellow"
+	echo
+	echo-green "Commands:"
+	printh "reset" "Reset Docksal system services"
+	printh "start" "Start Docksal system services"
+	printh "stop" "Stop Docksal system services"
+	printh "status" "Check Docksal system services"
+	echo
+	echo-green "Examples:"
+	printh "fin system reset" "Reset all Docksal system services"
+	printh "fin system reset dns" "Reset Docksal DNS service"
+	printh "fin system reset vhost-proxy" "Reset Docksal HTTP/HTTPS reverse proxy service (resolves ${yellow}*.docksal${NC} domain names into container IPs)"
+	printh "fin system reset ssh-agent" "Reset Docksal ssh-agent service"
 }
 
 show_help_update ()
@@ -2542,9 +2556,89 @@ project_create ()
 	fin init
 }
 
+# Resets Docksal system services
+system_reset ()
+{
+	# TODO: add /etc/exports, etc. here for a complete reset of Docksal
+
+	# Configure network has to happen before any communications with the docker daemon happen (before check_docker_running)
+	if [[ "$1" == "" ]] ; then
+		echo-green 'Resetting network settings...'
+		configure_network
+		echo-green 'Resetting Docksal services...'
+		echo ' * proxy'
+		install_proxy_service
+		echo ' * dns and resolver for .docksal domain'
+		install_dns_service
+		configure_resolver
+		echo ' * ssh-agent'
+		install_sshagent_service
+		return
+	fi
+
+	# Configure network has to happen before any communications with the docker daemon happen (before check_docker_running)
+	if [[ "$1" == "network" ]] ; then
+		echo-green 'Resetting network settings...'
+		configure_network
+		return
+	fi
+
+	if [[ "$1" == "vhost-proxy" ]] ; then
+		echo-green 'Resetting Docksal HTTP/HTTPS reverse proxy service...'
+		install_proxy_service
+		return
+	fi
+
+	if [[ "$1" == "dns" ]] ; then
+		echo-green 'Resetting Docksal DNS service and configuring resolver for .docksal domain...'
+		install_dns_service
+		configure_resolver
+		return
+	fi
+
+	if [[ "$1" == "ssh-agent" ]] ; then
+		echo-green 'Resetting Docksal ssh-agent service...'
+		install_sshagent_service
+		return
+	fi
+}
+
+# Disaplys Docksal system status
+system_status ()
+{
+	# TODO: replace with a custom view showing services, networks, vm, etc. status
+	docker ps --filter "label=io.docksal.group=system"
+}
+
+# Starts all Docksal related things
+system_start ()
+{
+	# TODO: add projects, network, /etc/exports, etc. here for a complete shutdown of Docksal
+	echo-green "Starting Docksal..."
+	
+	system_reset
+}
+
+# Stops/disables all Docksal things
+system_stop ()
+{
+	# TODO: add projects, network, /etc/exports, etc. here for a complete shutdown of Docksal
+	echo-green "Stopping Docksal..."
+	
+	configure_resolver off
+	if [[ ! is_linux && ! is_docker_native && ! is_wsl ]]; then
+		echo-green "Stopping Docksal VM..."
+		docker_machine_stop
+	else
+		echo-green "Stopping Docksal system services..."
+		docker ps -q --filter "label=io.docksal.group=system" | xargs docker stop >/dev/null
+	fi
+}
+
 # Add key to ssh-agent or run ssh-add with provided @param
 # @param $1 -D, -l or path to custom key
-ssh_add () {
+ssh_add ()
+{
 	check_winpty_found
 
 	# Check if ssh-agent container is running
@@ -2553,7 +2647,7 @@ ssh_add () {
 	if [[ "$running" != "true" ]]; then
 		echo-error "docksal-ssh-agent is not running" \
 			"Please report this issue, as this should not usually happen." \
-			"Run ${yellow}fin reset ssh-agent${NC} to start the service."
+			"Run ${yellow}fin system reset ssh-agent${NC} to start the service."
 		# We could automatically run install_sshagent_service here, however that may lead to an endless recursion
 		# if something is terribly wrong. So it's better to alret the user and ask them to try a manual fix.
 		return 1
@@ -2832,7 +2926,7 @@ configure_resolver ()
 					"You are either offline, $DOCKSAL_DNS_UPSTREAM is not a valid DNS server or DNS requests to $DOCKSAL_DNS_UPSTREAM are blocked." \
 					"Once the current operation completes, follow the steps below:" \
 					"  1. Open ${yellow}~/.docksal/docksal.env${NC} and set ${yellow}DOCKSAL_DNS_UPSTREAM${NC} to your local network DNS server" \
-					"  2. Run ${yellow}fin reset dns${NC} to see if it works"
+					"  2. Run ${yellow}fin system reset dns${NC} to see if it works"
 				_confirm "Continue?"
 			fi
 		fi
@@ -3169,7 +3263,7 @@ install_tools_wsl ()
 		if_failed "Docker Compose installation/upgrade has failed."
 	fi
 
-	reset system
+	system_reset
 }
 
 update_virtualbox () {
@@ -3332,7 +3426,7 @@ update_system_images ()
 		docker pull "${IMAGE_DNS}"
 		docker pull "${IMAGE_SSH_AGENT}"
 	fi
-	reset system
+	system_reset
 }
 
 # Update project images
@@ -4031,50 +4125,6 @@ exec_url ()
 # @param $1 $2... containers names
 reset ()
 {
-	# Configure network has to happen before any communications with the docker daemon happen (before check_docker_running)
-	if [[ "$1" == "system" ]] ; then
-		echo-green 'Resetting network settings...'
-		configure_network
-	fi
-
-	# Configure network has to happen before any communications with the docker daemon happen (before check_docker_running)
-	if [[ "$1" == "network" ]] ; then
-		echo-green 'Resetting network settings...'
-		configure_network
-		return
-	fi
-
-	if [[ "$1" == "proxy" ]] ; then
-		echo-green 'Resetting Docksal HTTP/HTTPS reverse proxy service...'
-		install_proxy_service
-		return
-	fi
-
-	if [[ "$1" == "dns" ]] ; then
-		echo-green 'Resetting Docksal DNS service and configuring resolver for .docksal domain...'
-		install_dns_service
-		configure_resolver
-		return
-	fi
-
-	if [[ "$1" == "ssh-agent" ]] ; then
-		echo-green 'Resetting Docksal ssh-agent service...'
-		install_sshagent_service
-		return
-	fi
-
-	if [[ "$1" == "system" ]] ; then
-		echo-green 'Resetting Docksal services...'
-		echo ' * proxy'
-		install_proxy_service
-		echo ' * dns and resolver for .docksal domain'
-		install_dns_service
-		configure_resolver
-		echo ' * ssh-agent'
-		install_sshagent_service
-		return
-	fi
-
 	check_project_root
 	# support quiet removal
 	if [[ $1 == "-f" ]]; then
@@ -5023,10 +5073,11 @@ case "$1" in
 		;;
 	reset)
 		shift
-		# Make sure docker daemon is accessible. reset network is a special excluded case.
-		[[ ! "network" =~ "$1" ]] && check_docker_running
-		# do not load configuration for resetting of dns, proxy, ssh-agent, network, system.
-		[[ ! "dns proxy ssh-agent network system" =~ "$1" ]] && load_configuration
+		if [[ "dns proxy ssh-agent network system" =~ "$1" ]]; then
+			echo-warning "${NC}Deprecated. Use ${yellow}fin system reset${NC} to reset Docksal system services"
+			exit 1
+		fi
+		load_configuration
 		reset "$@"
 		;;
 	remove|rm)
@@ -5102,10 +5153,8 @@ case "$1" in
 				;;
 			reset)
 				shift
-				# Make sure docker daemon is accessible
 				check_docker_running
-				# do not load configuration for resetting of dns, proxy, ssh-agent, network, system.
-				[[ ! "dns proxy ssh-agent network system" =~ "$1" ]] && load_configuration
+				load_configuration
 				reset "$@"
 				;;
 			remove|rm)
@@ -5128,6 +5177,34 @@ case "$1" in
 				;;
 			*)
 				show_help_project
+				exit 1
+				;;
+		esac
+		;;
+	system|s)
+		# no load_configuration
+		shift
+		case "$1" in
+			reset|r)
+				shift
+				# Make sure docker daemon is accessible. reset network is a special excluded case.
+				[[ ! "network" =~ "$1" ]] && check_docker_running
+				system_reset "$@"
+				;;
+			start|st)
+				shift
+				system_start
+				;;
+			status|s)
+				shift
+				system_status
+				;;
+			stop|sp)
+				shift
+				system_stop
+				;;
+			*)
+				show_help_system
 				exit 1
 				;;
 		esac

--- a/bin/fin
+++ b/bin/fin
@@ -5113,7 +5113,7 @@ case "$1" in
 		# no load_configuration
 		shift
 		case "$1" in
-			create|cr)
+			create)
 				project_create
 				;;
 			list|ls)
@@ -5124,12 +5124,12 @@ case "$1" in
 				echo -e "start stop list status ... (${yellow}fin help project${NC})"
 				exit 1
 				;;
-			status|s)
+			status|st)
 				load_configuration
 				check_for_updates
 				project_status
 				;;
-			start|st)
+			start)
 				load_configuration
 				check_for_updates
 				shift
@@ -5142,7 +5142,7 @@ case "$1" in
 				shift
 				up
 				;;
-			stop|sp)
+			stop)
 				shift
 				# load_configuration is called later in _stop_containers
 				stop "$@"
@@ -5163,7 +5163,7 @@ case "$1" in
 				shift
 				remove "$@"
 				;;
-			config|conf)
+			config)
 				load_configuration
 				check_for_updates
 				config_show "$@"
@@ -5182,25 +5182,25 @@ case "$1" in
 				;;
 		esac
 		;;
-	system|s)
+	system|sys)
 		# no load_configuration
 		shift
 		case "$1" in
-			reset|r)
+			reset)
 				shift
 				# Make sure docker daemon is accessible. reset network is a special excluded case.
 				[[ ! "network" =~ "$1" ]] && check_docker_running
 				system_reset "$@"
 				;;
-			start|st)
+			start)
 				shift
 				system_start
 				;;
-			status|s)
+			status|st)
 				shift
 				system_status
 				;;
-			stop|sp)
+			stop)
 				shift
 				system_stop
 				;;

--- a/docs/advanced/dns-resolver.md
+++ b/docs/advanced/dns-resolver.md
@@ -43,7 +43,7 @@ default upstream DNS settings.
     DOCKSAL_DNS_UPSTREAM=192.168.0.1
     ```
 
-2. Run `fin reset dns`
+2. Run `fin system reset dns`
 
 Inspect you LAN or WiFi interface settings and connection status to figure out the DNS server your network is using.
 
@@ -53,7 +53,7 @@ Inspect you LAN or WiFi interface settings and connection status to figure out t
 Enable logging
 
 ```
-DOCKSAL_DNS_DEBUG=true fin reset dns
+DOCKSAL_DNS_DEBUG=true fin system reset dns
 ```
 
 View logs

--- a/docs/fin/fin.md
+++ b/docs/fin/fin.md
@@ -8,41 +8,40 @@ Docksal Fin (`fin`) is a command line tool for controlling a Docksal powered sta
 To list available commands, either run `fin` with no parameters or execute `fin help`:
 
     $ fin help
-      Docksal Fin v1.24.0 commands:
-      start (up)                   Start project services ('up' forces re-read of configuration)
-      stop [-a (--all)]            Stop project services (-a stops all services on all projects)
-      restart                      Restart project services
-      reset                        Recreate project services and containers (fin help reset)
-      remove (rm)                  Stop project services and remove their containers (fin help remove)
-      status (ps)                  List project services
-      logs [service]               Show service logs (e.g. Apache logs, MySQL logs)
-      config [command]             Show project configuration (See fin help config for generate)
-      build                        Build or rebuild services (alias for 'docker-compose build')
-    
-      db <command>                 DB commands: import, dump, list, cli (fin help db)
-      project <command>            Projects management commands: list, create (fin help project)
-      vm <command>                 VM commands: start, stop, restart and more. See fin help vm
-    
-      bash [service]               Open shell into service's container. Defaults to cli
-      exec <command|file>          Execute a command or a script in cli
-      ssh-add [-lD] [key]          Adds ssh private key to the authentication agent (fin help ssh-add)
-    
-      drush [command]              Execute Drush command (Drupal)
-      drupal [command]             Execute Drupal Console command (Drupal 8)
-      wp [command]                 Execute WP-CLI command (WordPress)
-    
-      addon <name>                 Addons management commands
-      alias                        Manage aliases that allow fin @alias execution (fin help alias)
-      cleanup [--hard]             Remove unused Docker images and projects (saves disk space)
-      share                        Create temporary public url for current project using ngrok
-      exec-url <url>               Download script from URL and run it on host (URL should be public)
-      run-cli (rc) <command>       Run a command in a standalone cli container in the current directory
-      image <command>              Image management commands: registry, save, load (fin help image)
-      hosts <command>              Hosts file commands: add, remove, list (fin help hosts)
-      sysinfo                      Show system information for bug reporting
-      diagnose                     Show statistics for troubleshooting and bug reporting
-      version (v, -v)              Print fin version. [v, -v] prints short version
-      update                       Update Docksal
+    Docksal control cli utility v1.44.0
+
+    Usage: fin <command>
+
+    Management Commands:
+      db <command>             	Manage databases (fin help db)
+      project <command>        	Manage project(s) (fin help project)
+      system <command>         	Manage Docksal (fin help system)
+      vm <command>             	Manage Docksal VM (fin help vm)
+
+    Commands:
+      bash [service]           	Open shell into service's container. Defaults to cli
+      logs [service]           	Show service logs (e.g. Apache logs, MySQL logs) and Unison logs (fin help logs)
+      exec <command|file>      	Execute a command or a script in cli
+      config [command]         	Show or generate configuration (fin help config)
+
+      drush [command]          	Execute Drush command (Drupal)
+      drupal [command]         	Execute Drupal Console command (Drupal 8)
+      wp [command]             	Execute WP-CLI command (WordPress)
+
+      addon <command>          	Addons management commands: install, remove (fin help addon)
+      ssh-add [-lD] [key]      	Adds ssh private key to the authentication agent (fin help ssh-add)
+      alias                    	Manage aliases that allow fin @alias execution (fin help alias)
+      cleanup [--hard]         	Remove unused Docker images and projects (saves disk space)
+      share                    	Create temporary public url for current project using ngrok
+      exec-url <url>           	Download script from URL and run it on host (URL should be public)
+      run-cli (rc) <command>   	Run a command in a standalone cli container in the current directory
+      image <command>          	Image management commands: registry, save, load (fin help image)
+      hosts <command>          	Hosts file commands: add, remove, list (fin help hosts)
+      vhosts                   	List all virtual *.docksal hosts registered in docksal proxy
+      sysinfo                  	Show system information for bug reporting
+      diagnose                 	Show statistics for troubleshooting and bug reporting
+      version (v, -v)          	Print fin version. [v, -v] prints short version
+      update                   	Update Docksal
 
 Some more complex management commands have their own help sections.
 
@@ -50,120 +49,149 @@ Some more complex management commands have their own help sections.
 
     $ fin help db
     Database related commands
-      fin db <command> [file] [options]     
-    
+      fin db <command> [file] [options]	
+
     Commands:
-      import [file] [options]       Truncate the database and import from SQL dump file or stdin.
-               --progress           Show import progess (requires pv).
-               --no-truncate        Do no truncate database before import.
-      dump [file]                   Dump a database into an SQL dump file or stdout.
-      list (ls)                     Show list of existing databases.
-      cli [query]                   Open command line interface to the DB server (and execute query if provided).
-      create <name>                 Create a database.
-      drop <name>                   Delete a database.
-    
+      import [file] [options]  	Truncate the database and import from SQL dump file or stdin.
+              --progress      	Show import progess (requires pv).
+              --no-truncate   	Do no truncate database before import.
+      dump [file]              	Dump a database into an SQL dump file or stdout.
+      list (ls)                	Show list of existing databases.
+      cli [query]              	Open command line interface to the DB server (and execute query if provided).
+      create <name>            	Create a database.
+      drop <name>              	Delete a database.
+
     Parameters:
-      --db=drupal                   Use another database (default is the one set with 'MYSQL_DATABASE')
-      --db-user=admin               Use another mysql username (default is 'root')
-      --db-password=p4$$            Use another database password (default is the one set with 'MYSQL_ROOT_PASSWORD', see fin config)
-      --db-charset=utf8             Override charset when creating a database (default is utf8)
-      --db-collation=utf8           Override collation when creating a database (default is utf8_general_ci)
-    
+      --db=drupal              	Use another database (default is the one set with 'MYSQL_DATABASE')
+      --db-user=admin          	Use another mysql username (default is 'root')
+      --db-password=p4$$       	Use another database password (default is the one set with 'MYSQL_ROOT_PASSWORD', see fin config)
+      --db-charset=utf8        	Override charset when creating a database (default is utf8)
+      --db-collation=utf8mb4   	Override collation when creating a database (default is utf8_general_ci)
+
     Examples:
-      fin db import ~/dump.sql                      Import from dump.sql file
-      fin db import ~/dump.sql --progress           Import from dump.sql file showing import progress
-      fin db import ~/partial.sql --no-truncate     Import partial.sql without truncating DB
-    
-      cat dump.sql | fin db import                  Import dump from stdin into default database
-      fin db dump ~/dump.sql                        Export default database into dump.sql
-      fin db dump --db=drupal                       Export database 'drupal' dump into stdout
-      fin db dump --db=mysql --db-user=root --db-password=root mysql.sql    Export mysql database as root into mysql.sql    
-    
-      fin db cli --db=nondefault 'select * from users'    Execute query on database other than MYSQL_DATABASE       
-      fin db create project2 --db-charset=utf8mb4         Create database project2 with utf8mb4 charset  
+      fin db import ~/dump.sql 			Import from dump.sql file
+      fin db import ~/dump.sql --progress		Import from dump.sql file showing import progress
+      fin db import ~/partial.sql --no-truncate	Import partial.sql without truncating DB
+
+      cat dump.sql | fin db import			Import dump from stdin into default database
+      fin db dump ~/dump.sql   			Export default database into dump.sql
+      fin db dump --db=drupal  			Export database 'drupal' dump into stdout
+      fin db dump --db=mysql --db-user=root --db-password=root mysql.sql    Export mysql database as root into mysql.sql	
+
+      fin db cli --db=nondefault 'select * from users'    Execute query on database other than MYSQL_DATABASE	
+      fin db create project2 --db-charset=utf8mb4    Create database project2 with utf8mb4 charset	
 
 <a name="fin-help-project"></a>
 
     $ fin help project
     Project management
-      fin project <command>
-    
-    Commands:
-      list (pl) [-a (--all)]       List running Docksal projects (-a to show stopped as well)
-      create                       Create and install new Drupal, Wordpress or Magento project.
-    
-    Examples:
-      fin pl -a                    List all known Docksal projects, including stopped ones
-      fin project create           Start project wizard
+      fin project <command> [params]	
 
+    Commands:
+      start                    	Start project services (alias: fin start)
+      up                       	Forces re-read of configuration and start project services (alias: fin up)
+      stop [-a (--all)]        	Stop project services (-a stops all services on all projects) (alias: fin stop)
+      status                   	List project services (alias: fin ps)
+      restart                  	Restart project services (alias: fin restart)
+      reset                    	Recreate project services and containers (fin help reset) (alias: fin reset)
+      remove or rm             	Stop project services and remove their containers (fin help remove)
+      config                   	Show project configuration
+      build                    	Build or rebuild services (alias for 'docker-compose build')
+      list [-a (--all)]        	List running Docksal projects (-a to show stopped as well) (alias: fin pl)
+      create                   	Project wizard to create new Drupal, Wordpress, Magento or empty static project.
+
+    Examples:
+      fin pl -a                	List all known Docksal projects, including stopped ones
+      fin project reset db     	Reset only DB service to start with DB from scratch
+      fin project create       	Start a new project wizard
+
+<a name="fin-help-system"></a>
+
+    $ fin help system
+    Manage Docksal
+      fin system <command> [params]	
+
+    Commands:
+      reset                    	Reset Docksal
+      start                    	Start Docksal
+      stop                     	Stop Docksal
+      status                   	Check Docksal status
+
+    Examples:
+      fin system reset         	Reset all Docksal system services and settings
+      fin system reset dns     	Reset Docksal DNS service
+      fin system reset vhost-proxy	Reset Docksal HTTP/HTTPS reverse proxy service (resolves *.docksal domain names into container IPs)
+      fin system reset ssh-agent	Reset Docksal ssh-agent service
 
 <a name="fin-help-vm"></a>
 
     $ fin help vm
     Control docker machine directly
-      fin vm <command>
-    
+      fin vm <command>         	
+
     Commands:
-      start                        Start the machine (create if needed)
-      stop                         Stop the machine
-      kill                         Forcibely stop the machine
-      restart                      Restart the machine
-      status                       Get the status
-      ssh [command]                Log into ssh or run a command via ssh
-      remove                       Remove Docksal machine and cleanup after it
-      ip                           Show the machine IP address
-      ls                           List all docker machines
-      env                          Display the commands to set up the shell for direct use of Docker client
-      mount                        Try remounting host filesystem (NFS on macOS, SMB on Windows)
-    
-      ram                          Show memory size
-      ram [megabytes]              Set memory size. Default is 1024 (requires vm restart)
-      hdd                          Show disk size and usage
-      stats                        Show CPU and network usage
+      start                    	Start the machine (create if needed)
+      stop                     	Stop the machine
+      kill                     	Forcibely stop the machine
+      restart                  	Restart the machine
+      status                   	Get the status
+      ssh [command]            	Log into ssh or run a command via ssh
+      remove                   	Remove Docksal machine and cleanup after it
+      ip                       	Show the machine IP address
+      ls                       	List all docker machines
+      env                      	Display the commands to set up the shell for direct use of Docker client
+      mount                    	Try remounting host filesystem (NFS on macOS, SMB on Windows)
+
+      ram                      	Show memory size
+      ram [megabytes]          	Set memory size. Default is 1024 (requires vm restart)
+      hdd                      	Show disk size and usage
+      stats                    	Show CPU and network usage
+
+      regenerate-certs         	Regenerate TLS certificates and restart the VM
 
 <a name="fin-help-image"></a>
 
     $ fin help image
     Image management
-      fin image <command>
-    
+      fin image <command>      	
+
     Commands:
-      registry                     Show all Docksal images on Docker Hub
-      registry [image name]        Show all tags for a certain image
-    
-      save [--system|--project|--all]    Save docker images into a tar archive.
-      load <file>                  Load docker images from a tar archive.
-    
+      registry                 	Show all Docksal images on Docker Hub
+      registry [image name]    	Show all tags for a certain image
+
+      save [--system|--project|--all]	Save docker images into a tar archive.
+      load <file>              	Load docker images from a tar archive.
+
     Examples:
-      fin image registry           Show all available Docksal images on Docker Hub
-      fin image registry docksal/db    Show all tags for docksal/db image
-      fin image save --system      Save Docksal system images.
-      fin image save --project     Save current project's images.
-      fin image save --all         Save all images available on the host.
+      fin image registry       	Show all available Docksal images on Docker Hub
+      fin image registry docksal/db	Show all tags for docksal/db image
+      fin image save --system  	Save Docksal system images.
+      fin image save --project 	Save current project's images.
+      fin image save --all     	Save all images available on the host.
 
 <a name="fin-help-hosts"></a>
 
     $ fin help hosts
     Can add or remove lines to/from OS-dependent hosts file
-    
-      fin hosts [command]
-    
-      Uses 192.168.64.100 for IP when VirtualBox is used.
-      Uses 192.168.64.100 for IP when DOCKER_NATIVE is set.
-    
+
+      fin hosts [command]      	
+
+      Uses 192.168.64.100 for IP when VirtualBox is used.	
+      Uses 192.168.64.100 for IP when DOCKER_NATIVE is set.	
+
     Commands:
-      add [hostname]               Add hostname to hosts file. If no provided uses VIRTUAL_HOST
-      remove [hostname]            Remove all lines containing hostname from hosts file. Uses VIRTUAL_HOST if none provided
-      list                         Output hosts file
-      <no command>                 Output hosts file
-      help                         Show this help
-    
+      add [hostname]           	Add hostname to hosts file. If no provided uses VIRTUAL_HOST
+      remove [hostname]        	Remove all lines containing hostname from hosts file. Uses VIRTUAL_HOST if none provided
+      list                     	Output hosts file
+      <no command>             	Output hosts file
+      help                     	Show this help
+
     Examples:
-      fin hosts add                Append current project's VIRTUAL_HOST to hosts file
-      fin hosts add demo.docksal    Append a line '192.168.64.100 demo.docksal' to hosts file
-      fin hosts remove             Remove current project's VIRTUAL_HOST from hosts file
-      fin hosts remove demo.docksal    Remove *all* lines containing demo.docksal from hosts file
-      fin hosts                    Output hosts file
+      fin hosts add            	Append current project's VIRTUAL_HOST to hosts file
+      fin hosts add demo.docksal	Append a line '192.168.64.100 demo.docksal' to hosts file
+      fin hosts remove         	Remove current project's VIRTUAL_HOST from hosts file
+      fin hosts remove demo.docksal	Remove *all* lines containing demo.docksal from hosts file
+      fin hosts                	Output hosts file
 
 ## Custom commands
 

--- a/docs/getting-started/env-setup-native.md
+++ b/docs/getting-started/env-setup-native.md
@@ -36,7 +36,7 @@ curl -fsSL https://get.docksal.io | sh
 **5.** Reset Docksal system services.
 
 ```bash
-fin reset system
+fin system reset
 ```
 
 **6.** Configure file sharing as necessary (see below).
@@ -74,7 +74,7 @@ Remove `DOCKER_NATIVE=1` from `$HOME/.docksal/docksal.env`
 **3.** Reset networks settings, start Docksal VM and reset Docksal system services
 
 ```bash
-fin reset network
+fin system reset network
 fin vm start
-fin reset system
+fin system reset
 ```

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -79,7 +79,7 @@ First, try these quick fix steps in the order listed below. Check if the issue h
 
 - Update Docksal to the latest version. See the [updates](#updates) section.
 - (Mac and Windows) Restart the Docksal VM: `fin vm restart`
-- Reset Docksal system services with `fin reset system` and restart project containers with `fin project restart`
+- Reset Docksal system services with `fin system reset` and restart project containers with `fin project restart`
 - Reboot the host (your computer or remote server)
 - (Mac and Windows) Re-create Docksal VM: `fin vm remove` then `fin vm start` (**WARNING**: backup your DB data before doing this)
 

--- a/tests/smoke-test-system.bats
+++ b/tests/smoke-test-system.bats
@@ -33,10 +33,10 @@ DOCKSAL_IP=192.168.64.100
 
 }
 
-@test "DNS: fin reset dns" {
+@test "DNS: fin system reset dns" {
 	[[ $SKIP == 1 ]] && skip
 
-	run fin reset dns
+	run fin system reset dns
 	echo "$output" | grep "Resetting Docksal DNS service and configuring resolver for .docksal domain"
 
   	# Wait 2s to let the service fully initialize
@@ -66,10 +66,10 @@ DOCKSAL_IP=192.168.64.100
     [[ "$(echo \"$output\" | grep "Address" | tail -1 | tr -d ' ' | awk -F ':' '{print $2}')" == "$DOCKSAL_IP" ]]
 }
 
-@test "VHOST-PROXY: fin reset proxy" {
+@test "VHOST-PROXY: fin system reset vhost-proxy" {
 	[[ $SKIP == 1 ]] && skip
 
-	run fin reset proxy
+	run fin system reset vhost-proxy
 	echo "$output" | grep "Resetting Docksal HTTP/HTTPS reverse proxy service"
 
   	# Wait 2s to let the service fully initialize
@@ -90,10 +90,10 @@ DOCKSAL_IP=192.168.64.100
 	echo "$output" | grep 'Welcome to nginx!'
 }
 
-@test "SSH-AGENT: fin reset ssh-agent" {
+@test "SSH-AGENT: fin system reset ssh-agent" {
 	[[ $SKIP == 1 ]] && skip
 
-	run fin reset ssh-agent
+	run fin system reset ssh-agent
 	echo "$output" | grep "Resetting Docksal ssh-agent service"
 	# Assuming there is at least one default key
 	echo "$output" | egrep "Identity added: id_.+ \(id_.+\)"


### PR DESCRIPTION
Initial pass on `fin system` group of commands. Fixes #387 

The goal is to have a clear and clean way of turning everything related to Docksal ON or OFF. The only exclusion would be Docker itself, when run natively (Linux, Docker for Mac/Win).

```
$ fin help system
Manage Docksal
  fin system <command> [params]	

Commands:
  reset                    	Reset Docksal
  start                    	Start Docksal
  stop                     	Stop Docksal
  status                   	Check Docksal status

Examples:
  fin system reset         	Reset all Docksal system services and settings
  fin system reset dns     	Reset Docksal DNS service
  fin system reset vhost-proxy	Reset Docksal HTTP/HTTPS reverse proxy service (resolves *.docksal domain names into container IPs)
  fin system reset ssh-agent	Reset Docksal ssh-agent service
```

We may want the `fin vm` group assimilated into `fin system` as well at some point, but maybe not right now.