### PR TITLE
Added tip to project setup for docroot

### DIFF
--- a/docs/getting-started/project-setup.md
+++ b/docs/getting-started/project-setup.md
@@ -23,6 +23,9 @@ The `.docksal` directory is where all Docksal configurations and commands for th
 !!! note "Version control" 
     Git does not commit empty directories. To commit the `.docksal` directory into your Git repo create an empty `.gitkeep` file inside it ( or some other file of your choosing.)
 
+!!! tip "Document Root"
+    Is your Project Root the same as your Document Root? If so then you can accomplish this by setting the `DOCROOT=.` within the `.docksal/docksal.env`.
+
 ## Start containers
 
 ```bash


### PR DESCRIPTION
Added documentation to Project Setup so so that users know they can use the current directory as the `DOCROOT`

Solves #590 