### PR TITLE
Allow drush debugging through drush-launcher

### DIFF
--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -86,6 +86,7 @@ services:
       - VIRTUAL_HOST
       - XDEBUG_ENABLED=${XDEBUG_ENABLED:-0}
       - XDEBUG_CONFIG=remote_connect_back=0 remote_host=${DOCKSAL_HOST_IP}  # Point xdebug to the host IP
+      - DRUSH_ALLOW_XDEBUG=1 # Allow debugging through drush-launcher
       - SECRET_SSH_PRIVATE_KEY
       - SECRET_ACAPI_EMAIL
       - SECRET_ACAPI_KEY


### PR DESCRIPTION
As per 
https://github.com/drush-ops/drush/pull/3272 
and the PR https://github.com/drush-ops/drush-launcher/pull/41
One needs to add the DRUSH_ALLOW_XDEBUG=1 flag for debugging drush in the launcher.

For me; debugging drush did not work at all until I added above variable.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docksal/docksal/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Write a short summary that describes the changes in this pull request:
-->
