### PR TITLE
Fixed non tty message showing in tty environment

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -2888,7 +2888,7 @@ ssh_add ()
 	# Ensure ssh_path exists
 	mkdir -p "$ssh_path"
 
-	if is_tty; then
+	if ! is_tty; then
 		# In a non-interactive environment (e.g. CI) run non-interactively. Keys with passphrases cannot be used!
 		echo-yellow "Running in a non-interactive environment. SSH keys with passphrases cannot be used."
 	fi


### PR DESCRIPTION
I was receiving the message in fin 1.59.0 "Running in a non-interactive environment. SSH keys with passphrases cannot be used." No other non-tty messages were showing. I found that this function was asking if it was in a tty environment but showing a message to the contrary. Just added the ! to the check.
