### PR TITLE
Extending NGROK to use Variables

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -4450,6 +4450,14 @@ ngrok_share ()
 		--net ${network} \
 		--link ${container_name} \
 		--name ${ngrok_container_name} \
+		-e NGROK_AUTH \
+		-e NGROK_SUBDOMAIN \
+		-e NGROK_HOSTNAME \
+		-e NGROK_USERNAME \
+		-e NGROK_PASSWORD \
+		-e NGROK_PROTOCOL \
+		-e NGROK_PORT \
+		-e NGROK_REGION \
 		wernight/ngrok \
 		ngrok http -host-header "${host:-$NGROK_VIRTUAL_HOST}" ${container_name}.${network}:80
 }

--- a/bin/fin
+++ b/bin/fin
@@ -4449,44 +4449,43 @@ ngrok_share ()
 	# and use -e variables on the docker container
 	# Modifying entrypoint.sh file to gain more variables.
 
-	ARGS="ngrok"
+	local ARGS="ngrok"
 	# Set the protocol.
-	if [ "$NGROK_PROTOCOL" = "TCP" ]; then
+	if [[ "$NGROK_PROTOCOL" = "TCP" ]]; then
 	  ARGS="$ARGS tcp"
 	else
 	  ARGS="$ARGS http"
 	  NGROK_PORT="${NGROK_PORT:-80}"
 	fi
+	
+	NGROK_PORT=$(echo ${NGROK_PORT} | sed 's|^tcp://||')
 
 	# Set the authorization token.
-	if [ -n "$NGROK_AUTH" ]; then
+	if [[ -n "$NGROK_AUTH" ]]; then
 	  ARGS="$ARGS -authtoken=$NGROK_AUTH "
 	fi
 
 	# Set the subdomain or hostname, depending on which is set
 	if [ -n "$NGROK_HOSTNAME" ] && [ -n "$NGROK_AUTH" ]; then
 	  ARGS="$ARGS -hostname=$NGROK_HOSTNAME "
-	elif [ -n "$NGROK_SUBDOMAIN" ] && [ -n "$NGROK_AUTH" ]; then
+	elif [[ -n "$NGROK_SUBDOMAIN" ]] && [[ -n "$NGROK_AUTH" ]]; then
 	  ARGS="$ARGS -subdomain=$NGROK_SUBDOMAIN "
-	elif [ -n "$NGROK_HOSTNAME" ] || [ -n "$NGROK_SUBDOMAIN" ]; then
-	  if [ -z "$NGROK_AUTH" ]; then
-	    echo "You must specify an authentication token after registering at https://ngrok.com to use custom domains."
-	    exit 1
-	  fi
 	fi
 
 	# Set a custom region
-	if [ -n "$NGROK_REGION" ]; then
+	if [[ -n "$NGROK_REGION" ]]; then
 	  ARGS="$ARGS -region=$NGROK_REGION "
 	fi
 
-	if [ -n "$NGROK_HEADER" ]; then
+	if [[ -n "$NGROK_HEADER" ]]; then
 	  ARGS="$ARGS -host-header=$NGROK_HEADER "
 	fi
 
-	if [ -n "$NGROK_USERNAME" ] && [ -n "$NGROK_PASSWORD" ] && [ -n "$NGROK_AUTH" ]; then
+	if [[ -n "$NGROK_USERNAME" ]] && [[ -n "$NGROK_PASSWORD" ]]; then
 	  ARGS="$ARGS -auth=\"$NGROK_USERNAME:$NGROK_PASSWORD\" "
-	elif [ -n "$NGROK_USERNAME" ] || [ -n "$NGROK_PASSWORD" ]; then
+	fi
+	
+	if [[ -n "$NGROK_USERNAME" ]] || [[ -n "$NGROK_PASSWORD" ]] || [[ -n "$NGROK_HOSTNAME" ]] || [[ -n "$NGROK_SUBDOMAIN" ]]; then
 	  if [ -z "$NGROK_AUTH" ]; then
 	    echo-yellow "You must specify a username, password, and Ngrok authentication token to use the custom HTTP authentication."
 	    echo-yellow "Sign up for an authentication token at https://ngrok.com"
