### PR TITLE
Turn $VIRTUAL_HOST output in terminal into link for "fin up"

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -2409,7 +2409,7 @@ up ()
 
 	_start_containers
 	unison_sync_wait
-	echo-green "Virtual Host: ${yellow}$VIRTUAL_HOST${NC}"
+	echo-green "Virtual Host: ${yellow}http://$VIRTUAL_HOST${NC}"
 }
 
 # Stop containers


### PR DESCRIPTION
Currently after running `fin up` at the end we see the contents of $VIRTUAL_HOST printed to the screen, but this is not a link adding **http://** before the variable output will make this a clickable link on GUI terminals that can then be easily opened.

I added **http://** before the $VIRTUAL_HOST output in terminal for `fin up`. This makes it a link that is clickable. Normally by using **Ctrl-click** or **right-click** to bring up a context sensitive menu.

#### Before
Not a link.

![image](https://user-images.githubusercontent.com/864159/39781525-ab449c18-530f-11e8-9d87-3d409ef2ea10.png)
#### After
Clickable link that is underlined on mouse over and right-click give context sensitive menu with options **Open Link** and **Copy Link Address**.

![image](https://user-images.githubusercontent.com/864159/39781569-c76f0202-530f-11e8-88ea-7ade73cadd86.png)


