### PR TITLE
Alpine Linux / PWD support

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -5415,9 +5415,13 @@ fi
 # The startup script in the cli container picks these up and updates the docker user inside of the container
 # On Windows this is not necessary, as Linux permissions and ownership do not matter over SMB
 if ! is_windows; then
-	export HOST_UID=$(id -u)
-	export HOST_GID=$(id -g)
-	if [[ "$HOST_UID" == "0" ]] && [[ "$CI" == "" ]]; then
+	# Only do this for non-root users
+	if [[ "$(id -u)" != "0" ]]; then
+		export HOST_UID=$(id -u)
+		export HOST_GID=$(id -g)
+	else
+		# Note: php-fpm inside cli will fail to start as uid=0
+		# TODO: handle this case better
 		echo-alert "Running as root is not recommended"
 	fi
 fi

--- a/bin/fin
+++ b/bin/fin
@@ -3000,9 +3000,9 @@ install_dns_service ()
 
 # Configure system-wide *.docksal resolver using /etc/resolver
 configure_resolver_mac () {
-	local mode="$1"
+	local mode="${1:-on}"
 
-	if [[ "$mode" != "off" ]]; then
+	if [[ "$mode" == "on" ]]; then
 		# Check whether resolver is already configured
 		if ! (grep "^nameserver $DOCKSAL_IP$" /etc/resolver/$DOCKSAL_DNS_DOMAIN >/dev/null 2>&1); then
 			sudo mkdir -p /etc/resolver
@@ -3012,7 +3012,7 @@ configure_resolver_mac () {
 			echo -e "# .$DOCKSAL_DNS_DOMAIN domain resolution\nnameserver $DOCKSAL_IP" | \
 				sudo tee 1>/dev/null "/etc/resolver/$DOCKSAL_DNS_DOMAIN"
 		fi
-	else
+	elif [[ "$mode" == "off" ]]; then
 		sudo rm -r "/etc/resolver/$DOCKSAL_DNS_DOMAIN" >/dev/null 2>&1
 	fi
 
@@ -3022,13 +3022,12 @@ configure_resolver_mac () {
 	# to check: scutil --dns
 }
 
-# Configure system-wide *.docksal resolver using custom subnet and dns-nameservers instruction
+# Configure system-wide *.docksal resolver via /etc/network/interfaces on Ubuntu
 configure_resolver_ubuntu () {
-	local mode="$1"
+	local mode="${1:-on}"
 	local dns_settings="dns-nameservers ${DOCKSAL_DEFAULT_IP}"
 
-	if [[ "$mode" != "off" ]]; then
-		echo-green "Enabling automatic *.$DOCKSAL_DNS_DOMAIN DNS resolver..."
+	if [[ "$mode" == "on" ]]; then
 		# Make sure we don't do this twice
 		if ! grep -q "${dns_settings}" /etc/network/interfaces; then
 			# TODO: figure out how to insert a tab with sed (instead of using a temporary file)
@@ -3038,8 +3037,7 @@ EOF
 			sudo sed -i '/down .* lo:docksal/r /tmp/docksal.dns' /etc/network/interfaces
 			rm -f /tmp/docksal.dns
 		fi
-	else
-		echo-green "Disabling automatic *.$DOCKSAL_DNS_DOMAIN DNS resolver..."
+	elif [[ "$mode" == "off" ]]; then
 		sudo sed -i "/${dns_settings}/d" /etc/network/interfaces
 	fi
 
@@ -3048,10 +3046,32 @@ EOF
 	sudo ifup lo
 }
 
+# Configure system-wide *.docksal resolver via /etc/resolv.conf on Alpine
+configure_resolver_alpine () {
+	local mode="${1:-on}"
+	local dns_settings="nameserver ${DOCKSAL_DEFAULT_IP}"
+	local conf_file="/etc/resolv.conf"
+
+	# Enabling and settings are not present
+	if [[ "$mode" == "on" ]] && (! grep -q "$dns_settings" ${conf_file}); then
+		# Inline sed (sed -i) does not work with PWD/DnD. It it deletes the destination file first.
+		# /etc/resolv.conf cannot be deleted in a docker container, so it fails.
+		# We have to write into the file directly.
+		#echo -e "${dns_settings}\n$(cat /etc/resolv.conf)" | sudo tee /etc/resolv.conf
+		# Append dns_settings at the beginning
+		local dns_conf_text=$(sed "1i $dns_settings" ${conf_file})
+		echo "$dns_conf_text" | sudo tee ${conf_file} >/dev/null
+	# Disabling and settings are present
+	elif [[ "$mode" == "off" ]] && (grep -q "$dns_settings" ${conf_file}); then
+		local dns_conf_text=$(sed "/${dns_settings}/d" ${conf_file})
+		echo "$dns_conf_text" | sudo tee ${conf_file} >/dev/null
+	fi
+}
+
 # Configure system-wide *.docksal resolver
 # @param $1 mode, set to "off" to disable/revert settings, leave empty to enable
 configure_resolver_windows () {
-	local mode="$1"
+	local mode="${1:-on}"
 
 	local dns_ip="$DOCKSAL_IP"
 	# 10 is used increase the adapter's priority. 75 to - deprioritize it
@@ -3090,7 +3110,7 @@ configure_resolver_windows () {
 # Configure system-wide *.docksal resolver
 # @param $1 mode, set to "off" to disable/revert settings, leave empty to enable
 configure_resolver_wsl () {
-	local mode="$1"
+	local mode="${1:-on}"
 
 	local dns_ip="$DOCKSAL_IP"
 	# 10 is used increase the adapter's priority. 75 to - deprioritize it
@@ -3120,9 +3140,9 @@ configure_resolver ()
 	# Do not configure the resolver if asked so
 	[[ "$DOCKSAL_NO_DNS_RESOLVER" != "" ]] && return
 
-	local mode="$1"
+	local mode="${1:-on}"
 
-	if [[ "$mode" != "off" ]]; then
+	if [[ "$mode" == "on" ]]; then
 		echo-green "Enabling automatic *.$DOCKSAL_DNS_DOMAIN DNS resolver..."
 
 		# The following check requires nslookup. Skip it if the binary is not present.
@@ -3143,12 +3163,13 @@ configure_resolver ()
 				_confirm "Continue?"
 			fi
 		fi
-	else
+	elif [[ "$mode" == "off" ]]; then
 		echo-green "Disabling automatic *.$DOCKSAL_DNS_DOMAIN DNS resolver..."
 	fi
 
 	is_mac && configure_resolver_mac "$mode" && return $?
 	is_ubuntu && configure_resolver_ubuntu "$mode" && return $?
+	is_alpine && configure_resolver_alpine "$mode" && return $?
 	is_windows && configure_resolver_windows "$mode" && return $?
 	is_wsl && configure_resolver_wsl "$mode" && return $?
 }

--- a/bin/fin
+++ b/bin/fin
@@ -2896,13 +2896,16 @@ EOF
 		# Add our settings to the loopback interface
 		sudo sed -i '/iface lo inet loopback/r /tmp/docksal.ip' ${conf_file}
 		rm -f /tmp/docksal.ip
-		# ifupdown the interface to apply settings
-		sudo ifdown --force lo 2>/dev/null
-		sudo ifup lo
 	elif [[ "$mode" == "off" && "$status" == "enabled" ]]; then
-		# Remove our settings from the loopback interface
+		# Reset network settings
+		sudo ip addr del ${DOCKSAL_DEFAULT_SUBNET} dev lo
+		# Remove configuration from the loopback interface
 		sudo sed -i "/lo:docksal/d" ${conf_file}
 	fi
+
+	# Up/down interface to update settings
+	sudo ifdown --force lo 2>/dev/null
+	sudo ifup lo
 }
 
 # Configure Docksal network settings on Alpine via ip addr

--- a/bin/fin
+++ b/bin/fin
@@ -2911,7 +2911,7 @@ configure_network_alpine ()
 	local mode="${1:-on}"
 	# Determine current status
 	local status
-	(echo "$(ip addr show dev lo)"| grep -q "lo:docksal") && status="enabled" || status="disabled"
+	(grep -q "lo:docksal" <<< "$(ip addr show dev lo)") && status="enabled" || status="disabled"
 
 	if [[ "$mode" == "on" && "$status" == "disabled" ]] ; then
 		# Add an IP address alias to the loopback interface
@@ -2932,7 +2932,7 @@ configure_network_mac ()
 	local mode="${1:-on}"
 	# Determine current status
 	local status
-	(echo "$(ifconfig lo0)" | grep -q "$DOCKSAL_NATIVE_IP") && status="enabled" || status="disabled"
+	(grep -q "$DOCKSAL_NATIVE_IP" <<< "$(ifconfig lo0)") && status="enabled" || status="disabled"
 
 	if [[ "$mode" == "on" && "$status" == "disabled" ]] ; then
 		# Add Docksal IP aliases on the local loopback adapter
@@ -5044,7 +5044,7 @@ config_set ()
 
 		if grep -q "^$key\=" "$target_env_file"; then
 			# See https://stackoverflow.com/a/29613573 on why is it escaped so
-			replaceEscaped=$(sed 's/[&/\]/\\&/g' <<<"$value") # escape it
+			replaceEscaped=$(sed 's/[&/\]/\\&/g' <<< "$value") # escape it
 			# Replace the value if it exists
 			sed -i.bak "s/^$key\=.*$/$key=\"$replaceEscaped\"/g" "$target_env_file"
 			# Remove backup

--- a/bin/fin
+++ b/bin/fin
@@ -2926,9 +2926,6 @@ configure_network_alpine ()
 # Configure Docksal network settings on Mac
 configure_network_mac ()
 {
-	# Only applicable for the "native" Docker mode
-	! is_docker_native && return
-
 	local mode="${1:-on}"
 	# Determine current status
 	local status
@@ -2948,9 +2945,6 @@ configure_network_mac ()
 # Configure Docksal network settings on Windows
 configure_network_windows ()
 {
-	# Only applicable for the "native" Docker mode
-	! is_docker_native && return
-
 	local mode="${1:-on}"
 
 	# Docker for Win
@@ -2985,6 +2979,11 @@ configure_network_wsl ()
 configure_network ()
 {
 	local mode="${1:-on}"
+
+	# Set mode to off for Mac and Windows when not running in "native" mode
+	if ! is_docker_native && (is_mac || is_windows); then
+		mode="off"
+	fi
 
 	if [[ "$mode" == "on" ]]; then
 		echo-green "Configuring network settings..."

--- a/bin/fin
+++ b/bin/fin
@@ -2899,8 +2899,6 @@ EOF
 			sudo ifdown --force lo 2>/dev/null
 			sudo ifup lo
 		fi
-		# Wait 5s for network configuration to apply
-		sleep 5
 	fi
 
 	if is_mac; then
@@ -3021,10 +3019,10 @@ configure_resolver_mac () {
 # Configure system-wide *.docksal resolver using custom subnet and dns-nameservers instruction
 configure_resolver_ubuntu () {
 	local mode="$1"
+	local dns_settings="dns-nameservers ${DOCKSAL_DEFAULT_IP}"
 
 	if [[ "$mode" != "off" ]]; then
 		echo-green "Enabling automatic *.$DOCKSAL_DNS_DOMAIN DNS resolver..."
-		local dns_settings="dns-nameservers ${DOCKSAL_DEFAULT_IP}"
 		# Make sure we don't do this twice
 		if ! grep -q "${dns_settings}" /etc/network/interfaces; then
 			# TODO: figure out how to insert a tab with sed (instead of using a temporary file)
@@ -3033,13 +3031,15 @@ configure_resolver_ubuntu () {
 EOF
 			sudo sed -i '/down .* lo:docksal/r /tmp/docksal.dns' /etc/network/interfaces
 			rm -f /tmp/docksal.dns
-			sudo resolvconf -u
 		fi
 	else
 		echo-green "Disabling automatic *.$DOCKSAL_DNS_DOMAIN DNS resolver..."
 		sudo sed -i "/${dns_settings}/d" /etc/network/interfaces
-		sudo resolvconf -u
 	fi
+
+	# Up/down interface to update settings
+	sudo ifdown --force lo 2>/dev/null
+	sudo ifup lo
 }
 
 # Configure system-wide *.docksal resolver

--- a/bin/fin
+++ b/bin/fin
@@ -2886,6 +2886,12 @@ stats_ping ()
 
 configure_network ()
 {
+	if is_alpine; then
+		# This will not persist a reboot or interface change
+		# TODO: make this permanent(?)
+		ip addr add ${DOCKSAL_DEFAULT_SUBNET} dev lo label lo:docksal
+	fi
+
 	if is_ubuntu; then
 		# Adding a subnet for Docksal. Make sure we don't do this twice
 		if ! grep -q "$DOCKSAL_DEFAULT_SUBNET" /etc/network/interfaces; then

--- a/bin/fin
+++ b/bin/fin
@@ -62,6 +62,10 @@ REQUIREMENTS_VBOX='5.2.2'  # Remember to update the download URLs below
 REQUIREMENTS_WINPTY='0.4.3'
 REQUIREMENTS_WINPTY_CYGWIN='2.8.0'
 
+# Override Docker version requirement for Alpine
+# TODO: revise this
+is_alpine && REQUIREMENTS_DOCKER='17.12.0-ce'
+
 URL_VBOX_MAC="http://download.virtualbox.org/virtualbox/5.2.2/VirtualBox-5.2.2-119230-OSX.dmg"
 URL_VBOX_WIN="http://download.virtualbox.org/virtualbox/5.2.2/VirtualBox-5.2.2-119230-Win.exe"
 
@@ -3423,8 +3427,9 @@ install_tools_alpine ()
 	# Install Docker
 	# TODO: automate this
 	if ! is_docker_version || ! is_docker_server_version; then
-		echo-yellow "Automated Docker installation is not supported on this platform." \
-					"Please install Docker ${REQUIREMENTS_DOCKER} manually, then try again."
+		echo-error "Docker version should be ${REQUIREMENTS_DOCKER} or greater." \
+					"Automated Docker installation is not supported on this platform." \
+					"Please install Docker ${REQUIREMENTS_DOCKER} (or greater) manually, then try again."
 		exit 1
 	fi
 

--- a/bin/fin
+++ b/bin/fin
@@ -21,17 +21,17 @@ is_linux ()
 is_ubuntu ()
 {
 	OS_RELEASE="/etc/os-release"
-	[[ -r ${OS_RELEASE} ]] && source ${OS_RELEASE} || return 1
+	[[ -r ${OS_RELEASE} ]] && source ${OS_RELEASE}
 
-	[[ "$ID" == "ubuntu" && $(ver_to_int "$VERSION_ID") >= $(ver_to_int "14.04") ]]
+	[[ "$ID" == "ubuntu" ]] && [[ $(ver_to_int "$VERSION_ID") -eq $(ver_to_int "14.04") ]]
 }
 
 is_alpine ()
 {
 	OS_RELEASE="/etc/os-release"
-	[[ -r ${OS_RELEASE} ]] && source ${OS_RELEASE} || return 1
+	[[ -r ${OS_RELEASE} ]] && source ${OS_RELEASE}
 
-	[[ "$ID" == "alpine" && $(ver_to_int "$VERSION_ID") >= $(ver_to_int "3.7") ]]
+	[[ "$ID" == "alpine" ]] && [[ $(ver_to_int "$VERSION_ID") -eq $(ver_to_int "3.7.0") ]]
 }
 
 is_windows ()
@@ -2926,10 +2926,6 @@ configure_network ()
 		cmd.exe /c netsh interface ip add address name=\"vEthernet \(DockerNAT\)\" address="${DOCKSAL_NATIVE_HOST_IP}" mask="255.255.255.0"
 		# Wait 5s for network configuration to apply
 		sleep 5
-	fi
-
-	if is_ubuntu; then
-
 	fi
 }
 

--- a/bin/fin
+++ b/bin/fin
@@ -2733,12 +2733,11 @@ system_reset ()
 
 	# Configure network has to happen before any communications with the docker daemon happen (before check_docker_running)
 	if [[ "$1" == "" ]] ; then
-		echo-green 'Resetting network settings...'
 		configure_network
 		echo-green 'Resetting Docksal services...'
 		echo ' * proxy'
 		install_proxy_service
-		echo ' * dns and resolver for .docksal domain'
+		echo ' * dns'
 		install_dns_service
 		configure_resolver
 		echo ' * ssh-agent'
@@ -2748,7 +2747,6 @@ system_reset ()
 
 	# Configure network has to happen before any communications with the docker daemon happen (before check_docker_running)
 	if [[ "$1" == "network" ]] ; then
-		echo-green 'Resetting network settings...'
 		configure_network
 		return
 	fi

--- a/bin/fin
+++ b/bin/fin
@@ -13,41 +13,57 @@ yellow_bold='\033[1;33m'
 NC='\033[0m'
 
 #-------------------------------- OS Checks ------------------------------------
+# OS version detection
+if  [[ -f "/etc/os-release" ]]; then
+	(uname -a | grep -v 'Microsoft' >/dev/null) && OS_TYPE="Linux" || OS_TYPE="WSL"
+	read OS_NAME OS_VERSION < <(source "/etc/os-release"; echo "$NAME  $VERSION_ID")
+	export OS_TYPE OS_NAME OS_VERSION
+fi
+
+if (uname | grep 'Darwin' >/dev/null); then
+	export OS_TYPE="Darwin"
+	export OS_NAME="$(sw_vers -productName)"
+	export OS_VERSION="$(sw_vers -productVersion)"
+
+fi
+
+if (uname | grep 'CYGWIN_NT' >/dev/null); then
+	export OS_TYPE="Cygwin"
+	export OS_NAME="Windows"
+	export OS_VERSION="$(echo $(cmd /c ver) | sed 's/.*Version \(.*\)\..*]/\1/')"
+fi
+
 is_linux ()
 {
-	uname -a | grep -v 'Microsoft' | grep 'Linux' >/dev/null
+	[[ "$OS_TYPE" == "Linux" ]]
 }
 
 is_ubuntu ()
 {
-	OS_RELEASE="/etc/os-release"
-	[[ -r ${OS_RELEASE} ]] && source ${OS_RELEASE}
-
-	[[ "$ID" == "ubuntu" ]] && [[ $(ver_to_int "$VERSION_ID") -eq $(ver_to_int "14.04") ]]
+	# TODO: Does the version check belong here?
+	[[ "$OS_NAME" == "Ubuntu" ]] && [[ $(ver_to_int "$OS_VERSION") -eq $(ver_to_int "14.04") ]]
 }
 
 is_alpine ()
 {
-	OS_RELEASE="/etc/os-release"
-	[[ -r ${OS_RELEASE} ]] && source ${OS_RELEASE}
-
-	[[ "$ID" == "alpine" ]] && [[ $(ver_to_int "$VERSION_ID") -eq $(ver_to_int "3.7.0") ]]
+	[[ "$OS_NAME" == "Alpine" ]]
 }
 
 is_windows ()
 {
-	uname | grep 'CYGWIN_NT' >/dev/null
+	[[ "$OS_TYPE" == "Cygwin" ]]
 }
 
 is_wsl ()
 {
-	uname -a | grep 'Microsoft' | grep 'Linux' >/dev/null
+	[[ "$OS_TYPE" == "WSL" ]]
 }
 
 is_mac ()
 {
-	uname | grep 'Darwin' >/dev/null
+	[[ "$OS_TYPE" == "Darwin" ]]
 }
+
 #------------------------------------------------------------------------------
 
 
@@ -683,7 +699,7 @@ check_docker_running ()
 		docker_status=$?
 	fi
 
-	if is_linux; then
+	if is_ubuntu; then
 		# Remind the user about running 'newgrp docker' after install.
 		if ! (id -nG | grep docker >/dev/null 2>&1) && [[ "$(id -u)" != "0" ]] ; then
 			echo-error "Current user is not part of the docker group." \
@@ -2854,9 +2870,9 @@ stats_ping ()
 
 	# We are passing OS version via a custom User-Agent request header, which GA can parse
 	local user_agent
-	is_linux && user_agent="fin/${FIN_VERSION} (Linux $(lsb_release -si)-$(lsb_release -sr))"
-	is_mac && user_agent="fin/${FIN_VERSION} (Macintosh Intel Mac OS X $(sw_vers -productVersion))"
-	is_windows && user_agent="fin/${FIN_VERSION} (Windows NT $(echo $(cmd /c ver) | sed 's/.*Version \(.*\)\..*]/\1/'))"
+	is_linux && user_agent="fin/${FIN_VERSION} (Linux ${OS_NAME}-${OS_VERSION})"
+	is_mac && user_agent="fin/${FIN_VERSION} (Macintosh Intel Mac OS X ${OS_VERSION})"
+	is_windows && user_agent="fin/${FIN_VERSION} (Windows NT ${OS_VERSION})"
 
 	local source='Local'
 	[[ "$CI" != "" ]] && source='CI'
@@ -3418,12 +3434,6 @@ install_tools_alpine ()
 	 	echo "WARNING: Installation is running not in a tty mode"
 	fi
 
-#	if ! is_alpine; then
-#		echo-red "Prerequisites installation is currently supported on Alpine 3.7+"
-#		echo-yellow "You can continue at your own risk, if you know your Linux distribution is compatible with Alpine 3.7+"
-#		_confirm "Are you sure you want to continue?"
-#	fi
-
 	# Install Docker
 	# TODO: automate this
 	if ! is_docker_version || ! is_docker_server_version; then
@@ -3716,8 +3726,8 @@ update ()
 			# If docksal services present, then we are doing an upgrade.
 			is_docksal_running && UPGRADE_IN_PROGRESS=1
 		else
-			# Check out the case when current user on linux does not have access to docker daemon
-			if is_linux && ! is_wsl; then
+			# Check out the case when current user on Ubuntu does not have access to docker daemon
+			if is_ubuntu; then
 				ps -p $(cat /var/run/docker.pid) 2>&1 >/dev/null
 				[ ! $? -eq 0 ] && LINUX_DAEMON_RUNNING="exit 1"
 				# if daemon is running but docker info does not return 0 then this is the case
@@ -3846,7 +3856,7 @@ update ()
 	# [STEP - POST UPDATE]
 	[ $? -eq 0 ] && echo-green "Update finished"
 
-	if is_linux && [[ ${UPGRADE_IN_PROGRESS} != 1 ]]; then
+	if is_ubuntu && [[ ${UPGRADE_IN_PROGRESS} != 1 ]]; then
 		echo -e "${yellow}IMPORTANT NOTE FOR LINUX USERS:${NC}"
 		echo -e "  Current user was added to the 'docker' group."
 		echo -e "  Re-login or run ${yellow}newgrp docker${NC} now to apply that change and use Docksal."
@@ -4574,9 +4584,7 @@ sysinfo ()
 {
 	echo "███  OS"
 	# OS version
-	is_linux && echo $(lsb_release -si) $(lsb_release -sr)
-	is_mac && echo $(sw_vers -productName) $(sw_vers -productVersion)
-	is_windows && echo $(cmd /c ver)
+	echo "${OS_TYPE} ${OS_NAME} ${OS_VERSION}"
 	uname -a
 	# Docker Mode
 	echo -n "Mode: "

--- a/bin/fin
+++ b/bin/fin
@@ -2799,7 +2799,7 @@ system_start ()
 }
 
 # Stops/disables all Docksal things
-# TODO: add projects, network, /etc/exports, etc. here for a complete shutdown of Docksal
+# TODO: add projects, /etc/exports, etc. here for a complete shutdown of Docksal
 system_stop ()
 {
 	if ! is_linux && ! is_docker_native && ! is_wsl; then
@@ -2808,9 +2808,10 @@ system_stop ()
 		vm stop
 	else
 		_stop_containers --all
-		configure_resolver off
 		echo-green "Stopping Docksal system services..."
 		docker ps -q --filter "label=io.docksal.group=system" | xargs docker rm -vf >/dev/null
+		configure_resolver off
+		configure_network off
 	fi
 }
 
@@ -2887,55 +2888,85 @@ stats_ping ()
 # Configure Docksal network settings on Ubuntu via /etc/network/interfaces
 configure_network_ubuntu ()
 {
+	local mode="${1:-on}"
+	local conf_file="/etc/network/interfaces"
+	# Determine current status
+	local status
+	(grep -q "$DOCKSAL_DEFAULT_SUBNET" ${conf_file}) && status="enabled" || status=="disabled"
+
 	# Adding a subnet for Docksal. Make sure we don't do this twice
-	if ! grep -q "$DOCKSAL_DEFAULT_SUBNET" /etc/network/interfaces; then
-		echo-green "Adding a subnet for Docksal..."
+	if [[ "$mode" == "on" && "$status" == "disabled" ]] ; then
 		cat > /tmp/docksal.ip <<EOF
-up   ip addr add ${DOCKSAL_DEFAULT_SUBNET} dev lo label lo:docksal
-down ip addr del ${DOCKSAL_DEFAULT_SUBNET} dev lo label lo:docksal
+	up   ip addr add ${DOCKSAL_DEFAULT_SUBNET} dev lo label lo:docksal
+	down ip addr del ${DOCKSAL_DEFAULT_SUBNET} dev lo
 EOF
-		sudo sed -i '/iface lo inet loopback/r /tmp/docksal.ip' /etc/network/interfaces
+		# Add our settings to the loopback interface
+		sudo sed -i '/iface lo inet loopback/r /tmp/docksal.ip' ${conf_file}
 		rm -f /tmp/docksal.ip
+		# ifupdown the interface to apply settings
 		sudo ifdown --force lo 2>/dev/null
 		sudo ifup lo
+	elif [[ "$mode" == "off" && "$status" == "enabled" ]]; then
+		# Remove our settings from the loopback interface
+		sed "/${DOCKSAL_DEFAULT_SUBNET}/d" ${conf_file}
 	fi
 }
 
 # Configure Docksal network settings on Alpine via ip addr
 configure_network_alpine ()
 {
-	# This will not persist a reboot or interface change
-	# TODO: make this permanent like with Ubuntu (?)
-	ip addr add ${DOCKSAL_DEFAULT_SUBNET} dev lo label lo:docksal
+	local mode="${1:-on}"
+	# Determine current status
+	local status
+	(echo "$(ip addr show dev lo)"| grep -q "$DOCKSAL_DEFAULT_SUBNET") && status="enabled" || status="disabled"
+
+	if [[ "$mode" == "on" && "$status" == "disabled" ]] ; then
+		# Add an IP address alias to the loopback interface
+		# This will not persist a reboot or interface change
+		ip addr add ${DOCKSAL_DEFAULT_SUBNET} dev lo label lo:docksal
+	elif [[ "$mode" == "off" && "$status" == "enabled" ]]; then
+		# Remove the IP address alias
+		ip addr del ${DOCKSAL_DEFAULT_SUBNET} dev lo
+	fi
 }
 
 # Configure Docksal network settings on Mac
 configure_network_mac ()
 {
-	# Docker for Mac
-	if is_docker_native; then
+	# Only applicable for the "native" Docker mode
+	! is_docker_native && return
+
+	local mode="${1:-on}"
+	# Determine current status
+	local status
+	(echo "$(ifconfig lo0)" | grep -q "$DOCKSAL_NATIVE_IP") && status="enabled" || status="disabled"
+
+	if [[ "$mode" == "on" && "$status" == "disabled" ]] ; then
 		# Add Docksal IP aliases on the local loopback adapter
 		sudo ifconfig lo0 alias ${DOCKSAL_NATIVE_IP} 255.255.255.0
 		sudo ifconfig lo0 alias ${DOCKSAL_NATIVE_HOST_IP} 255.255.255.0
-	else
+	elif [[ "$mode" == "off" && "$status" == "enabled" ]]; then
 		# Remove Docksal IP alias from the local loopback adapter
 		sudo ifconfig lo0 -alias ${DOCKSAL_NATIVE_IP} >/dev/null 2>&1
 		sudo ifconfig lo0 -alias ${DOCKSAL_NATIVE_HOST_IP} >/dev/null 2>&1
 	fi
-	# Wait 5s for network configuration to apply
-	sleep 5
 }
 
 # Configure Docksal network settings on Windows
 configure_network_windows ()
 {
+	# Only applicable for the "native" Docker mode
+	! is_docker_native && return
+
+	local mode="${1:-on}"
+
 	# Docker for Win
-	if is_docker_native; then
+	if [[ "$mode" == "on" ]]; then
 		# Add Docksal IP aliases on the DockerNAT adapter
 		local command1="netsh interface ip add address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_NATIVE_IP} mask=255.255.255.0"
 		local command2="netsh interface ip add address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_NATIVE_HOST_IP} mask=255.255.255.0"
 		winsudo "$command1 && $command2"
-	else
+	elif [[ "$mode" == "off" ]]; then
 		# Remove Docksal IP aliases on the DockerNAT adapter
 		local command1="netsh interface ip delete address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_NATIVE_IP}"
 		local command1="netsh interface ip delete address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_NATIVE_HOST_IP}"
@@ -2948,6 +2979,9 @@ configure_network_windows ()
 # Configure Docksal network settings on WSL
 configure_network_wsl ()
 {
+	# TODO: implement on/off modes
+	local mode="${1:-on}"
+
 	cmd.exe /c netsh interface ip add address name=\"vEthernet \(DockerNAT\)\" address="${DOCKSAL_NATIVE_IP}" mask="255.255.255.0"
 	cmd.exe /c netsh interface ip add address name=\"vEthernet \(DockerNAT\)\" address="${DOCKSAL_NATIVE_HOST_IP}" mask="255.255.255.0"
 	# Wait 5s for network configuration to apply
@@ -2957,11 +2991,19 @@ configure_network_wsl ()
 # Configure Docksal network settings
 configure_network ()
 {
-	is_ubuntu && configure_network_ubuntu
-	is_alpine && configure_network_alpine
-	is_mac && configure_network_mac
-	is_windows && configure_network_windows
-	is_wsl && configure_network_wsl
+	local mode="${1:-on}"
+
+	if [[ "$mode" == "on" ]]; then
+		echo-green "Configuring network settings..."
+	else
+		echo-green "Restoring network settings..."
+	fi
+
+	is_ubuntu && configure_network_ubuntu "$mode" && return $?
+	is_alpine && configure_network_alpine "$mode" && return $?
+	is_mac && configure_network_mac "$mode" && return $?
+	is_windows && configure_network_windows "$mode" && return $?
+	is_wsl && configure_network_wsl "$mode" && return $?
 }
 
 # Start system-wide vhost-proxy service

--- a/bin/fin
+++ b/bin/fin
@@ -2885,13 +2885,13 @@ configure_network_ubuntu ()
 	local conf_file="/etc/network/interfaces"
 	# Determine current status
 	local status
-	(grep -q "$DOCKSAL_DEFAULT_SUBNET" ${conf_file}) && status="enabled" || status=="disabled"
+	(grep -q "lo:docksal" ${conf_file}) && status="enabled" || status="disabled"
 
 	# Adding a subnet for Docksal. Make sure we don't do this twice
 	if [[ "$mode" == "on" && "$status" == "disabled" ]] ; then
 		cat > /tmp/docksal.ip <<EOF
 	up   ip addr add ${DOCKSAL_DEFAULT_SUBNET} dev lo label lo:docksal
-	down ip addr del ${DOCKSAL_DEFAULT_SUBNET} dev lo
+	down ip addr del ${DOCKSAL_DEFAULT_SUBNET} dev lo label lo:docksal
 EOF
 		# Add our settings to the loopback interface
 		sudo sed -i '/iface lo inet loopback/r /tmp/docksal.ip' ${conf_file}
@@ -2901,7 +2901,7 @@ EOF
 		sudo ifup lo
 	elif [[ "$mode" == "off" && "$status" == "enabled" ]]; then
 		# Remove our settings from the loopback interface
-		sed "/${DOCKSAL_DEFAULT_SUBNET}/d" ${conf_file}
+		sudo sed -i "/lo:docksal/d" ${conf_file}
 	fi
 }
 
@@ -2911,7 +2911,7 @@ configure_network_alpine ()
 	local mode="${1:-on}"
 	# Determine current status
 	local status
-	(echo "$(ip addr show dev lo)"| grep -q "$DOCKSAL_DEFAULT_SUBNET") && status="enabled" || status="disabled"
+	(echo "$(ip addr show dev lo)"| grep -q "lo:docksal") && status="enabled" || status="disabled"
 
 	if [[ "$mode" == "on" && "$status" == "disabled" ]] ; then
 		# Add an IP address alias to the loopback interface

--- a/bin/fin
+++ b/bin/fin
@@ -18,16 +18,11 @@ if  [[ -f "/etc/os-release" ]]; then
 	(uname -a | grep -v 'Microsoft' >/dev/null) && OS_TYPE="Linux" || OS_TYPE="WSL"
 	read OS_NAME OS_VERSION < <(source "/etc/os-release"; echo "$NAME  $VERSION_ID")
 	export OS_TYPE OS_NAME OS_VERSION
-fi
-
-if (uname | grep 'Darwin' >/dev/null); then
+elif (uname | grep 'Darwin' >/dev/null); then
 	export OS_TYPE="Darwin"
 	export OS_NAME="$(sw_vers -productName)"
 	export OS_VERSION="$(sw_vers -productVersion)"
-
-fi
-
-if (uname | grep 'CYGWIN_NT' >/dev/null); then
+elif (uname | grep 'CYGWIN_NT' >/dev/null); then
 	export OS_TYPE="Cygwin"
 	export OS_NAME="Windows"
 	export OS_VERSION="$(echo $(cmd /c ver) | sed 's/.*Version \(.*\)\..*]/\1/')"
@@ -3473,12 +3468,6 @@ install_tools_ubuntu ()
 	 	echo "WARNING: Installation is running not in a tty mode"
 	fi
 
-	if ! is_ubuntu; then
-		echo-red "Prerequisites installation is currently supported only on Ubuntu"
-		echo-yellow "You can continue at your own risk, if you know your Linux distribution is compatible with Ubuntu"
-		_confirm "Are you sure you want to continue?"
-	fi
-
 	# Install Docker client
 	sudo service docker start 2>/dev/null
 	if ! is_docker_version || ! is_docker_server_version; then
@@ -3654,20 +3643,25 @@ update_virtualbox () {
 
 update_tools ()
 {
+	if is_linux; then
+		is_ubuntu && \
+			install_tools_ubuntu && \
+			return $?
+
+		is_alpine && \
+			install_tools_alpine && \
+			return $?
+
+		# Display a warning for unsupported Linux distros
+		echo-warning "Automatic prerequisites installation not supported on your system"
+	fi
+
 	is_wsl && \
 		install_tools_wsl && \
 		return $?
 
 	is_windows && \
 		install_tools_windows && \
-		return $?
-
-	is_ubuntu && \
-		install_tools_ubuntu && \
-		return $?
-
-	is_alpine && \
-		install_tools_alpine && \
 		return $?
 
 	is_mac && \

--- a/bin/fin
+++ b/bin/fin
@@ -3433,7 +3433,40 @@ install_tools_ubuntu ()
 	#	fi
 }
 
-# Install everything required on Ubuntu 14.04+
+# Install Alpine dependencies
+install_tools_alpine ()
+{
+	if ! is_tty; then
+	 	echo "WARNING: Installation is running not in a tty mode"
+	fi
+
+#	if ! is_alpine; then
+#		echo-red "Prerequisites installation is currently supported on Alpine 3.7+"
+#		echo-yellow "You can continue at your own risk, if you know your Linux distribution is compatible with Alpine 3.7+"
+#		_confirm "Are you sure you want to continue?"
+#	fi
+
+	# Install Docker
+	# TODO: automate this
+	if ! is_docker_version || ! is_docker_server_version; then
+		echo-yellow "Automated Docker installation is not supported on this platform." \
+					"Please install Docker ${REQUIREMENTS_DOCKER} manually, then try again."
+		exit 1
+	fi
+
+	# Install Docker Compose
+	if ! is_docker_compose_version; then
+		echo-green "Installing Docker Compose..."
+		# docker-compose has to be install via pip on Alpine
+		# See https://github.com/docker/compose/issues/3465
+		apk add --no-cache python3 >/dev/null && \
+			pip3 install docker-compose >/dev/null && \
+			docker-compose --version
+		if_failed "Docker Compose installation/upgrade has failed."
+	fi
+}
+
+# Install WSL dependencies
 install_tools_wsl ()
 {
 	# Install Docker client
@@ -3540,6 +3573,10 @@ update_tools ()
 
 	is_ubuntu && \
 		install_tools_ubuntu && \
+		return $?
+
+	is_alpine && \
+		install_tools_alpine && \
 		return $?
 
 	is_mac && \

--- a/bin/fin
+++ b/bin/fin
@@ -40,8 +40,7 @@ is_linux ()
 
 is_ubuntu ()
 {
-	# TODO: Does the version check belong here?
-	[[ "$OS_NAME" == "Ubuntu" ]] && [[ $(ver_to_int "$OS_VERSION") -eq $(ver_to_int "14.04") ]]
+	[[ "$OS_NAME" == "Ubuntu" ]]
 }
 
 is_alpine ()
@@ -3389,8 +3388,8 @@ install_tools_ubuntu ()
 	fi
 
 	if ! is_ubuntu; then
-		echo-red "Prerequisites installation is currently supported only on Ubuntu 14.04+"
-		echo-yellow "You can continue at your own risk, if you know your Linux distribution is compatible with Ubuntu 14.04+"
+		echo-red "Prerequisites installation is currently supported only on Ubuntu"
+		echo-yellow "You can continue at your own risk, if you know your Linux distribution is compatible with Ubuntu"
 		_confirm "Are you sure you want to continue?"
 	fi
 

--- a/bin/fin
+++ b/bin/fin
@@ -3449,7 +3449,7 @@ install_tools_alpine ()
 		# docker-compose has to be install via pip on Alpine
 		# See https://github.com/docker/compose/issues/3465
 		apk add --no-cache python3 >/dev/null && \
-			pip3 install docker-compose >/dev/null && \
+			pip3 install "docker-compose==${REQUIREMENTS_DOCKER_COMPOSE}" >/dev/null && \
 			docker-compose --version
 		if_failed "Docker Compose installation/upgrade has failed."
 	fi

--- a/bin/fin
+++ b/bin/fin
@@ -20,16 +20,18 @@ is_linux ()
 
 is_ubuntu ()
 {
-	if [ -r /etc/lsb-release ]; then
-		lsb_dist="$(. /etc/lsb-release && echo "$DISTRIB_ID")"
-		lsb_release="$(. /etc/lsb-release && echo "$DISTRIB_RELEASE")"
-	fi
+	OS_RELEASE="/etc/os-release"
+	[[ -r ${OS_RELEASE} ]] && source ${OS_RELEASE} || return 1
 
-	if [[ "$lsb_dist" != 'Ubuntu' || $(ver_to_int "$lsb_release") < $(ver_to_int '14.04') ]]; then
-		return 1
-	fi
+	[[ "$ID" == "ubuntu" && $(ver_to_int "$VERSION_ID") >= $(ver_to_int "14.04") ]]
+}
 
-	return 0
+is_alpine ()
+{
+	OS_RELEASE="/etc/os-release"
+	[[ -r ${OS_RELEASE} ]] && source ${OS_RELEASE} || return 1
+
+	[[ "$ID" == "alpine" && $(ver_to_int "$VERSION_ID") >= $(ver_to_int "3.7") ]]
 }
 
 is_windows ()
@@ -2925,6 +2927,10 @@ configure_network ()
 		# Wait 5s for network configuration to apply
 		sleep 5
 	fi
+
+	if is_ubuntu; then
+
+	fi
 }
 
 # Start system-wide vhost-proxy service
@@ -3003,7 +3009,7 @@ configure_resolver_mac () {
 }
 
 # Configure system-wide *.docksal resolver using custom subnet and dns-nameservers instruction
-configure_resolver_linux () {
+configure_resolver_ubuntu () {
 	local mode="$1"
 
 	# TODO: implement the off/disabled mode on Linux
@@ -3126,7 +3132,7 @@ configure_resolver ()
 	fi
 
 	is_mac && configure_resolver_mac "$mode" && return $?
-	is_linux && configure_resolver_linux "$mode" && return $?
+	is_ubuntu && configure_resolver_ubuntu "$mode" && return $?
 	is_windows && configure_resolver_windows "$mode" && return $?
 	is_wsl && configure_resolver_wsl "$mode" && return $?
 }
@@ -3144,7 +3150,7 @@ install_sshagent_service ()
 	ssh_add || true
 }
 
-# Install tools on Mac
+# Install Mac dependencies
 install_tools_mac ()
 {
 	mkdir -p "$CONFIG_DOWNLOADS_DIR" 2>/dev/null
@@ -3232,6 +3238,7 @@ install_tools_mac ()
 	fi
 }
 
+# Install Windows dependencies
 install_tools_windows ()
 {
 	mkdir -p "$CONFIG_DOWNLOADS_DIR" 2>/dev/null
@@ -3363,7 +3370,7 @@ install_tools_windows ()
 	fi
 }
 
-# Install everything required on Ubuntu 14.04+
+# Install Ubuntu dependencies
 install_tools_ubuntu ()
 {
 	if ! is_tty; then
@@ -3531,7 +3538,7 @@ update_tools ()
 		install_tools_windows && \
 		return $?
 
-	is_linux && \
+	is_ubuntu && \
 		install_tools_ubuntu && \
 		return $?
 
@@ -3780,10 +3787,10 @@ update ()
 		# Run cleanup to get rid of outdated images
 		cleanup
 	else
-		# [4.2] On Linux update during install, but use sudo as user will not be in docker group yet.
-		if is_linux; then
+		# [4.2] On Ubuntu update during install, but use sudo as user will not be in docker group yet.
+		if is_ubuntu; then
 			# On Linux a subnet needs to be created first
-			configure_resolver_linux
+			configure_resolver_ubuntu
 			# Override docker to run it via sudo
 			docker () {
 				sudo "$(which docker)" "$@"

--- a/bin/fin
+++ b/bin/fin
@@ -743,59 +743,37 @@ is_vbox_version ()
 is_docker_version ()
 {
 	! which docker >/dev/null 2>&1 && return 1
-
-	local version=$(docker -v | sed "s/.*version \(.*\),.*/\1/")
-
-	[[ $(ver_to_int "$REQUIREMENTS_DOCKER") -gt $(ver_to_int "$version") ]] && \
-		return 1;
-
-	return 0;
+	local version=$(docker version --format '{{.Client.Version}}' 2>/dev/null)
+	[[ $(ver_to_int "$REQUIREMENTS_DOCKER") -le $(ver_to_int "$version") ]]
 }
 
 is_docker_server_version ()
 {
 	! which docker >/dev/null 2>&1 && return 1
-
 	local version=$(docker version --format '{{.Server.Version}}' 2>/dev/null)
-
-	[[ $(ver_to_int "$REQUIREMENTS_DOCKER") -gt $(ver_to_int "$version") ]] && \
-		return 1;
-
-	return 0;
+	[[ $(ver_to_int "$REQUIREMENTS_DOCKER") -le $(ver_to_int "$version") ]]
 }
 
 is_docker_compose_version ()
 {
 	! which docker-compose >/dev/null 2>&1 && return 1
-
 	# Trim any control characters from docker-compose output (necessary on Windows)
 	local version=$(docker-compose version --short | tr -d '[:cntrl:]')
-	[[ $(ver_to_int "$REQUIREMENTS_DOCKER_COMPOSE") > $(ver_to_int "$version") ]] && \
-		return 1;
-
-	return 0;
+	[[ $(ver_to_int "$REQUIREMENTS_DOCKER_COMPOSE") -le $(ver_to_int "$version") ]]
 }
 
 is_docker_machine_version ()
 {
 	! which docker-machine >/dev/null 2>&1 && return 1
-
 	local version=$(docker-machine -v | sed "s/.*version \(.*\),.*/\1/")
-	[[ $(ver_to_int "$REQUIREMENTS_DOCKER_MACHINE") > $(ver_to_int "$version") ]] && \
-		return 1;
-
-	return 0;
+	[[ $(ver_to_int "$REQUIREMENTS_DOCKER_MACHINE") -le $(ver_to_int "$version") ]]
 }
 
 is_winpty_version ()
 {
 	! which "$WINPTY_BIN" >/dev/null 2>&1 && return 2
-
 	local version=$("$WINPTY_BIN" --version | head -1 | sed "s/.*version \(.*\).*/\1/")
-	[[ $(ver_to_int "$REQUIREMENTS_WINPTY") > $(ver_to_int "$version") ]] && \
-		return 1;
-
-	return 0;
+	[[ $(ver_to_int "$REQUIREMENTS_WINPTY") -le $(ver_to_int "$version") ]]
 }
 
 check_vbox_version ()

--- a/bin/fin
+++ b/bin/fin
@@ -2884,67 +2884,84 @@ stats_ping ()
 	return 0
 }
 
+# Configure Docksal network settings on Ubuntu via /etc/network/interfaces
+configure_network_ubuntu ()
+{
+	# Adding a subnet for Docksal. Make sure we don't do this twice
+	if ! grep -q "$DOCKSAL_DEFAULT_SUBNET" /etc/network/interfaces; then
+		echo-green "Adding a subnet for Docksal..."
+		cat > /tmp/docksal.ip <<EOF
+up   ip addr add ${DOCKSAL_DEFAULT_SUBNET} dev lo label lo:docksal
+down ip addr del ${DOCKSAL_DEFAULT_SUBNET} dev lo label lo:docksal
+EOF
+		sudo sed -i '/iface lo inet loopback/r /tmp/docksal.ip' /etc/network/interfaces
+		rm -f /tmp/docksal.ip
+		sudo ifdown --force lo 2>/dev/null
+		sudo ifup lo
+	fi
+}
+
+# Configure Docksal network settings on Alpine via ip addr
+configure_network_alpine ()
+{
+	# This will not persist a reboot or interface change
+	# TODO: make this permanent like with Ubuntu (?)
+	ip addr add ${DOCKSAL_DEFAULT_SUBNET} dev lo label lo:docksal
+}
+
+# Configure Docksal network settings on Mac
+configure_network_mac ()
+{
+	# Docker for Mac
+	if is_docker_native; then
+		# Add Docksal IP aliases on the local loopback adapter
+		sudo ifconfig lo0 alias ${DOCKSAL_NATIVE_IP} 255.255.255.0
+		sudo ifconfig lo0 alias ${DOCKSAL_NATIVE_HOST_IP} 255.255.255.0
+	else
+		# Remove Docksal IP alias from the local loopback adapter
+		sudo ifconfig lo0 -alias ${DOCKSAL_NATIVE_IP} >/dev/null 2>&1
+		sudo ifconfig lo0 -alias ${DOCKSAL_NATIVE_HOST_IP} >/dev/null 2>&1
+	fi
+	# Wait 5s for network configuration to apply
+	sleep 5
+}
+
+# Configure Docksal network settings on Windows
+configure_network_windows ()
+{
+	# Docker for Win
+	if is_docker_native; then
+		# Add Docksal IP aliases on the DockerNAT adapter
+		local command1="netsh interface ip add address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_NATIVE_IP} mask=255.255.255.0"
+		local command2="netsh interface ip add address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_NATIVE_HOST_IP} mask=255.255.255.0"
+		winsudo "$command1 && $command2"
+	else
+		# Remove Docksal IP aliases on the DockerNAT adapter
+		local command1="netsh interface ip delete address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_NATIVE_IP}"
+		local command1="netsh interface ip delete address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_NATIVE_HOST_IP}"
+		winsudo "$command1 && $command2"
+	fi
+	# Wait 5s for network configuration to apply
+	sleep 5
+}
+
+# Configure Docksal network settings on WSL
+configure_network_wsl ()
+{
+	cmd.exe /c netsh interface ip add address name=\"vEthernet \(DockerNAT\)\" address="${DOCKSAL_NATIVE_IP}" mask="255.255.255.0"
+	cmd.exe /c netsh interface ip add address name=\"vEthernet \(DockerNAT\)\" address="${DOCKSAL_NATIVE_HOST_IP}" mask="255.255.255.0"
+	# Wait 5s for network configuration to apply
+	sleep 5
+}
+
+# Configure Docksal network settings
 configure_network ()
 {
-	if is_alpine; then
-		# This will not persist a reboot or interface change
-		# TODO: make this permanent(?)
-		ip addr add ${DOCKSAL_DEFAULT_SUBNET} dev lo label lo:docksal
-	fi
-
-	if is_ubuntu; then
-		# Adding a subnet for Docksal. Make sure we don't do this twice
-		if ! grep -q "$DOCKSAL_DEFAULT_SUBNET" /etc/network/interfaces; then
-			echo-green "Adding a subnet for Docksal..."
-			cat > /tmp/docksal.ip <<EOF
-	up   ip addr add ${DOCKSAL_DEFAULT_SUBNET} dev lo label lo:docksal
-	down ip addr del ${DOCKSAL_DEFAULT_SUBNET} dev lo label lo:docksal
-EOF
-			sudo sed -i '/iface lo inet loopback/r /tmp/docksal.ip' /etc/network/interfaces
-			rm -f /tmp/docksal.ip
-			sudo ifdown --force lo 2>/dev/null
-			sudo ifup lo
-		fi
-	fi
-
-	if is_mac; then
-	 	# Docker for Mac
-	 	if is_docker_native; then
-			# Add Docksal IP aliases on the local loopback adapter
-			sudo ifconfig lo0 alias ${DOCKSAL_NATIVE_IP} 255.255.255.0
-			sudo ifconfig lo0 alias ${DOCKSAL_NATIVE_HOST_IP} 255.255.255.0
-		else
-			# Remove Docksal IP alias from the local loopback adapter
-			sudo ifconfig lo0 -alias ${DOCKSAL_NATIVE_IP} >/dev/null 2>&1
-			sudo ifconfig lo0 -alias ${DOCKSAL_NATIVE_HOST_IP} >/dev/null 2>&1
-		fi
-		# Wait 5s for network configuration to apply
-		sleep 5
-	fi
-
-	if is_windows; then
-		# Docker for Win
-		if is_docker_native; then
-			# Add Docksal IP aliases on the DockerNAT adapter
-			local command1="netsh interface ip add address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_NATIVE_IP} mask=255.255.255.0"
-			local command2="netsh interface ip add address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_NATIVE_HOST_IP} mask=255.255.255.0"
-			winsudo "$command1 && $command2"
-		else
-			# Remove Docksal IP aliases on the DockerNAT adapter
-			local command1="netsh interface ip delete address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_NATIVE_IP}"
-			local command1="netsh interface ip delete address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_NATIVE_HOST_IP}"
-			winsudo "$command1 && $command2"
-		fi
-		# Wait 5s for network configuration to apply
-		sleep 5
-	fi
-
-	if is_wsl; then
-		cmd.exe /c netsh interface ip add address name=\"vEthernet \(DockerNAT\)\" address="${DOCKSAL_NATIVE_IP}" mask="255.255.255.0"
-		cmd.exe /c netsh interface ip add address name=\"vEthernet \(DockerNAT\)\" address="${DOCKSAL_NATIVE_HOST_IP}" mask="255.255.255.0"
-		# Wait 5s for network configuration to apply
-		sleep 5
-	fi
+	is_ubuntu && configure_network_ubuntu
+	is_alpine && configure_network_alpine
+	is_mac && configure_network_mac
+	is_windows && configure_network_windows
+	is_wsl && configure_network_wsl
 }
 
 # Start system-wide vhost-proxy service

--- a/bin/fin
+++ b/bin/fin
@@ -2887,6 +2887,23 @@ stats_ping ()
 
 configure_network ()
 {
+	if is_ubuntu; then
+		# Adding a subnet for Docksal. Make sure we don't do this twice
+		if ! grep -q "$DOCKSAL_DEFAULT_SUBNET" /etc/network/interfaces; then
+			echo-green "Adding a subnet for Docksal..."
+			cat > /tmp/docksal.ip <<EOF
+	up   ip addr add ${DOCKSAL_DEFAULT_SUBNET} dev lo label lo:docksal
+	down ip addr del ${DOCKSAL_DEFAULT_SUBNET} dev lo label lo:docksal
+EOF
+			sudo sed -i '/iface lo inet loopback/r /tmp/docksal.ip' /etc/network/interfaces
+			rm -f /tmp/docksal.ip
+			sudo ifdown --force lo 2>/dev/null
+			sudo ifup lo
+		fi
+		# Wait 5s for network configuration to apply
+		sleep 5
+	fi
+
 	if is_mac; then
 	 	# Docker for Mac
 	 	if is_docker_native; then
@@ -3006,22 +3023,22 @@ configure_resolver_mac () {
 configure_resolver_ubuntu () {
 	local mode="$1"
 
-	# TODO: implement the off/disabled mode on Linux
-	[[ "$mode" == "off" ]] && return
-
-	# TODO: split resolver and network configuration into different functions
-	# Adding a subnet for Docksal. Make sure we don't do this twice
-	if ! grep -q "$DOCKSAL_DEFAULT_SUBNET" /etc/network/interfaces; then
-		echo-green "Adding a subnet for Docksal..."
-		cat > /tmp/docksal.ip.addr <<EOF
-	up   ip addr add ${DOCKSAL_DEFAULT_SUBNET} dev lo label lo:docksal
-	down ip addr del ${DOCKSAL_DEFAULT_SUBNET} dev lo label lo:docksal
+	if [[ "$mode" != "off" ]]; then
+		echo-green "Enabling automatic *.$DOCKSAL_DNS_DOMAIN DNS resolver..."
+		local dns_settings="dns-nameservers ${DOCKSAL_DEFAULT_IP}"
+		# Make sure we don't do this twice
+		if ! grep -q "${dns_settings}" /etc/network/interfaces; then
+			# TODO: figure out how to insert a tab with sed (instead of using a temporary file)
+			cat > /tmp/docksal.dns <<EOF
 	dns-nameservers ${DOCKSAL_DEFAULT_IP}
 EOF
-		sudo sed -i '/iface lo inet loopback/r /tmp/docksal.ip.addr' /etc/network/interfaces
-		rm -f /tmp/docksal.ip.addr
-		sudo ifdown --force lo 2>/dev/null
-		sudo ifup lo
+			sudo sed -i '/down .* lo:docksal/r /tmp/docksal.dns' /etc/network/interfaces
+			rm -f /tmp/docksal.dns
+			sudo resolvconf -u
+		fi
+	else
+		echo-green "Disabling automatic *.$DOCKSAL_DNS_DOMAIN DNS resolver..."
+		sudo sed -i "/${dns_settings}/d" /etc/network/interfaces
 		sudo resolvconf -u
 	fi
 }
@@ -3816,7 +3833,7 @@ update ()
 		# [4.2] On Ubuntu update during install, but use sudo as user will not be in docker group yet.
 		if is_ubuntu; then
 			# On Linux a subnet needs to be created first
-			configure_resolver_ubuntu
+			configure_network
 			# Override docker to run it via sudo
 			docker () {
 				sudo "$(which docker)" "$@"


### PR DESCRIPTION
This adds basic support/compatibility with Alpine Linux / PWD (Play-with-Docker)

- workarounds necessary for Alpine/PWD: older Docker version, root user treatment, `docker-compose` installation via PIP
- network configuration for Alpine
- split network and resolver configuration for Ubuntu
- some other refactoring

## Testing

1. Launch a single node instance on PWD (https://labs.play-with-docker.com/)

2. Install Docksal (currently using a feature branch version), create a non-root user (`docker`)

```
curl -L get.docksal.io | CI=true DOCKSAL_VERSION=feature/alpine bash
addgroup docker
adduser docker -D -G docker -s /bin/bash
```

3. Clone `docksal/drupal8`, set non-root permissions

```
mkdir projects
cd projects
git clone https://github.com/docksal/drupal8.git
chown -R docker:docker drupal8
cd drupal8
```

4. Edit `.docksal/docksal.yml`:

```
version: "2.1"

services:
  web:
    labels:
      - io.docksal.virtual-host=${VIRTUAL_HOST}.*
```

5. Run `fin init`

6. Open drupal8.docksal.<pwd-base-url>

Screencast of the result: http://take.ms/MGFN4