### PR TITLE
ngrok share fix

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -4643,7 +4643,7 @@ ngrok_share ()
 		--link ${container_name} \
 		--name ${ngrok_container_name} \
 		wernight/ngrok \
-		"$ARGS"
+		$ARGS
 }
 
 diagnose ()

--- a/docs/tools/ngrok.md
+++ b/docs/tools/ngrok.md
@@ -66,3 +66,4 @@ NGROK_PROTOCOL | Can either be `HTTP` or `TCP`, and it defaults to `HTTP` if not
 NGROK_PORT | Port to expose (defaults to `80` for `HTTP` protocol).
 NGROK_REGION | Location of the ngrok tunnel server; can be `us` (United States, default), `eu` (Europe), `ap` (Asia/Pacific) or `au` (Australia)
 NGROK_DEBUG | To debug the connection and see a more detailed log set this to 1
+NGROK_HEADER | Set Host Header. Set to the domain that should be past through to the host.

--- a/docs/tools/ngrok.md
+++ b/docs/tools/ngrok.md
@@ -66,4 +66,4 @@ NGROK_PROTOCOL | Can either be `HTTP` or `TCP`, and it defaults to `HTTP` if not
 NGROK_PORT | Port to expose (defaults to `80` for `HTTP` protocol).
 NGROK_REGION | Location of the ngrok tunnel server; can be `us` (United States, default), `eu` (Europe), `ap` (Asia/Pacific) or `au` (Australia)
 NGROK_DEBUG | To debug the connection and see a more detailed log set this to 1
-NGROK_HEADER | Set Host Header. Set to the domain that should be past through to the host.
+NGROK_HEADER | Set Host Header. Set to the domain that should be passed through to the host.


### PR DESCRIPTION
When supplying arguments for Ngrok I am getting the following issue:

```
docker: Error response from daemon: oci runtime error: container_linux.go:265: starting container process caused "exec: \"ngrok http -authtoken=\\\"XXX\\\"  testdrupal_web_1.testdrupal_default:80\": executable file not found in $PATH".
```

This was due to the following being set in my `docksal.env`

```
NGROK_HOSTNAME="testdrupal.docksal"
NGROK_AUTH="XXX"
```