### PR TITLE
run-cli (rc) should use 2.0 cli image.

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -3902,28 +3902,37 @@ run_cli ()
 	[[ $1 == "-T" ]] && \
 		local no_tty=true && shift
 	# Set default image
-	# Have to stick with docksal/1.3-php7 for now.
-	# TODO: Fix compatibility with docksal/cli:2.0 images.
-	local IMAGE="${IMAGE:-docksal/cli:1.3-php7}"
+	local IMAGE="${IMAGE:-docksal/cli:2.0-php7.1}"
 	local cmd="$@"
 
 	# Assume bash if no command was given
 	[[ "$cmd" == "" ]] && cmd="bash"
 
-	# Source $HOME/.docksalrc in cli.
-	# Commands in this file will be sourced for both interactive and non-interactive sessions.
-	DOCKSALRC='source $HOME/.docksalrc >/dev/null 2>&1'
-
 	# Debug mode off by default
 	DEBUG=${DEBUG:-0}
 
-	if is_tty && [[ "$no_tty" != true ]]; then
-		# interactive
-		# (exit \$?) is a hack to return correct exit codes when docker exec is run with tty (-t).
-		${winpty} docker run --rm -it -v $(pwd):/var/www -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) -e DEBUG="$DEBUG" ${IMAGE} bash -ic "$DOCKSALRC; $cmd; (exit \$?)"
+	# Backwards compability. Prior 2.0 images are executing the commands directly.
+	if [[ "$IMAGE" == docksal/cli:1* ]]; then
+		# Source $HOME/.docksalrc in cli.
+		# Commands in this file will be sourced for both interactive and non-interactive sessions.
+		DOCKSALRC='source $HOME/.docksalrc >/dev/null 2>&1'
+		if is_tty && [[ "$no_tty" != true ]]; then
+			# interactive
+			# (exit \$?) is a hack to return correct exit codes when docker exec is run with tty (-t).
+			${winpty} docker run --rm -it -v $(pwd):/var/www -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) -e DEBUG="$DEBUG" ${IMAGE} bash -ic "$DOCKSALRC; $cmd; (exit \$?)"
+		else
+			# non-interactive
+			docker run --rm -v $(pwd):/var/www -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) -e DEBUG="$DEBUG" ${IMAGE} bash -c "$DOCKSALRC; $cmd"
+		fi
 	else
-		# non-interactive
-		docker run --rm -v $(pwd):/var/www -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) -e DEBUG="$DEBUG" ${IMAGE} bash -c "$DOCKSALRC; $cmd"
+		if is_tty && [[ "$no_tty" != true ]]; then
+			# interactive
+			# (exit \$?) is a hack to return correct exit codes when docker exec is run with tty (-t).
+			${winpty} docker run --rm -it -v $(pwd):/var/www -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) -e DEBUG="$DEBUG" ${IMAGE} "$cmd; (exit \$?)"
+		else
+			# non-interactive
+			docker run --rm -v $(pwd):/var/www -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) -e DEBUG="$DEBUG" ${IMAGE} "$cmd"
+		fi
 	fi
 }
 


### PR DESCRIPTION

Trying out the run-cli command I figured out that it does not work with the new 2.0 images. I wanted to use it for a fast project start for a blt project like:
fin run-cli composer create-project --no-interaction acquia/blt-project my-project

But failed because that project has php 7.1 as requirement, which is not available for the 1.x images.

I tried to refactor a little bit to reduce the recurring if conditions but couldn't figure out how to optimize that and open for suggestions :)