### PR TITLE
Allow `fin alias` creation command to also update aliases

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -1511,10 +1511,10 @@ show_help_alias ()
 	echo
 	echo-green "Usage:"
 	printh "fin alias [list]" "Show aliases list"
-	printh "fin alias <path> <alias_name>" "Create an alias that links to target path"
+	printh "fin alias <path> <alias_name>" "Create or update an alias that links to target path"
 	printh "fin alias remove <alias_name>" "Remove alias"
 	echo-green "Examples:"
-	printh "fin alias ~/site1/docroot dev" "Create alias ${yellow}dev${NC} that is linked to ${yellow}~/site1/docroot${NC}"
+	printh "fin alias ~/site1/docroot dev" "Create or update an alias ${yellow}dev${NC} that is linked to ${yellow}~/site1/docroot${NC}"
 	printh "fin @dev drush st" "Execute 'drush st' command in directory linked by ${yellow}dev${NC} alias"
 	printh "" "Hint: create alias to Drupal sub-site folder to launch subsite targeted commands"
 	printh "fin alias remove dev" "Delete ${yellow}dev${NC} alias"
@@ -4390,7 +4390,7 @@ alias_create ()
 	[[ ! -d "$1" ]] && echo 'Path should be a valid dir' && exit 1
 
 	! is_windows && \
-		ln -s $(get_abs_path "$1") "$CONFIG_ALIASES/$2"
+		ln -fs $(get_abs_path "$1") "$CONFIG_ALIASES/$2"
 
 	[[ $? -eq 0 ]] && \
 		echo "$2 -> $(get_abs_path $1)"


### PR DESCRIPTION
Currently if one has an alias and they want to update it it must be first removed then added again. This pull request makes it possible to update a existing alias by using the normal fin alias creation command. A fin alias update command could have been created but for the limited number of times it would be used it make more sense to have this as part of the fin alias creation command.

I added the "-f" option to `ln` when creating an new fin alias link. This allow one to use the same command to update aliases vs. the current workflow of first removing the alias then adding it back in with the new path.

### Before this pull request
```bash
fin alias remove projectname
fin alias ~/docker/projectname projectname
```
### After this pull request
```bash
fin alias ~/docker/projectname projectname
```

