### PR TITLE
Adding Environment Variables to run-cli command

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -3909,25 +3909,17 @@ run_cli ()
 		-T) local no_tty=true; shift; ;;
 		# Throw all environment variables into an array so that they can be spit into the docker run command.
 		-e)
-		local vars=($(echo $2 | tr "=" " "))
-		local key=${vars[0]}
-		vars=("${vars[@]:1}")
-		local value=${vars[@]}
+		IFS='=' read -r key value <<< "${2}"
 
-		# Test if $key is already a defined variable if not add 
-		# to $env_str which will be passed to the docker run command.
-		if [[ -z ${!key+x} ]]; then
-			if [[ -z "${value}" ]]; then
-				env_str="${env_str} -e ${key}"
-			else
-				env_str="${env_str} -e ${key}='${value}'"
-			fi
-		else
-			if [[ ! -z "${value}" ]]; then
-				eval ${key}=`echo -ne \""${value}"\"`
-			fi
-			env_str="${env_str} -e ${key}"
+		# If value is empty set the value to whatever the variable name in $key is
+		# If key does not exist then sets it to empty variable
+		if [[ -z $value ]]; then
+			value="${!key}"
 		fi
+		# Set the $key back to whatever $value is
+		eval ${key}=`echo -ne \""${value}"\"`
+		# Add only key to $env_str to be used at runtime.
+		env_str="${env_str}-e ${key} "
 		shift 2
 		;;
 		*) break;;

--- a/bin/fin
+++ b/bin/fin
@@ -3898,26 +3898,43 @@ _exec ()
 # @param $* command with its params to run.
 run_cli ()
 {
-	local env_vars=()
 	local env_str=""
+
+	local HOST_UID=$(id -u)
+	local HOST_GID=$(id -g)
+
+	[[ -f "$CONFIG_ENV" ]] && set -a; source "$CONFIG_ENV";
 
 	while [ $# -gt 0 ]
 	do
-		case $1 in
-			# Allow disabling TTY mode.
-			# Useful for non-interactive commands when output is saved into a variable for further comparison.
-			# In a TTY mode the output may contain unexpected control symbols/etc.
-			-T) local no_tty=true; shift; ;;
-			# Throw all environment variables into an array so that they can be spit into the docker run command.
-			-e) env_vars+=("${2}"); shift 2; ;;
-			*) break;;
-		esac
-	done
+	    case $1 in
+		# Allow disabling TTY mode.
+		# Useful for non-interactive commands when output is saved into a variable for further comparison.
+		# In a TTY mode the output may contain unexpected control symbols/etc.
+		-T) local no_tty=true; shift; ;;
+		# Throw all environment variables into an array so that they can be spit into the docker run command.
+		-e)
+		local vars=($(echo $2 | tr "=" " "))
+		local key=${vars[0]}
+		vars=("${vars[@]:1}")
+		local value=${vars[@]}
 
-	# If env_vars array has anything in it let's put it into a string.
-	if [ ${#env_vars[@]} -gt 0 ]; then
-		local env_str=$(printf " -e %s " "${env_vars[@]}")
-	fi
+		# Test if $key is already a defined variable if not add 
+		# to $env_str which will be passed to the docker run command.
+		if [[ -z ${!key+x} ]]; then
+			if [[ -z "${value}" ]]; then
+				env_str="${env_str} -e ${key}"
+			else
+				env_str="${env_str} -e ${key}='${value}'"
+			fi
+		else
+			eval ${key}=`echo -ne \""${value}"\"`
+		fi
+		shift 2
+		;;
+		*) break;;
+	    esac
+	done
 
 	# Set default image
 	local IMAGE="${IMAGE:-docksal/cli:2.1-php7.1}"
@@ -3937,10 +3954,10 @@ run_cli ()
 	if is_tty && [[ "$no_tty" != true ]]; then
 		# interactive
 		# (exit \$?) is a hack to return correct exit codes when docker exec is run with tty (-t).
-		${winpty} docker run --rm -it -v $(pwd):/var/www -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) -e DEBUG="$DEBUG" $env_str ${IMAGE} "$cmd; (exit \$?)"
+		eval "${winpty} docker run --rm -it -v $(pwd):/var/www -e VIRTUAL_HOST -e DOCROOT -e SECRET_SSH_PRIVATE_KEY -e SECRET_ACAPI_EMAIL -e SECRET_ACAPI_KEY -e SECRET_TERMINUS_TOKEN -e HOST_UID -e HOST_GID -e DEBUG" ${env_str} ${IMAGE} "$cmd; (exit \$?)"
 	else
 		# non-interactive