@@ -4494,11 +4493,11 @@ ngrok_share ()
 	  fi
 	fi
 
-	if [ ! -n ${NGROK_DEBUG} ]; then
+	if [[ -n "$NGROK_DEBUG" ]]; then
 		ARGS="$ARGS -log stdout"
 	fi
 
-	ARGS="$ARGS `echo ${container_name}.${network}:${NGROK_PORT} | sed 's|^tcp://||'`"
+	ARGS="$ARGS ${container_name}.${network}:${NGROK_PORT}"
 
 	${winpty} docker run --rm -it \
 		--publish 4040 \
@@ -4506,7 +4505,7 @@ ngrok_share ()
 		--link ${container_name} \
 		--name ${ngrok_container_name} \
 		wernight/ngrok \
-		$ARGS
+		"$ARGS"
 }
 
 diagnose ()

--- a/bin/fin
+++ b/bin/fin
@@ -4445,21 +4445,66 @@ ngrok_share ()
 	echo -e "Exposing domain ${yellow}${host:-$NGROK_VIRTUAL_HOST}${NC} via ngrok..."
 	sleep 1
 	# Based on https://github.com/wernight/docker-ngrok
+	# Modifying entrypoint.sh file to gain more variables.
+
+	ARGS="ngrok"
+	# Set the protocol.
+	if [ "$NGROK_PROTOCOL" = "TCP" ]; then
+	  ARGS="$ARGS tcp"
+	else
+	  ARGS="$ARGS http"
+	  NGROK_PORT="${NGROK_PORT:-80}"
+	fi
+
+	# Set the authorization token.
+	if [ -n "$NGROK_AUTH" ]; then
+	  ARGS="$ARGS -authtoken=$NGROK_AUTH "
+	fi
+
+	# Set the subdomain or hostname, depending on which is set
+	if [ -n "$NGROK_HOSTNAME" ] && [ -n "$NGROK_AUTH" ]; then
+	  ARGS="$ARGS -hostname=$NGROK_HOSTNAME "
+	elif [ -n "$NGROK_SUBDOMAIN" ] && [ -n "$NGROK_AUTH" ]; then
+	  ARGS="$ARGS -subdomain=$NGROK_SUBDOMAIN "
+	elif [ -n "$NGROK_HOSTNAME" ] || [ -n "$NGROK_SUBDOMAIN" ]; then
+	  if [ -z "$NGROK_AUTH" ]; then
+	    echo "You must specify an authentication token after registering at https://ngrok.com to use custom domains."
+	    exit 1
+	  fi
+	fi
+
+	# Set a custom region
+	if [ -n "$NGROK_REGION" ]; then
+	  ARGS="$ARGS -region=$NGROK_REGION "
+	fi
+
+	if [ -n "$NGROK_HEADER" ]; then
+	  ARGS="$ARGS -host-header=$NGROK_HEADER "
+	fi
+
+	if [ -n "$NGROK_USERNAME" ] && [ -n "$NGROK_PASSWORD" ] && [ -n "$NGROK_AUTH" ]; then
+	  ARGS="$ARGS -auth=\"$NGROK_USERNAME:$NGROK_PASSWORD\" "
+	elif [ -n "$NGROK_USERNAME" ] || [ -n "$NGROK_PASSWORD" ]; then
+	  if [ -z "$NGROK_AUTH" ]; then
+	    echo-yellow "You must specify a username, password, and Ngrok authentication token to use the custom HTTP authentication."
+	    echo-yellow "Sign up for an authentication token at https://ngrok.com"
+	    exit 1
+	  fi
+	fi
+
+	if [ ! -n ${NGROK_DEBUG} ]; then
+		ARGS="$ARGS -log stdout"
+	fi
+
+	ARGS="$ARGS `echo ${container_name}.${network}:${NGROK_PORT} | sed 's|^tcp://||'`"
+
 	${winpty} docker run --rm -it \
 		--publish 4040 \
 		--net ${network} \
 		--link ${container_name} \
 		--name ${ngrok_container_name} \
