### PR TITLE
added env option for fin config set/remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Docs](https://readthedocs.org/projects/docksal/badge?version=master&style=flat-square)](http://docksal.readthedocs.io/en/master)
 [![Gitter](https://img.shields.io/gitter/room/docksal/community-support.svg?style=flat-square)](https://gitter.im/docksal/community-support)
 
-Docker powered environments for web development on macOS, Windows and Linux.
+Docker powered environments for web development on macOS, Windows, and Linux.
 
 Running a complete LAMP stack for your project can be two steps away!<sup>*</sup>
 
@@ -19,7 +19,7 @@ fin init
 
 "I love my Vagrant box. Why would I want to switch to a Docker based solution?"  
 Containers are just [better than VMs](https://github.com/docker/docker#better-than-vms): 
-smaller, faster, portable and more efficient across the board.
+smaller, faster, portable, and more efficient across the board.
 
 <a name="setup"></a>
 <a name="updates"></a>

--- a/bin/fin
+++ b/bin/fin
@@ -1686,13 +1686,16 @@ show_help_config ()
 	printh "    --docroot=mydir" "Set non-default DOCROOT during config generate"
 	printh "set [options] [VAR=VAL]" "Set value(s) for the variable(s) in project ENV file"
 	printh "    --global" "Set for global ENV file"
+	printh "    --env=[name]" "Set in environment specific project ENV file (default: local)"
 	echo
 	printh "remove [options] [VAR]" "Remove variable(s) from project ENV file"
 	printh "rm [options] [VAR]" ""
 	printh "    --global" "Remove from global ENV file"
+	printh "    --env=[name]" "Remove from environment specific project ENV file (default: local)"
 	echo
 	printh "get [options] [VAR]" "Get the value of the single variable from project ENV file"
 	printh "    --global" "Get value from global ENV file"
+	printh "    --env=[name]" "Get value from environment specific project ENV file (default: local)"
 
 	echo
 	echo "Examples:"
@@ -5146,10 +5149,13 @@ config_get ()
 		target_env_file="$CONFIG_ENV"
 	else
 		load_configuration
+		if [[ -n $env ]]; then
+			local docksal_env_file="$(get_project_path_dc)/.docksal/docksal-${env}.env"
+		fi
 		target_env_file="$docksal_env_file"
 	fi
 
-	grep "^$1\=" "$target_env_file" | sed "s/^$1=\(.*\)$/\1/"
+	grep "^${ARGV[0]}\=" "$target_env_file" | sed "s/^${ARGV[0]}=\(.*\)$/\1/"
 }
 
 config_set ()
@@ -5162,7 +5168,15 @@ config_set ()
 		target_env_file="$CONFIG_ENV"
 	else
 		load_configuration
+		if [[ -n $env ]]; then
+			local docksal_env_file="$(get_project_path_dc)/.docksal/docksal-${env}.env"
+		fi
 		target_env_file="$docksal_env_file"
+
+		if [[ ! -f $dockal_env_file ]]; then
+			touch "$docksal_env_file"
+			if_failed_error "Could not create $docksal_env_file"
+		fi
 	fi
 
 	# Warn if no values were found
@@ -5175,6 +5189,11 @@ config_set ()
 	for param in "${ARGN[@]}"
 	do
 		shift
+
+		if [[ "${param}" =~ ^- ]]; then
+			continue;
+		fi
+
 		# Parse variable to set
 		IFS='=' read -r key value <<< "${param}"
 
@@ -5206,23 +5225,34 @@ config_remove ()
 		target_env_file="$CONFIG_ENV"
 	else
 		load_configuration
+		if [[ -n $env ]]; then
+			local docksal_env_file="$(get_project_path_dc)/.docksal/docksal-${env}.env"
+		fi
 		target_env_file="$docksal_env_file"
 	fi
 
-	while [ $# -gt 0 ]
+	# Warn if no values were found
+	if [[ "${#ARGV[@]}" == 0 ]]; then
+		echo "No values to remove"
+		return 1
+	fi
+
+	# Loop named params array
+	for param in "${ARGV[@]}"
 	do
-		if [[ "$1" == "--global" ]]; then
+		if [[ "${param}" =~ ^- ]]; then
 			shift
-			continue
+			continue;
 		fi
-		if grep -q "$1" "${target_env_file}"; then
+
+		if grep -q "^${param}\=" "${target_env_file}"; then
 			# Remove the value if it exists
-			echo "Removing $1 from $target_env_file"
-			sed -i.bak "/^$1\=.*$/d" "$target_env_file"
+			echo "Removing ${param} from $target_env_file"
+			sed -i.bak "/^${param}\=.*$/d" "$target_env_file"
 			# Remove backup
 			rm -f "${docksal_env_file}.bak" >/dev/null 2>&1
 		else
-			echo "Could not find $1 in ${target_env_file}"
+			echo "Could not find ${param} in ${target_env_file}"
 		fi
 		shift
 	done

--- a/bin/fin
+++ b/bin/fin
@@ -5240,11 +5240,6 @@ config_remove ()
 	# Loop named params array
 	for param in "${ARGV[@]}"
 	do
-		if [[ "${param}" =~ ^- ]]; then
-			shift
-			continue;
-		fi
-
 		if grep -q "^${param}\=" "${target_env_file}"; then
 			# Remove the value if it exists
 			echo "Removing ${param} from $target_env_file"

--- a/docs/getting-started/project-setup.md
+++ b/docs/getting-started/project-setup.md
@@ -24,7 +24,7 @@ The `.docksal` directory is where all Docksal configurations and commands for th
     Git does not commit empty directories. To commit the `.docksal` directory into your Git repo create an empty `.gitkeep` file inside it ( or some other file of your choosing.)
 
 !!! tip "Document Root"
-    Is your Project Root the same as your Document Root? If so then you can accomplish this by setting the `DOCROOT=.` within the `.docksal/docksal.env`.
+    Is your Project Root the same as your Document Root? If so, you can accomplish this by setting the `DOCROOT=.` within the `.docksal/docksal.env` file.
 
 ## Start containers
 

--- a/docs/getting-started/project-setup.md
+++ b/docs/getting-started/project-setup.md
@@ -23,6 +23,9 @@ The `.docksal` directory is where all Docksal configurations and commands for th
 !!! note "Version control" 
     Git does not commit empty directories. To commit the `.docksal` directory into your Git repo create an empty `.gitkeep` file inside it ( or some other file of your choosing.)
 
+!!! tip "Document Root"
+    Is your Project Root the same as your Document Root? If so then you can accomplish this by setting the `DOCROOT=.` within the `.docksal/docksal.env`.
+
 ## Start containers
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ along with VirtualBox to support macOS and Windows. Its main feature is the incl
 simplifies the management of all components.
 
 Docksal comes preloaded with common development tools, e.g., Composer, PHP Code Sniffer, php-cli, node, npm, ruby, bundler, and python.
-For Drupal and WordPress development it comes with drush, Drupal Console, and WP-CLI. 
+For Drupal and WordPress development, it comes with drush, Drupal Console, and WP-CLI. 
 
 There is built-in support for Apache Solr, Varnish, Memcache, Selenium, and Behat. And since services are containerized with Docker, 
 any other service needed for a project can be added.
@@ -17,17 +17,17 @@ any other service needed for a project can be added.
 Docksal does more than simply manage containers. Below is a list of some of Docksal's key features. While it is not
 limited to these features, we think you'll find these to be some of its main selling points.
 
-- Fully [containerized environments](advanced/stack.md).
+- Fully [containerized environments](advanced/stack.md)
     - all projects stay separated from each other
     - each can have its own requirements
     - each can have different versions of the same service
     - each can be managed independently (start, stop, restart, trash, etc.)
     - each can be extended with any service you want
 - [Zero-configuration](advanced/stack-config.md#zero-configuration) projects - with two commands you can be up and running with an AMP stack without
-having to create or understand any configurations.
-- Easy to create [configurations](advanced/stack-config.md) to partially or fully override any defaults.
-- Tools such as drush, console, and WP-CLI are builtin so you don't need to have them installed locally.
+having to create or understand any configurations
+- Easy to create [configurations](advanced/stack-config.md) to partially or fully override any defaults
+- Tools such as drush, console, and WP-CLI are built-in so you don't need to have them installed locally
 - Automatic virtual host configuration
-- Support for [custom commands](fin/custom-commands.md) using any interpreter you want.
+- Support for [custom commands](fin/custom-commands.md) using any interpreter you want
 - Easily [share your site](tools/ngrok.md) over the internet using ngrok. This lets show your project to others without having to 
-move your project to a web host somewhere.
+move your project to a web host somewhere

--- a/docs/tools/xdebug.md
+++ b/docs/tools/xdebug.md
@@ -6,7 +6,7 @@ Xdebug can be used to debug both web requests as well as cli scripts (e.g., Drus
 
 `xdebug` extension is disabled by default since it causes about a 20% performance hit. To enable it:
 
-1) Set `XDEBUG_ENABLED=1` in `.docksal/docksal.env` or `.docksal/docksal-local.env` in your project
+1) Set `XDEBUG_ENABLED=1` in `.docksal/docksal.env` or `.docksal/docksal-local.env` in your project  
 2) Apply container configuration with `fin project start` (`fin p start`)
 
 To verify that Xdebug was enabled run:

--- a/docs/troubleshooting-smb.md
+++ b/docs/troubleshooting-smb.md
@@ -1,4 +1,4 @@
-# Troubleshooting SMB shares creation, mounting and related issues on Windows
+# Troubleshooting SMB shares creation, mounting, and related issues on Windows
 
 ## Windows 10 Fall Creators Update 1709
 
@@ -15,7 +15,7 @@ exit status 255
 ```
 
 You will have to manually enable `SMB 1.0/CIFS Server` package in Windows Feature and reboot the host.  
-See [this](https://github.com/docksal/docksal/issues/382) issue for details.
+See [this issue](https://github.com/docksal/docksal/issues/382) for details.
 
 ## How SMB related errors look
 
@@ -97,7 +97,7 @@ try opening that IP again.
 
 If after enabling files sharing you still can not access your IP via explorer,
 then see this [elaborate post on superuser about issues with File/Printer sharing on Windows](https://superuser.com/a/446500/140872).
-Hopefully it helps. Do not proceed to next steps, if you have not fixed the issue
+Hopefully it helps. Do not proceed to next steps if you have not fixed the issue
 because they will fail too.
 
 Friendly reminder: if everything fails to make it working, then you might be limited to
@@ -113,15 +113,15 @@ issues with accessing your local IP via explorer. (If error with vm
 start is not related to mounting or shares, then see regular [troubleshooting guide](troubleshooting.md).)
 
 In this step you need to check access to Docksal IP. Open explorer and navigate to `\\192.168.64.1\`.
-This is the IP that VirtualBox adapter assigns to your host machine. Just like in previous step it
+This is the IP that VirtualBox adapter assigns to your host machine. Just like in the previous step, it
 should open with no errors and now you should see your network shares.
 
 ![Getting your IP](_img/troubleshooting-smb-your-shares2.png)
 
 If you get errors when trying to open it, then there is an issue with VirtualBox network adapter. The
 most common reason is Windows Firewall blocking it. Try disabling your Firewall and check if it
-helps. It disabling firewall helped, then you either need to keep it this way or create an
-Incoming rule for your firewall to allow all traffic to all ports from IP `192.168.64.100`.
+helps. If disabling firewall helped, then you either need to keep it this way or create an
+incoming rule for your firewall to allow all traffic to all ports from IP `192.168.64.100`.
 
 If you disabled Windows Firewall, but you still can not access this IP address, then it is not
 firewall to blame. You would need to refer to the same
@@ -130,7 +130,7 @@ firewall to blame. You would need to refer to the same
 In worst case try removing Docksal VM with `fin vm remove`, uninstall VirtualBox, **reboot**, install
 VirtualBox and start vm again.
 
-If any option fails you might be limited to re-installing Windows. We had cases when
+If all options fail, you might be limited to re-installing Windows. We had cases when
 people had mysterious issues related to shares mounting. They re-installed Windows and everything
 worked like a charm.
 
@@ -139,9 +139,9 @@ worked like a charm.
 If both IPs are working, then it's not the network access issue.
 
 Open explorer and navigate to `\\192.168.64.1\`. Make sure that you see and can
-access shares, that Docksal should have created for your local drives. `docksal-c`, `docksal-d` etc.
+access shares that Docksal should have created for your local drives. `docksal-c`, `docksal-d` etc.
 
-If you see the shares, but can not access them then most likely you hit some edge case. Easiest
+If you see the shares but can not access them, then most likely you hit some edge case. Easiest
 fix is to stop Docksal VM, remove those shares manually using Windows UI and start VM back again.
 
 If you don't see those shares altogether, then there is an issue with shares creation.
@@ -152,7 +152,7 @@ Possible common reasons:
 * Microsoft account should use Microsoft account password, not the one that is used to unlock PC
 * group policies prevent share creation
 
-Check you password. Check that you can create shares, but do not create Docksal shares manually
+Check your password. Check that you can create shares, but do not create Docksal shares manually
 unless you know which permissions to set.
 
 Try running `fin vm restart`. If the issue with share creation does not go away and you think
@@ -165,7 +165,7 @@ For Microsoft Account use Microsoft Account password not the one you use to unlo
 **Your password can NOT contain:** `,` (comma), `\` (back slash) or `'` (single quote) symbol
 because the password is being passed to the console mount command.
 
-Other special symbols are not an issue but in case your password contains some other special
+Other special symbols are not an issue, but in case your password contains some other special
 symbols and you see errors that contain `Invalid argument`:
 
 ```
@@ -179,7 +179,7 @@ mount: mounting //192.168.64.1/docksal-c on /c failed: Invalid argument
 exit status 255
 ```
 
-In this case try simplifying your password and if it works with a new password,
+In this case, try simplifying your password. If it works with a new password,
 then create an issue on GitHub (see step 6), so we could investigate and fix.
 
 ### 6. Report an issue
@@ -187,7 +187,7 @@ then create an issue on GitHub (see step 6), so we could investigate and fix.
 If you checked all the steps above and it didn't help, then report an
 [issue on GitHub](https://github.com/docksal/docksal/issues) and we will investigate the edge case.
 
-If you have questions on resolving issues with steps above try searching the issue queue or
-if you stuck, then you can also create an issue on GitHUb to ask a question. Describe which step
-you stumbled upon, what fails, what is the error, what did you try to resolve it, provide output
-you are getting and `fin sysinfo` output.
+If you have questions on resolving issues with steps above, try searching the issue queue or
+if you are stuck, you can also create an issue on GitHUb to ask a question. Describe which step
+you stumbled on, what fails, what is the error, what did you try to resolve it, and provide the output
+you are getting and the `fin sysinfo` output.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,12 +20,12 @@ Error creating machine: Error in driver during machine creation: read tcp 127.0.
 Remove docksal? [y/n]:
 ```
 
-If you see this error then most likely you had just installed Virtual Box.
-Sometimes Virtual Box fails to initialize it's network interfaces properly.
+If you see this error, most likely you had just installed Virtual Box.
+Sometimes Virtual Box fails to initialize its network interfaces properly.
 
 ### How to resolve
 
-1. Reply yes to remove malfunctioned virtual machine.
+1. Reply `yes` to remove malfunctioned virtual machine.
 2. Reboot your local host and try again.
 
 
@@ -42,8 +42,8 @@ Sometimes docker-machine certificates re-generation fails.
 
 ### How to resolve
 
-1. Perform `fin vm restart`.
-2. If above did not help, then reboot your local host.
+1. Perform `fin vm restart`
+2. If above did not help, then reboot your local host
 3. If above did not help, perform commands below and then reboot your host:
 
 ```bash
@@ -123,7 +123,7 @@ This prevents Docksal from running properly.
 
 1. Stop Apache or
 2. Reconfigure Apache to listen on different ports (e.g., `8080` and `4433`) or
-different/specific IPs (e.g., `127.0.0.1:80` and `127.0.0.1:443`).
+different/specific IPs (e.g., `127.0.0.1:80` and `127.0.0.1:443`)
 
 
 <a name="issue-06"></a>
@@ -206,7 +206,7 @@ Check `docksal.yml` and `.htaccess` files for configuration errors, fix them and
 <a name="issue-10"></a>
 ## Issue 10. SMB share creation, share mounting and related issues on Windows
 
-Please see a separate [troubleshooting document on share creation, share mounting and related issues](troubleshooting-smb.md).
+Please see a separate [troubleshooting document on share creation, share mounting, and related issues](troubleshooting-smb.md).
 
 
 <a name="issue-11"></a>
@@ -219,7 +219,7 @@ ERROR 2003 (HY000): Can't connect to MySQL server on 'db' (111)
 There may be many different errors. Check Mysql logs with `fin logs db` for details.
 Here we will just look at the most common case.
 
-If you see error like:
+If you see an error like:
 
 ```
 db_1   | 170614 14:26:54 [Note] Plugin 'FEDERATED' is disabled.
@@ -260,7 +260,7 @@ around third-party kernel extensions.
 In certain cases you may have to reboot your Mac and then reinstall VirtualBox manually.
 
 [This video](https://www.youtube.com/watch?v=0vmQOYRCdZM) covers the manual steps necessary to install VirtualBox 
-successfully. More details [here](https://github.com/docksal/docksal/issues/417).
+successfully. [See detailed issue resolution](https://github.com/docksal/docksal/issues/417).
 
 ## Issue 13. Docker unauthorized
 

--- a/tests/smoke-test-config.bats
+++ b/tests/smoke-test-config.bats
@@ -217,12 +217,12 @@ services:
 
 	cp "${HOME}/.docksal/docksal.env" "${HOME}/.docksal/docksal.env.bak"
 	# Test command can run with --global
-	run fin config set --global TEST=12345
+	run fin config set --global TEST_VAR=12345
 	[[ $status == 0 ]] &&
-	[[ $output =~ "Added value for TEST into ${HOME}/.docksal/docksal.env" ]]
+	[[ $output =~ "Added value for TEST_VAR into ${HOME}/.docksal/docksal.env" ]]
 	source "${HOME}/.docksal/docksal.env"
 	# Testing what value is
-	[[ "$TEST" == "12345" ]]
+	[[ "$TEST_VAR" == "12345" ]]
 	unset output
 
 	mv "${HOME}/.docksal/docksal.env.bak" "${HOME}/.docksal/docksal.env"
@@ -232,12 +232,12 @@ services:
 	[[ $SKIP == 1 ]] && skip
 
 	cp "${HOME}/.docksal/docksal.env" "${HOME}/.docksal/docksal.env.bak"
-	echo "TEST=1" >> "${HOME}/.docksal/docksal.env"
-	run fin config set --global TEST=54321
-	[[ $status == 0 ]] && [[ "$output" =~ "Replaced value for TEST in ${HOME}/.docksal/docksal.env" ]]
+	echo "TEST_VAR=1" >> "${HOME}/.docksal/docksal.env"
+	run fin config set --global TEST_VAR=54321
+	[[ $status == 0 ]] && [[ "$output" =~ "Replaced value for TEST_VAR in ${HOME}/.docksal/docksal.env" ]]
 
 	source "${HOME}/.docksal/docksal.env"
-	[[ "$TEST" == "54321" ]]
+	[[ "$TEST_VAR" == "54321" ]]
 	unset output
 
 	mv "${HOME}/.docksal/docksal.env.bak" "${HOME}/.docksal/docksal.env"
@@ -248,17 +248,12 @@ services:
 
 	cp "${HOME}/.docksal/docksal.env" "${HOME}/.docksal/docksal.env.bak"
 
-	echo "TEST=123456" >> ${HOME}/.docksal/docksal.env
+	echo "TEST_VAR=123456" >> ${HOME}/.docksal/docksal.env
+	run fin config remove --global TEST_VAR
+	[[ $status == 0 ]] && [[ "$output" =~ "Removing TEST_VAR from ${HOME}/.docksal/docksal.env" ]]
 
 	source "${HOME}/.docksal/docksal.env"
-	[[ "$TEST" == "123456" ]]
-	unset TEST
-
-	run fin config remove --global TEST
-	[[ $status == 0 ]] && [[ "$output" =~ "Removing TEST from ${HOME}/.docksal/docksal.env" ]]
-
-	source "${HOME}/.docksal/docksal.env"
-	[[ -z "$TEST" ]]
+	[[ -z "$TEST_VAR" ]]
 	unset output
 
 	mv "${HOME}/.docksal/docksal.env.bak" "${HOME}/.docksal/docksal.env"
@@ -267,9 +262,9 @@ services:
 @test "fin config remove: global file variable does not exist" {
 	[[ $SKIP == 1 ]] && skip
 
-	run fin config remove --global TEST
+	run fin config remove --global TEST_VAR
 	[[ $status == 0 ]] &&
-	[[ $output =~ "Could not find TEST in ${HOME}/.docksal/docksal.env" ]]
+	[[ $output =~ "Could not find TEST_VAR in ${HOME}/.docksal/docksal.env" ]]
 
 	unset output
 }

--- a/tests/smoke-test-config.bats
+++ b/tests/smoke-test-config.bats
@@ -215,7 +215,7 @@ services:
 @test "fin config set: global file" {
 	[[ $SKIP == 1 ]] && skip
 
-	cp "${HOME}/.docksal/docksal.env" "${HOME}/.docksal/docksal.env.bak"
+	cp "${HOME}/.docksal/docksal.env" "${HOME}/.docksal/docksal.env.orig"
 	# Test command can run with --global
 	run fin config set --global TEST_VAR=12345
 	[[ $status == 0 ]] &&
@@ -225,13 +225,13 @@ services:
 	[[ "$TEST_VAR" == "12345" ]]
 	unset output
 
-	mv "${HOME}/.docksal/docksal.env.bak" "${HOME}/.docksal/docksal.env"
+	mv "${HOME}/.docksal/docksal.env.orig" "${HOME}/.docksal/docksal.env"
 }
 
 @test "fin config replace: global file" {
 	[[ $SKIP == 1 ]] && skip
 
-	cp "${HOME}/.docksal/docksal.env" "${HOME}/.docksal/docksal.env.bak"
+	cp "${HOME}/.docksal/docksal.env" "${HOME}/.docksal/docksal.env.orig"
 	echo "TEST_VAR=1" >> "${HOME}/.docksal/docksal.env"
 	run fin config set --global TEST_VAR=54321
 	[[ $status == 0 ]] && [[ "$output" =~ "Replaced value for TEST_VAR in ${HOME}/.docksal/docksal.env" ]]
@@ -240,13 +240,13 @@ services:
 	[[ "$TEST_VAR" == "54321" ]]
 	unset output
 
-	mv "${HOME}/.docksal/docksal.env.bak" "${HOME}/.docksal/docksal.env"
+	mv "${HOME}/.docksal/docksal.env.orig" "${HOME}/.docksal/docksal.env"
 }
 
 @test "fin config remove: global file" {
 	[[ $SKIP == 1 ]] && skip
 
-	cp "${HOME}/.docksal/docksal.env" "${HOME}/.docksal/docksal.env.bak"
+	cp "${HOME}/.docksal/docksal.env" "${HOME}/.docksal/docksal.env.orig"
 
 	echo "TEST_VAR=123456" >> ${HOME}/.docksal/docksal.env
 	run fin config remove --global TEST_VAR
@@ -256,7 +256,7 @@ services:
 	[[ -z "$TEST_VAR" ]]
 	unset output
 
-	mv "${HOME}/.docksal/docksal.env.bak" "${HOME}/.docksal/docksal.env"
+	mv "${HOME}/.docksal/docksal.env.orig" "${HOME}/.docksal/docksal.env"
 }
 
 @test "fin config remove: global file variable does not exist" {

--- a/tests/smoke-test-config.bats
+++ b/tests/smoke-test-config.bats
@@ -268,3 +268,164 @@ services:
 
 	unset output
 }
+
+# Project
+
+@test "fin config set: project docksal.env file" {
+	[[ $SKIP == 1 ]] && skip
+
+	# Create .docksal
+	mkdir .docksal
+
+	run fin config set TEST=23456
+	local project=$(pwd)
+	[[ $status == 0 ]] &&
+	[[ $output =~ "Added value for TEST into ${project}/.docksal/docksal.env" ]]
+
+	source "${project}/.docksal/docksal.env"
+	[[ "$TEST" == "23456" ]]
+	unset output
+
+	# cleanup
+	rm -rf .docksal
+}
+
+@test "fin config replace: project docksal.env file" {
+	[[ $SKIP == 1 ]] && skip
+
+	# Create .docksal
+	mkdir .docksal
+
+	local project=$(pwd)
+	echo "TEST=1" >> "${project}/.docksal/docksal.env"
+	run fin config set TEST=65432
+	[[ $status == 0 ]] && [[ "$output" =~ "Replaced value for TEST in ${project}/.docksal/docksal.env" ]]
+
+	source "${project}/.docksal/docksal.env"
+	[[ "$TEST" == "65432" ]]
+	unset output
+
+
+	# cleanup
+	rm -rf .docksal
+}
+
+@test "fin config remove: project docksal.env file" {
+	[[ $SKIP == 1 ]] && skip
+
+	# Create .docksal
+	mkdir .docksal
+
+	echo "TEST=126534" >> .docksal/docksal.env
+	source ".docksal/docksal.env"
+	[[ "$TEST" == "126534" ]]
+	unset TEST
+
+	run fin config remove TEST
+	local project=$(pwd)
+	[[ $status == 0 ]] && [[ "$output" =~ "Removing TEST from ${project}/.docksal/docksal.env" ]]
+
+	source "${project}/.docksal/docksal.env"
+	[[ -z "$TEST" ]]
+	unset output
+
+	# cleanup
+	rm -rf .docksal
+}
+
+@test "fin config remove: project file variable does not exist" {
+	[[ $SKIP == 1 ]] && skip
+
+	# Create .docksal
+	mkdir .docksal
+
+	local project=$(pwd)
+	run fin config remove TEST
+	[[ $status == 0 ]] &&
+	[[ $output =~ "Could not find TEST in ${project}/.docksal/docksal.env" ]]
+	unset output
+
+	# cleanup
+	rm -rf .docksal
+}
+
+# Project Local
+
+@test "fin config set: project docksal-ENV.env file" {
+	[[ $SKIP == 1 ]] && skip
+
+	# Create .docksal
+	mkdir .docksal
+
+	run fin config set --env=local TEST=34567
+	local project=$(pwd)
+	[[ $status == 0 ]] &&
+	[[ $output =~ "Added value for TEST into ${project}/.docksal/docksal-local.env" ]]
+
+	source "${project}/.docksal/docksal-local.env"
+	[[ "$TEST" == "34567" ]]
+	unset output
+
+	# cleanup
+	rm -rf .docksal
+}
+
+
+@test "fin config replace: project docksal-ENV.env file" {
+	[[ $SKIP == 1 ]] && skip
+
+	# Create .docksal
+	mkdir .docksal
+
+	local project=$(pwd)
+	echo "TEST=1" >> "${project}/.docksal/docksal-local.env"
+	run fin config set --env=local TEST=76543
+	[[ $status == 0 ]] &&
+	[[ "$output" =~ "Replaced value for TEST in ${project}/.docksal/docksal-local.env" ]]
+
+	source "${project}/.docksal/docksal-local.env"
+	[[ "$TEST" == "76543" ]]
+	unset output
+
+	# cleanup
+	rm -rf .docksal
+}
+
+@test "fin config remove: project docksal-ENV.env file" {
+	[[ $SKIP == 1 ]] && skip
+
+	# Create .docksal
+	mkdir .docksal
+
+	echo "TEST=126534" >> .docksal/docksal-local.env
+	source ".docksal/docksal.env"
+	[[ "$TEST" == "126534" ]]
+	unset TEST
+
+	run fin config remove --env=local TEST
+	local project=$(pwd)
+	[[ $status == 0 ]] &&
+	[[ $output =~ "Removing TEST from ${project}/.docksal/docksal-local.env" ]]
+
+	source "${project}/.docksal/docksal-local.env"
+	[[ -z "$TEST" ]]
+	unset output
+
+	# cleanup
+	rm -rf .docksal
+}
+
+@test "fin config remove: project env file variable does not exist" {
+	[[ $SKIP == 1 ]] && skip
+
+	mkdir .docksal
+
+	local project=$(pwd)
+	run fin config remove --env=local TEST
+	[[ $status == 0 ]] &&
+	[[ $output =~ "Could not find TEST in ${project}/.docksal/docksal-local.env" ]]
+	unset output
+
+	# cleanup
+	rm -rf .docksal
+}

--- a/tests/smoke-test-config.bats
+++ b/tests/smoke-test-config.bats
@@ -209,3 +209,67 @@ services:
 	[[ $output =~ "docksal.env" ]]
 	unset output
 }
+
+# Global
+
+@test "fin config set: global file" {
+	[[ $SKIP == 1 ]] && skip
+
+	cp "${HOME}/.docksal/docksal.env" "${HOME}/.docksal/docksal.env.bak"
+	# Test command can run with --global
+	run fin config set --global TEST=12345
+	[[ $status == 0 ]] &&
+	[[ $output =~ "Added value for TEST into ${HOME}/.docksal/docksal.env" ]]
+	source "${HOME}/.docksal/docksal.env"
+	# Testing what value is
+	[[ "$TEST" == "12345" ]]
+	unset output
+
+	mv "${HOME}/.docksal/docksal.env.bak" "${HOME}/.docksal/docksal.env"
+}
+
+@test "fin config replace: global file" {
+	[[ $SKIP == 1 ]] && skip
+
+	cp "${HOME}/.docksal/docksal.env" "${HOME}/.docksal/docksal.env.bak"
+	echo "TEST=1" >> "${HOME}/.docksal/docksal.env"
+	run fin config set --global TEST=54321
+	[[ $status == 0 ]] && [[ "$output" =~ "Replaced value for TEST in ${HOME}/.docksal/docksal.env" ]]
+
+	source "${HOME}/.docksal/docksal.env"
+	[[ "$TEST" == "54321" ]]
+	unset output
+
+	mv "${HOME}/.docksal/docksal.env.bak" "${HOME}/.docksal/docksal.env"
+}
+
+@test "fin config remove: global file" {
+	[[ $SKIP == 1 ]] && skip
+
+	cp "${HOME}/.docksal/docksal.env" "${HOME}/.docksal/docksal.env.bak"
+
+	echo "TEST=123456" >> ${HOME}/.docksal/docksal.env
+
+	source "${HOME}/.docksal/docksal.env"
+	[[ "$TEST" == "123456" ]]
+	unset TEST
+
+	run fin config remove --global TEST
+	[[ $status == 0 ]] && [[ "$output" =~ "Removing TEST from ${HOME}/.docksal/docksal.env" ]]
+
+	source "${HOME}/.docksal/docksal.env"
+	[[ -z "$TEST" ]]
+	unset output
+
+	mv "${HOME}/.docksal/docksal.env.bak" "${HOME}/.docksal/docksal.env"
+}
+
+@test "fin config remove: global file variable does not exist" {
+	[[ $SKIP == 1 ]] && skip
+
+	run fin config remove --global TEST
+	[[ $status == 0 ]] &&
+	[[ $output =~ "Could not find TEST in ${HOME}/.docksal/docksal.env" ]]
+
+	unset output
+}

--- a/tests/smoke-test-config.bats
+++ b/tests/smoke-test-config.bats
@@ -297,7 +297,6 @@ services:
 	rm -rf .docksal
 	mkdir .docksal
 
-
 	local project=$(pwd)
 	echo "TEST=1" >> "${project}/.docksal/docksal.env"
 	run fin config set TEST=65432
@@ -316,9 +315,6 @@ services:
 	mkdir .docksal
 
 	echo "TEST=126534" >> .docksal/docksal.env
-	source ".docksal/docksal.env"
-	[[ "$TEST" == "126534" ]]
-	unset TEST
 
 	run fin config remove TEST
 	local project=$(pwd)
@@ -362,7 +358,6 @@ services:
 	unset output
 }
 
-
 @test "fin config replace: project docksal-ENV.env file" {
 	[[ $SKIP == 1 ]] && skip
 
@@ -389,9 +384,6 @@ services:
 	mkdir .docksal
 
 	echo "TEST=126534" >> .docksal/docksal-local.env
-	source ".docksal/docksal.env"
-	[[ "$TEST" == "126534" ]]
-	unset TEST
 
 	run fin config remove --env=local TEST
 	local project=$(pwd)

--- a/tests/smoke-test-config.bats
+++ b/tests/smoke-test-config.bats
@@ -72,8 +72,8 @@ version: '2.1'
 
 services:
   web:
-    environment:
-      - TEST_VAR=test_val"
+	environment:
+	  - TEST_VAR=test_val"
 
 	echo "$yml" > .docksal/docksal.yml
 
@@ -101,9 +101,9 @@ version: '2.1'
 
 services:
   web:
-    image: nginx
-    environment:
-      - TEST_VAR="'${TEST_VAR:-test_val_default}'
+	image: nginx
+	environment:
+	  - TEST_VAR="'${TEST_VAR:-test_val_default}'
 
 	echo "$yml" > .docksal/docksal.yml
 
@@ -143,9 +143,9 @@ version: '2.1'
 
 services:
   web:
-    image: nginx
-    environment:
-      - TEST_VAR_LOCAL="'${TEST_VAR_LOCAL:-test_val_default}'
+	image: nginx
+	environment:
+	  - TEST_VAR_LOCAL="'${TEST_VAR_LOCAL:-test_val_default}'
 
 	echo "$yml" > .docksal/docksal-local.yml
 
@@ -274,7 +274,8 @@ services:
 @test "fin config set: project docksal.env file" {
 	[[ $SKIP == 1 ]] && skip
 
-	# Create .docksal
+	# cleanup
+	rm -rf .docksal
 	mkdir .docksal
 
 	run fin config set TEST=23456
@@ -287,14 +288,15 @@ services:
 	unset output
 
 	# cleanup
-	rm -rf .docksal
 }
 
 @test "fin config replace: project docksal.env file" {
 	[[ $SKIP == 1 ]] && skip
 
-	# Create .docksal
+	# cleanup
+	rm -rf .docksal
 	mkdir .docksal
+
 
 	local project=$(pwd)
 	echo "TEST=1" >> "${project}/.docksal/docksal.env"
@@ -304,16 +306,13 @@ services:
 	source "${project}/.docksal/docksal.env"
 	[[ "$TEST" == "65432" ]]
 	unset output
-
-
-	# cleanup
-	rm -rf .docksal
 }
 
 @test "fin config remove: project docksal.env file" {
 	[[ $SKIP == 1 ]] && skip
 
-	# Create .docksal
+	# cleanup
+	rm -rf .docksal
 	mkdir .docksal
 
 	echo "TEST=126534" >> .docksal/docksal.env
@@ -328,15 +327,13 @@ services:
 	source "${project}/.docksal/docksal.env"
 	[[ -z "$TEST" ]]
 	unset output
-
-	# cleanup
-	rm -rf .docksal
 }
 
 @test "fin config remove: project file variable does not exist" {
 	[[ $SKIP == 1 ]] && skip
 
-	# Create .docksal
+	# cleanup
+	rm -rf .docksal
 	mkdir .docksal
 
 	local project=$(pwd)
@@ -344,9 +341,6 @@ services:
 	[[ $status == 0 ]] &&
 	[[ $output =~ "Could not find TEST in ${project}/.docksal/docksal.env" ]]
 	unset output
-
-	# cleanup
-	rm -rf .docksal
 }
 
 # Project Local
@@ -354,7 +348,8 @@ services:
 @test "fin config set: project docksal-ENV.env file" {
 	[[ $SKIP == 1 ]] && skip
 
-	# Create .docksal
+	# cleanup
+	rm -rf .docksal
 	mkdir .docksal
 
 	run fin config set --env=local TEST=34567
@@ -365,16 +360,14 @@ services:
 	source "${project}/.docksal/docksal-local.env"
 	[[ "$TEST" == "34567" ]]
 	unset output
-
-	# cleanup
-	rm -rf .docksal
 }
 
 
 @test "fin config replace: project docksal-ENV.env file" {
 	[[ $SKIP == 1 ]] && skip
 
-	# Create .docksal
+	# cleanup
+	rm -rf .docksal
 	mkdir .docksal
 
 	local project=$(pwd)
@@ -386,15 +379,13 @@ services:
 	source "${project}/.docksal/docksal-local.env"
 	[[ "$TEST" == "76543" ]]
 	unset output
-
-	# cleanup
-	rm -rf .docksal
 }
 
 @test "fin config remove: project docksal-ENV.env file" {
 	[[ $SKIP == 1 ]] && skip
 
-	# Create .docksal
+	# cleanup
+	rm -rf .docksal
 	mkdir .docksal
 
 	echo "TEST=126534" >> .docksal/docksal-local.env
@@ -410,14 +401,13 @@ services:
 	source "${project}/.docksal/docksal-local.env"
 	[[ -z "$TEST" ]]
 	unset output
-
-	# cleanup
-	rm -rf .docksal
 }
 
 @test "fin config remove: project env file variable does not exist" {
 	[[ $SKIP == 1 ]] && skip
 
+	# cleanup
+	rm -rf .docksal
 	mkdir .docksal
 
 	local project=$(pwd)
@@ -425,7 +415,4 @@ services:
 	[[ $status == 0 ]] &&
 	[[ $output =~ "Could not find TEST in ${project}/.docksal/docksal-local.env" ]]
 	unset output
-
-	# cleanup
-	rm -rf .docksal
 }


### PR DESCRIPTION
Added option for `fin config set/remove` to pass an `--env` flag.

Example of command

```
$ fin config set --env=local TEST=1
Added value for TEST into HOME/.docksal/docksal.env
```

Additionally added tests and updated help command to reflect the changes.

Solves #584 