### PR TITLE
Fix db import for paths with spaces in their name

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -4120,7 +4120,7 @@ mysql_import ()
 	__mysql_command=$(docker exec "$container_id" bash -c "echo -u${__dump_user} -p${__dump_password}")
 	__mysql_command=$(echo "${__mysql_command}" | sed -e 's/[^a-zA-Z0-9_-]$//')
 	# "docker exec -i" is required as it creates stdin/stdout streams but does not create tty
-	${pipe_cmd} ${__input} | docker exec -i ${container_id} mysql ${__mysql_command} ${__database}
+	${pipe_cmd} "${__input}" | docker exec -i ${container_id} mysql ${__mysql_command} ${__database}
 
 	# Check if import succeeded or not and print results.
 	if [ $? -eq 0 ]; then


### PR DESCRIPTION
There were quotes missing around the input argument for ${pipe_cmd} causing `db import` to fail if the provided path argument contains spaces.