### PR TITLE
Release 1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   * Switched `cli` to [docksal/cli:2.2-php-7.1](https://github.com/docksal/service-cli/releases/tag/v2.2.0).
 - Docker 18.03.1
 - Docker Compose 1.21.1
-    * **[BREAKING]** Projects with dashes in names need `fin reset` ([Read more](https://medium.com/docksal/breaking-change-in-docker-compose-1-2-1-6e6fd4640d6f))
+    * **[BREAKING]** Projects with dashes in names need `fin reset` ([Read more](https://blog.docksal.io/breaking-change-in-docker-compose-1-21-1-c00fda7e1b75))
 - VirtualBox 5.2.2
 
 # New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
   - You can now try and play with Docksal online, free of charge, and within minutes!
 - **Experimental**: Cloud9 IDE integration
   - Cloud9 provides an in-browser IDE and terminal for your project and stack.
-  - Run `fin config set IDE_ENABLED=1 && fin project start` in your project folder to enable Cloud9 IDE.
+  - Run `fin config set IDE_ENABLED=1 && fin project reset cli` in your project folder to enable Cloud9 IDE.
   - Open `http://ide.<VIRTUAL_HOST>` 
 - `fin config [get|set|remove]`
   - New commands to manage project level (`.docksal/docksal.env`) and global (`$HOME/docksal/docksal.env`) Docksal variables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * Switched `cli` to [docksal/cli:2.2-php-7.1](https://github.com/docksal/service-cli/releases/tag/v2.2.0).
 - Docker 18.03.1
 - Docker Compose 1.21.1
+    * **[BREAKING]** Projects with dashes in names need `fin reset` ([Read more](https://medium.com/docksal/breaking-change-in-docker-compose-1-2-1-6e6fd4640d6f))
 - VirtualBox 5.2.2
 
 # New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 # Changes and improvements
 
-- Improved `fin share` to allow for custom ngrok configuration.
+- Improved `fin share` to allow for custom ngrok configuration (see [Additional ngrok configuration](https://docs.docksal.io/en/master/tools/ngrok/#additional-ngrok-configuration)).
 - Extended `fin config generate` to allow for `DOCKSAL_STACK` and `DOCROOT` to be set at runtime.
   - See `fin help config` for details.
 - `fin run-cli`:
@@ -43,24 +43,23 @@
   - **[BREAKING]** Persistent `$HOME` directory in the `run-cli` container by default.
   - **[BREAKING]** Image and debug are now options (`--image=...`, `--debug`) 
 - Reworked `fin project create` command screen to separate out different frameworks and languages.
-- Refactored `fin ssh-add` command to allow for non-standard ssh keys to be add automatically.
+- Refactored `fin ssh-add` command to allow for non-standard ssh keys to be add automatically (see [Automatically add keys](https://docs.docksal.io/en/master/advanced/ssh-agent/#automatically-add-keys)).
 - Refactored OS detection.
 - Fixed `fin help` to reference commands within folders.
 - Refactored container remove function.
 - Refactored unison volumes integration.
   - Forked our own `docksal/unison` image.
   - **[BREAKING]** renamed `bg-sync` to `unison` in `fin` and in `stacks/volumes-unison.yml`. 
-- Fixed `fin stop --all` to stop all containers not just single project.
+- Fixed `fin stop --all` to stop all Docksal projects not all existing Docker containers.
 - Fixed Travis CI to run correctly with external pull requests.
 - Improved testing across functionality.
-- Fixed issue with `fin db create` not failing if database did not exist.
+- Fixed issue with `fin db create` failing if database exists and `fin db drop` failing if database did not exist.
 - Fixed missing host file on WSL.
 - Added `blackfire` service configuration to `services.yml` and updated Blackfire documentation.
 - Refactored network configuration on Ubuntu
   - During `fin system stop` network settings introduced by Docksal will now be reverted.
 - Fixed (workaround) a Docker bug with long commands overlapping on single terminal line (`fin exec` and `fin run-cli`).
-- Add a warning when running as root.
-- Updated automated test.
+- Add a warning when running `fin` as root.
 
 # Documentation
 
@@ -71,7 +70,7 @@
 - New: [fin run-cli](https://docs.docksal.io/en/v1.9.0/fin/fin-run-cli) command docs.
 - Updated [Using native Docker applications](https://docs.docksal.io/en/v1.9.0/getting-started/env-setup-native) docs to use the new `fin config set` command.
 - Updated [SSH agent](https://docs.docksal.io/en/v1.9.0/advanced/ssh-agent) with a section on how to automatically local non-default keys.
-- Updated [Custom commands](https://docs.docksal.io/en/v1.9.0/fin/custom-commands) with a section on grouping custom commands.
+- Updated [Custom commands](https://docs.docksal.io/en/v1.9.0/fin/custom-commands/#grouping-commands) with a section on grouping custom commands.
 - Updated [Setup instructions](https://docs.docksal.io/en/v1.9.0/getting-started/setup) with new boilerplate repos.
 - Updated [Blackfire](https://docs.docksal.io/en/v1.9.0/tools/blackfire) integration instructions.
 - Updated [ngrok](https://docs.docksal.io/en/v1.9.0/tools/ngrok) (`fin share`) integration instructions with the new configuration options.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+# 1.9.1 (2018-06-07)
+
+# Changes and improvements
+
+- Fixed an error with setting DB privileges during `fin db create`
+- Disabled network cleanup in `fin cleanup` (triggered during updates) (#582)
+  - Check [this fix](https://github.com/docksal/docksal/issues/582#issuecomment-395537109) if you updated to Docksal 1.9.0 and had your stopped project(s) broken
+
+# Documentation
+
+- Updated 1.9.0 release notes to mention a breaking change in docker-compose 1.21.1
+- Fixed typos here and there
+
+
 # 1.9.0 (2018-06-05)
 
 # New software versions

--- a/bin/fin
+++ b/bin/fin
@@ -5144,7 +5144,7 @@ config_set ()
 			sed -i.bak "s/^$key\=.*$/$key=\"$replaceEscaped\"/g" "$target_env_file"
 			# Remove backup
 			rm -f "${docksal_env_file}.bak" >/dev/null 2>&1
-			echo "Replaced value for $key into $target_env_file"
+			echo "Replaced value for $key in $target_env_file"
 		else
 			# Make sure the is a new line at the end of the config file
 			sed -i~ '$ a\' "$CONFIG_ENV"

--- a/bin/fin
+++ b/bin/fin
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-FIN_VERSION=1.60.0
+FIN_VERSION=1.60.1
 
 if [[ "$TERM" != "dumb" ]]; then
 	# Console colors
@@ -4395,13 +4395,8 @@ _mysql ()
 	local __dump_password="${dbpassword:-$MYSQL_ROOT_PASSWORD}"
 	local __database="${db:-$MYSQL_DATABASE}"
 
-	local _query=""
-	for _arg in "${ARGV[@]}"; do
-		_query="$_query $_arg"
-	done
-
-	if [[ "$_query" != "" ]]; then
-		${winpty} docker exec -it "$container_id" mysql -u${__dump_user} -p${__dump_password} ${__database} -e "${_query}"
+	if [[ "${ARGV[*]}" != "" ]]; then
+		${winpty} docker exec -it "$container_id" mysql -u${__dump_user} -p${__dump_password} ${__database} -e "${ARGV[*]}"
 	else
 		${winpty} docker exec -it "$container_id" mysql -u${__dump_user} -p${__dump_password}
 	fi
@@ -4456,7 +4451,7 @@ mysql_db_create ()
 		"CREATE DATABASE IF NOT EXISTS \`${__db}\` CHARACTER SET ${__db_charset} COLLATE ${__db_collation};") &&
 		# GRANT ALL has to happen in a separate query, otherwise we will be hitting a race condition (when db is not yet created).
 		(_mysql --db="${__db}" --db-user="${__dump_user}" --db-password="${__dump_password}" \
-		"GRANT ALL PRIVILEGES ON \`${__db}.*\` TO \`${MYSQL_USER}\`; FLUSH PRIVILEGES;")
+		"GRANT ALL PRIVILEGES ON \`${__db}\`.* TO \`${MYSQL_USER}\`;")
 
 	if_failed_error "Database '${__db}' creation failed"
 

--- a/bin/fin
+++ b/bin/fin
@@ -1377,9 +1377,9 @@ show_help_project() {
 	echo
 	printh "status" "List project services (alias: fin ps)"
 	printh "restart" "Restart project services (alias: fin restart)"
-	printh "reset [service]" "Recreate all or specified project services and containers without deleting named volumes"
+	printh "reset [service]" "Recreate all or specified project services, their containers and named volumes"
 	printh "" "Changes to home directory in \`cli\` are preserved."
-	printh "remove [option] [service]" "Remove all project services, networks and their volumes, or specified services only"
+	printh "remove [option] [service]" "Remove all project services, networks and all their volumes, or specified services only"
 	printh "    rm [option] [service]" ""
 	printh "  --force (-f)" "Do not ask for confirmation when deleting all project services"
 	echo

--- a/bin/fin
+++ b/bin/fin
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-FIN_VERSION=1.60.1
+FIN_VERSION=1.60.2
 
 if [[ "$TERM" != "dumb" ]]; then
 	# Console colors
@@ -1015,9 +1015,10 @@ cleanup ()
 	docker image prune -f 2>/dev/null
 	echo-green "Removing dangling volumes..."
 	docker volume prune -f 2>/dev/null
-	echo-green "Removing dangling networks..."
-	install_proxy_service  # Reset project to disconnect it from abandoned networks
-	docker network prune -f 2>/dev/null
+	# TODO: this is temporary disabled as it causes issues. See https://github.com/docksal/docksal/issues/582
+#	echo-green "Removing dangling networks..."
+#	install_proxy_service  # Reset vhost-proxy to disconnect it from abandoned networks
+#	docker network prune -f 2>/dev/null
 }
 
 # Connect vhost-proxy to all bridge networks on the host

--- a/docs/fin/fin-run-cli.md
+++ b/docs/fin/fin-run-cli.md
@@ -11,7 +11,7 @@ This also eliminates the need of having any of the console tools installed local
 
 ### Run a script in a disposable environment
 
-You can run any scrips (PHP, Python, Ruby, Nodejs, Bash, etc.) in a safe, disposable environment:
+You can run any scripts (PHP, Python, Ruby, Nodejs, Bash, etc.) in a safe, disposable environment:
 
 ```bash
 fin run-cli <script-file-name>
@@ -42,7 +42,7 @@ fin project start
 
 Generally, anything you do inside of a `fun run-cli` environment is gone once the container is stopped.
 You can install new packages, run scripts, break things, etc., without the risk of damaging your host system.
-The next time you do `fin run-cli`, the `run-cli` environment is started fresh and clean
+The next time you do `fin run-cli`, the `run-cli` environment is started fresh and clean.
 
 The only exceptions are:
 
@@ -59,7 +59,7 @@ fin run-cli --clean
 
 Note: this does not drop the shared `$HOME` volume used for regular `fun run-cli` executions.
 
-You can wipe the shared `$HOME` volume with
+You can wipe the shared `$HOME` volume with:
 
 ```bash
 fin run-cli --cleanup

--- a/docs/getting-started/env-setup-native.md
+++ b/docs/getting-started/env-setup-native.md
@@ -38,7 +38,7 @@ Follow instructions in this section if you've been previously using Docksal with
 
 ```bash
 fin vm stop
-fin config set --global DOCKSAL_NATIVE=1
+fin config set --global DOCKER_NATIVE=1
 fin system reset
 ```
 
@@ -75,7 +75,7 @@ support and cannot run 64bit VMs because of that.
 **2.** Disable the "native" apps mode, reset networks settings, start Docksal VM and reset Docksal system services
 
 ```bash
-fin config set --global DOCKSAL_NATIVE=0
+fin config set --global DOCKER_NATIVE=0
 fin system reset network
 fin vm start
 fin system reset

--- a/docs/tools/drush.md
+++ b/docs/tools/drush.md
@@ -13,7 +13,7 @@ run `composer require drush/drush` to add it.
 [Drush Launcher](https://github.com/drush-ops/drush-launcher) is also installed globally in the `cli` container. 
 It will automatically pickup project level drush version and pass execution to it.
 
-For legacy setups and older Drupal versions `cli` also ships with a globally installed Drush 8. 
+For legacy setups and older Drupal versions, `cli` also ships with a globally installed Drush 8. 
 The launcher is configured to use it as a fallback when no project level drush is available.
 
 ## Usage 

--- a/docs/tools/phpcs.md
+++ b/docs/tools/phpcs.md
@@ -6,7 +6,7 @@
 
 It's recommended to see how to [extend fin with custom commands](../fin/custom-commands.md) first.
 
-From your project's root folder (where the `.docksal` folder is) download the sample `phpcs` command
+From your project's root folder (where the `.docksal` folder is) download the sample `phpcs` command:
 
 ```bash
 mkdir -p .docksal/commands

--- a/docs/tools/redis.md
+++ b/docs/tools/redis.md
@@ -70,4 +70,4 @@ The following is listed on the [wodby/redis](https://github.com/wodby/redis) ima
 ## Extending the Stock Image
 
 Redis can also be configured by extending the stock image within a Dockerfile. For more
-information consult the [Extending stock Docksal Images](../advanced/extend-images.md)
+information consult the [Extending stock Docksal Images](../advanced/extend-images.md) documentation.

--- a/docs/tools/sass.md
+++ b/docs/tools/sass.md
@@ -24,7 +24,7 @@ fin exec bundle install
 ```
 
 There are two folder (`.bundle`, `.bundler`) and a file (`Gemfile.lock`) will be created.
-Please add this directories (`.bundle`/`.bundler`) to `.gitignore`
+Please add these directories (`.bundle`/`.bundler`) to your `.gitignore` file.
 
 ## Compile SASS
 


### PR DESCRIPTION
# Changes and improvements

- Fixed an error with setting DB privileges during `fin db create`
- Disabled network cleanup in `fin cleanup` (triggered during updates) (#582)
  - Check [this fix](https://github.com/docksal/docksal/issues/582#issuecomment-395537109) if you updated to Docksal 1.9.0 and had your stopped project(s) broken

# Documentation

- Updated 1.9.0 release notes to mention a breaking change in docker-compose 1.21.1
- Fixed typos here and there