-		docker run --rm -v $(pwd):/var/www -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) -e DEBUG="$DEBUG" $env_str ${IMAGE} "$cmd"
+		eval "docker run --rm -v $(pwd):/var/www -e VIRTUAL_HOST  -e DOCROOT -e SECRET_SSH_PRIVATE_KEY -e SECRET_ACAPI_EMAIL -e SECRET_ACAPI_KEY -e SECRET_TERMINUS_TOKEN -e HOST_UID -e HOST_GID -e DEBUG" ${env_str} ${IMAGE} "$cmd"
 	fi
 }
 

--- a/bin/fin
+++ b/bin/fin
@@ -3928,7 +3928,10 @@ run_cli ()
 				env_str="${env_str} -e ${key}='${value}'"
 			fi
 		else
-			eval ${key}=`echo -ne \""${value}"\"`
+			if [[ ! -z "${value}" ]]; then
+				eval ${key}=`echo -ne \""${value}"\"`
+			fi
+			env_str="${env_str} -e ${key}"
 		fi
 		shift 2
 		;;

--- a/bin/fin
+++ b/bin/fin
@@ -3898,11 +3898,27 @@ _exec ()
 # @param $* command with its params to run.
 run_cli ()
 {
-	# Allow disabling TTY mode.
-	# Useful for non-interactive commands when output is saved into a variable for further comparison.
-	# In a TTY mode the output may contain unexpected control symbols/etc.
-	[[ $1 == "-T" ]] && \
-		local no_tty=true && shift
+	local env_vars=()
+	local env_str=""
+
+	while [ $# -gt 0 ]
+	do
+		case $1 in
+			# Allow disabling TTY mode.
+			# Useful for non-interactive commands when output is saved into a variable for further comparison.
+			# In a TTY mode the output may contain unexpected control symbols/etc.
+			-T) local no_tty=true; shift; ;;
+			# Throw all environment variables into an array so that they can be spit into the docker run command.
+			-e) env_vars+=("${2}"); shift 2; ;;
+			*) break;;
+		esac
+	done
+
+	# If env_vars array has anything in it let's put it into a string.
+	if [ ${#env_vars[@]} -gt 0 ]; then
+		local env_str=$(printf " -e %s " "${env_vars[@]}")
+	fi
+
 	# Set default image
 	local IMAGE="${IMAGE:-docksal/cli:2.1-php7.1}"
 	local cmd="$@"
@@ -3921,10 +3937,10 @@ run_cli ()
 	if is_tty && [[ "$no_tty" != true ]]; then
 		# interactive
 		# (exit \$?) is a hack to return correct exit codes when docker exec is run with tty (-t).
-		${winpty} docker run --rm -it -v $(pwd):/var/www -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) -e DEBUG="$DEBUG" ${IMAGE} "$cmd; (exit \$?)"
+		${winpty} docker run --rm -it -v $(pwd):/var/www -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) -e DEBUG="$DEBUG" $env_str ${IMAGE} "$cmd; (exit \$?)"
 	else
 		# non-interactive
-		docker run --rm -v $(pwd):/var/www -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) -e DEBUG="$DEBUG" ${IMAGE} "$cmd"
+		docker run --rm -v $(pwd):/var/www -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) -e DEBUG="$DEBUG" $env_str ${IMAGE} "$cmd"
 	fi
 }
 

