### PR TITLE
fin db create will not fail if database does exist (#548)

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -4424,7 +4424,7 @@ mysql_db_create ()
 
 	# Set db to space since the db does not exist here yet
 	(_mysql --db=" " --db-user="${__dump_user}" --db-password="${__dump_password}" \
-		"CREATE DATABASE \`${__db}\` CHARACTER SET ${__db_charset} COLLATE ${__db_collation};") &&
+		"CREATE DATABASE IF NOT EXISTS \`${__db}\` CHARACTER SET ${__db_charset} COLLATE ${__db_collation};") &&
 		# GRANT ALL has to happen in a separate query, otherwise we will be hitting a race condition (when db is not yet created).
 		(_mysql --db="${__db}" --db-user="${__dump_user}" --db-password="${__dump_password}" \
 		"GRANT ALL PRIVILEGES ON \`${__db}.*\` TO \`${MYSQL_USER}\`; FLUSH PRIVILEGES;")


### PR DESCRIPTION
Added complementary addition to fin db create as was made to fin db drop. Allows a user to simply use fin db create mydb in a script without having to first call fin db drop.