### PR TITLE
fixed missing hosts file path on WSL

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -5156,7 +5156,7 @@ config_remove ()
 # Can add or remove a host to/from hosts file
 hosts ()
 {
-	is_windows && HOSTS_FILE="/c/windows/system32/drivers/etc/hosts"
+	is_windows || is_wsl && HOSTS_FILE="/c/windows/system32/drivers/etc/hosts"
 	is_mac && HOSTS_FILE="/etc/hosts"
 	is_linux && HOSTS_FILE="/etc/hosts"
 	case "$1" in


### PR DESCRIPTION
`HOSTS_FILE` path was empty when on WSL in `hosts ()` thus `hosts_add|hosts_remove ()` would fail

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docksal/docksal/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Write a short summary that describes the changes in this pull request:
-->