--- a/bin/fin
+++ b/bin/fin
@@ -3900,11 +3900,6 @@ run_cli ()
 {
 	local env_str=""
 
-	local HOST_UID=$(id -u)
-	local HOST_GID=$(id -g)
-
-	[[ -f "$CONFIG_ENV" ]] && set -a; source "$CONFIG_ENV";
-
 	while [ $# -gt 0 ]
 	do
 	    case $1 in
@@ -4551,14 +4546,6 @@ load_configuration ()
 	is_windows && export PROJECT_ROOT_WIN="$(get_project_path_dc)"
 	# https://docs.docker.com/compose/reference/envvars/#compose_convert_windows_paths
 	export COMPOSE_CONVERT_WINDOWS_PATHS=1
-
-	# Export host user uid/gid
-	# The startup script in the cli container picks these up and updates the docker user inside of the container
-	# On Windows this is not necessary, as Linux permissions and ownership do not matter over SMB
-	if ! is_windows; then
-		export HOST_UID=$(id -u)
-		export HOST_GID=$(id -g)
-	fi
 }
 
 config_show ()
@@ -5063,6 +5050,14 @@ else
 	if [[ ! -f "$docksal_env_file" ]]; then
 		touch "$docksal_env_file" 2>/dev/null
 	fi
+fi
+
+# Host user uid/gid
+# The startup script in the cli container picks these up and updates the docker user inside of the container
+# On Windows this is not necessary, as Linux permissions and ownership do not matter over SMB
+if ! is_windows; then
+	export HOST_UID=$(id -u)
+	export HOST_GID=$(id -g)
 fi
 
 # Network settings

--- a/bin/fin
+++ b/bin/fin
@@ -3952,10 +3952,28 @@ run_cli ()
 	if is_tty && [[ "$no_tty" != true ]]; then
 		# interactive
 		# (exit \$?) is a hack to return correct exit codes when docker exec is run with tty (-t).
-		eval "${winpty} docker run --rm -it -v $(pwd):/var/www -e VIRTUAL_HOST -e DOCROOT -e SECRET_SSH_PRIVATE_KEY -e SECRET_ACAPI_EMAIL -e SECRET_ACAPI_KEY -e SECRET_TERMINUS_TOKEN -e HOST_UID -e HOST_GID -e DEBUG" ${env_str} ${IMAGE} "$cmd; (exit \$?)"
+		eval "${winpty} docker run --rm -it \
+			-v $(pwd):/var/www \
+			-e SECRET_SSH_PRIVATE_KEY \
+			-e SECRET_ACAPI_EMAIL \
+			-e SECRET_ACAPI_KEY \
+			-e SECRET_TERMINUS_TOKEN \
+			-e HOST_UID \
+			-e HOST_GID \
+			-e DEBUG" \
+			${env_str} ${IMAGE} "$cmd; (exit \$?)"
 	else
 		# non-interactive
-		eval "docker run --rm -v $(pwd):/var/www -e VIRTUAL_HOST  -e DOCROOT -e SECRET_SSH_PRIVATE_KEY -e SECRET_ACAPI_EMAIL -e SECRET_ACAPI_KEY -e SECRET_TERMINUS_TOKEN -e HOST_UID -e HOST_GID -e DEBUG" ${env_str} ${IMAGE} "$cmd"
+		eval "docker run --rm \
+			-v $(pwd):/var/www \
+			-e SECRET_SSH_PRIVATE_KEY \
+			-e SECRET_ACAPI_EMAIL \
+			-e SECRET_ACAPI_KEY \
+			-e SECRET_TERMINUS_TOKEN \
+			-e HOST_UID \
+			-e HOST_GID \
+			-e DEBUG" \
+			${env_str} ${IMAGE} "$cmd"
 	fi
 }
 

--- a/tests/smoke-test-general.bats
+++ b/tests/smoke-test-general.bats
@@ -184,32 +184,28 @@ teardown() {
 	run fin rc -T 'echo $(id -u):$(id -g)'
 	[[ "$output" == "$(id -u):$(id -g)" ]]
 	unset output
-	
+
 	# check to make sure custom variables are passed into container
 	run fin rc -T -e TEST_VAR="TEST VARIABLES" 'echo \$TEST_VAR'
 	[[ "$output" == "TEST VARIABLES" ]]
 	unset output
 
-	# check to make sure variables are included from $HOME/.docksal/docksal.env
-	echo "DOCROOT=web" >> $HOME/.docksal/docksal.env
-	run fin rc -T 'echo \$DOCROOT'
-	[[ "$output" == "web" ]]
+	# check to make sure a global default variable (from $HOME/.docksal/docksal.env) is passed automatically.
+	# These are SECRET_ and some other variables passed by default.
+	echo "SECRET_SSH_PRIVATE_KEY=xyz" >> $HOME/.docksal/docksal.env
+	run fin rc -T 'echo \$SECRET_SSH_PRIVATE_KEY'
+	[[ "$output" == "xyz" ]]
 	unset output
-	
-	# Check to make sure default variables can be overridden 
-	run fin rc -T -e DOCROOT="test" 'echo \$DOCROOT'
-	[[ "$output" == "test" ]]
+
+	# Check to make sure a global default variable can be overridden
+	run fin rc -T -e SECRET_SSH_PRIVATE_KEY="abc" 'echo \$SECRET_SSH_PRIVATE_KEY'
+	[[ "$output" == "abc" ]]
 	unset output
-	
-	# check to make sure the variable in $HOME/.docksal/docksal.env file can be passed if included in command
+
+	# check to make sure a global (non-default) variable can be passed if included in command
 	echo "TEST=1234" >> $HOME/.docksal/docksal.env
 	run fin rc -T -e TEST 'echo \$TEST'
 	[[ "$output" == "1234" ]]
-	unset output
-	
-	# check to make sure variable in $HOME/.docksal/docksal.env file can be overridden
-	run fin rc -T -e TEST="Hello World" 'echo \$TEST'
-	[[ "$output" == "Hello World" ]]
 	unset output
 }
 