-		-e NGROK_AUTH \
-		-e NGROK_SUBDOMAIN \
-		-e NGROK_HOSTNAME \
-		-e NGROK_USERNAME \
-		-e NGROK_PASSWORD \
-		-e NGROK_PROTOCOL \
-		-e NGROK_PORT \
-		-e NGROK_REGION \
 		wernight/ngrok \
-		ngrok http -host-header "${host:-$NGROK_VIRTUAL_HOST}" ${container_name}.${network}:80
+		$ARGS
 }
 
 diagnose ()

--- a/bin/fin
+++ b/bin/fin
@@ -4445,6 +4445,8 @@ ngrok_share ()
 	echo -e "Exposing domain ${yellow}${host:-$NGROK_VIRTUAL_HOST}${NC} via ngrok..."
 	sleep 1
 	# Based on https://github.com/wernight/docker-ngrok
+	# Using pending PR https://github.com/wernight/docker-ngrok/pull/17 can refactor
+	# and use -e variables on the docker container
 	# Modifying entrypoint.sh file to gain more variables.
 
 	ARGS="ngrok"

--- a/docs/tools/ngrok.md
+++ b/docs/tools/ngrok.md
@@ -50,3 +50,18 @@ This can be useful to share a specific site in a Drupal multi-site project.
 ```bash
 fin share --host=example.com
 ``` 
+
+## Additional NGROK Configuration
+
+Additionally, you can specify one of several environment variables to configure your Ngrok tunnel. These can be configured either in `$HOME/.dockal/docksal.env` or at the project level within `.docksal/docksal.env` although due to the nature and sensitivity of these variables they should be configured within `.docksal/docksal-local.env` and not committed to the repository.
+
+Variable | Purpose
+---------|--------
+NGROK_AUTH | Authentication key for your Ngrok account. This is needed for custom subdomains, custom domains, and HTTP authentication.
+NGROK_SUBDOMAIN | Name of the custom subdomain to use for your tunnel. You must also provide the authentication token.
+NGROK_HOSTNAME | Paying Ngrok customers can specify a custom domain. Only one subdomain or domain can be specified, with the domain taking priority.
+NGROK_USERNAME | Username to use for HTTP authentication on the tunnel. You must also specify an authentication token.
+NGROK_PASSWORD | Password to use for HTTP authentication on the tunnel. You must also specify an authentication token.
+NGROK_PROTOCOL | Can either be `HTTP` or `TCP`, and it defaults to `HTTP` if not specified. If set to `TCP`, Ngrok will allocate a port instead of a subdomain and proxy TCP requests directly to your application.
+NGROK_PORT | Port to expose (defaults to `80` for `HTTP` protocol).
+NGROK_REGION | Location of the ngrok tunnel server; can be `us` (United States, default), `eu` (Europe), `ap` (Asia/Pacific) or `au` (Australia)

--- a/docs/tools/ngrok.md
+++ b/docs/tools/ngrok.md
@@ -65,3 +65,4 @@ NGROK_PASSWORD | Password to use for HTTP authentication on the tunnel. You must
 NGROK_PROTOCOL | Can either be `HTTP` or `TCP`, and it defaults to `HTTP` if not specified. If set to `TCP`, Ngrok will allocate a port instead of a subdomain and proxy TCP requests directly to your application.
 NGROK_PORT | Port to expose (defaults to `80` for `HTTP` protocol).
 NGROK_REGION | Location of the ngrok tunnel server; can be `us` (United States, default), `eu` (Europe), `ap` (Asia/Pacific) or `au` (Australia)
+NGROK_DEBUG | To debug the connection and see a more detailed log set this to 1


### PR DESCRIPTION
Extending NGROK so that it utilizes the docker environment variables for authentication.

Environmental variables are outlined on the README within the [repo](https://github.com/wernight/docker-ngrok#environment-variables)

Particularly this is useful if someone has an NGROK account and wants to authenticate using that.