--- a/tests/smoke-test-general.bats
+++ b/tests/smoke-test-general.bats
@@ -184,6 +184,33 @@ teardown() {
 	run fin rc -T 'echo $(id -u):$(id -g)'
 	[[ "$output" == "$(id -u):$(id -g)" ]]
 	unset output
+	
+	# check to make sure custom variables are passed into container
+	run fin rc -T -e TEST_VAR="TEST VARIABLES" 'echo \$TEST_VAR'
+	[[ "$output" == "TEST VARIABLES" ]]
+	unset output
+
+	# check to make sure variables are included from $HOME/.docksal/docksal.env
+	echo "DOCROOT=web" >> $HOME/.docksal/docksal.env
+	run fin rc -T 'echo \$DOCROOT'
+	[[ "$output" == "web" ]]
+	unset output
+	
+	# Check to make sure default variables can be overridden 
+	run fin rc -T -e DOCROOT="test" 'echo \$DOCROOT'
+	[[ "$output" == "test" ]]
+	unset output
+	
+	# check to make sure the variable in $HOME/.docksal/docksal.env file can be passed if included in command
+	echo "TEST=1234" >> $HOME/.docksal/docksal.env
+	run fin rc -T -e TEST 'echo \$TEST'
+	[[ "$output" == "1234" ]]
+	unset output
+	
+	# check to make sure variable in $HOME/.docksal/docksal.env file can be overridden
+	run fin rc -T -e TEST="Hello World" 'echo \$TEST'
+	[[ "$output" == "Hello World" ]]
+	unset output
 }
 
 @test "fin rm -f" {

--- a/tests/smoke-test-general.bats
+++ b/tests/smoke-test-general.bats
@@ -186,25 +186,25 @@ teardown() {
 	unset output
 
 	# check to make sure custom variables are passed into container
-	run fin rc -T -e TEST_VAR="TEST VARIABLES" 'echo \$TEST_VAR'
+	run fin rc -T -e TEST_VAR="TEST VARIABLES" "echo \$TEST_VAR"
 	[[ "$output" == "TEST VARIABLES" ]]
 	unset output
 
 	# check to make sure a global default variable (from $HOME/.docksal/docksal.env) is passed automatically.
 	# These are SECRET_ and some other variables passed by default.
 	echo "SECRET_SSH_PRIVATE_KEY=xyz" >> $HOME/.docksal/docksal.env
-	run fin rc -T 'echo \$SECRET_SSH_PRIVATE_KEY'
+	run fin rc -T "echo \$SECRET_SSH_PRIVATE_KEY"
 	[[ "$output" == "xyz" ]]
 	unset output
 
 	# Check to make sure a global default variable can be overridden
-	run fin rc -T -e SECRET_SSH_PRIVATE_KEY="abc" 'echo \$SECRET_SSH_PRIVATE_KEY'
+	run fin rc -T -e SECRET_SSH_PRIVATE_KEY="abc" "echo \$SECRET_SSH_PRIVATE_KEY"
 	[[ "$output" == "abc" ]]
 	unset output
 
 	# check to make sure a global (non-default) variable can be passed if included in command
 	echo "TEST=1234" >> $HOME/.docksal/docksal.env
-	run fin rc -T -e TEST 'echo \$TEST'
+	run fin rc -T -e TEST "echo \$TEST"
 	[[ "$output" == "1234" ]]
 	unset output
 }


### PR DESCRIPTION
Added in ability for run-cli command to accept docker -e variables.

The purpose for this is that by default variables like `SECRET_TERMINUS_TOKEN` are not passed to the container nor are there currently an easy way to pass them to the `run-cli` container. Additionally, if there are custom images that are use it may be necessary to pass on those environmental variables.

Example use case now:

```
SECRET_TERMINUS_TOKEN=xxx;
fin run-cli -T -e SECRET_TERMINUS_TOKEN=$SECRET_TERMINUS_TOKEN 'terminus sites --fields="id,name,framework" --format=csv';
```

This will allow for us to automatically login to terminus (which when the variable is presented automatically does) and then run any necessary commands through the run-cli command.