### PR TITLE
Allow for Container Names option with fin exec [WIP]

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -1323,7 +1323,7 @@ show_help_exec ()
 	printh "-T" "Disable pseudo-tty allocation."
 	printh "" "Useful for non-interactive commands when output is saved into a variable for further comparison."
 	printh "" "In a TTY mode the output may contain unexpected control symbols (garbage)."
-
+    printh "--container=db" "Name of the container to execute command in."
 	echo
 	echo "Advanced:"
 	printh "CONTAINER_NAME=[name]" "Environment variable. Defines container to run in (default is \`cli\`)"
@@ -1334,7 +1334,8 @@ show_help_exec ()
 	printh "fin exec \"ls -la > /tmp/list\"" "		Execute advanced shell command with pipes or stdout redirects happening inside cli"
 	printh "res=\$(fin exec -T drush st)" "		Use -T switch when using exec output"
 	printh "fin exec .docksal/script.sh" "		Execute a whole file inside \`cli\` container"
-	printh "CONTAINER_NAME=db fin exec mysql -uroot -p" "Execute command in \`db\` container"
+	printh "fin exec --container=db mysql -uroot -p" "Using --container option. Execute command in \`db\` container"
+	printh "CONTAINER_NAME=db fin exec mysql -uroot -p" "Using Env variable. Execute command in \`db\` container"
 }
 
 show_help_run-cli ()
@@ -4214,15 +4215,20 @@ _exec ()
 		show_help_exec && exit
 	check_project_environment
 	check_winpty_found
+	eval $(parse_params "$@")
 
 	# Allow disabling TTY mode.
 	# Useful for non-interactive commands when output is saved into a variable for further comparison.
 	# In a TTY mode the output may contain unexpected control symbols/etc.
-	[[ $1 == "-T" ]] && \
+	[[ $T == "T" ]] && \
 		local no_tty=true && shift
 
 	# TODO: refactor to use ${COMPOSE_PROJECT_NAME_SAFE}_<service>_1
 	# CONTAINER_NAME can be used to override where to run. Used in _bash()
+
+	[[ -n "$container" ]] && \
+		CONTAINER_NAME=${container:-${CONTAINER_NAME}} && shift
+
 	CONTAINER_NAME=${CONTAINER_NAME:-cli}
 	container_id=$(get_container_id "$CONTAINER_NAME")
 

--- a/bin/fin
+++ b/bin/fin
@@ -1322,20 +1322,16 @@ show_help_exec ()
 	echo "Options:"
 	printh "-T" "Disable pseudo-tty allocation."
 	printh "" "Useful for non-interactive commands when output is saved into a variable for further comparison."
-	printh "" "In a TTY mode the output may contain unexpected control symbols (garbage)."
-    printh "--container=db" "Name of the container to execute command in."
-	echo
-	echo "Advanced:"
-	printh "CONTAINER_NAME=[name]" "Environment variable. Defines container to run in (default is \`cli\`)"
+	printh "" "In a TTY mode the output may contain unexpected invisible control symbols."
+	printh "--in=[name]" "Name of the container to execute the command in."
 
 	echo
 	echo "Examples:"
 	printh "fin exec ls -la" "		Current directory listing"
-	printh "fin exec \"ls -la > /tmp/list\"" "		Execute advanced shell command with pipes or stdout redirects happening inside cli"
+	printh "fin exec \"ls -la > /tmp/list\"" "		Execute advanced shell command with pipes or stdout redirects happening inside \`cli\`"
 	printh "res=\$(fin exec -T drush st)" "		Use -T switch when using exec output"
 	printh "fin exec .docksal/script.sh" "		Execute a whole file inside \`cli\` container"
-	printh "fin exec --container=db mysql -uroot -p" "Using --container option. Execute command in \`db\` container"
-	printh "CONTAINER_NAME=db fin exec mysql -uroot -p" "Using Env variable. Execute command in \`db\` container"
+	printh "fin exec --in=db mysql -uroot -p" "	Execute command in \`db\` container"
 }
 
 show_help_run-cli ()
@@ -4211,7 +4207,7 @@ _bash ()
 # @param $* command with its params to run
 _exec ()
 {
-	[[ $1 == "" ]] && \
+	[[ $1 == "" ]] &&
 		show_help_exec && exit
 	check_project_environment
 	check_winpty_found
@@ -4220,14 +4216,16 @@ _exec ()
 	# Allow disabling TTY mode.
 	# Useful for non-interactive commands when output is saved into a variable for further comparison.
 	# In a TTY mode the output may contain unexpected control symbols/etc.
-	[[ $T == "T" ]] && \
-		local no_tty=true && shift
+	[[ $T == "T" ]] &&
+		local no_tty=true &&
+		shift
 
 	# TODO: refactor to use ${COMPOSE_PROJECT_NAME_SAFE}_<service>_1
 	# CONTAINER_NAME can be used to override where to run. Used in _bash()
 
-	[[ -n "$container" ]] && \
-		CONTAINER_NAME=${container:-${CONTAINER_NAME}} && shift
+	[[ -n "$in" ]] &&
+		CONTAINER_NAME=${in} &&
+		shift
 
 	CONTAINER_NAME=${CONTAINER_NAME:-cli}
 	container_id=$(get_container_id "$CONTAINER_NAME")
@@ -4307,7 +4305,7 @@ run_cli ()
 		case $1 in
 		# Allow disabling TTY mode.
 		# Useful for non-interactive commands when output is saved into a variable for further comparison.
-		# In a TTY mode the output may contain unexpected control symbols/etc.
+		# In a TTY mode the output may contain unexpected invisible control symbols/etc.
 		-T)
 			local no_tty=true;
 			shift;

--- a/tests/smoke-test-general.bats
+++ b/tests/smoke-test-general.bats
@@ -178,6 +178,11 @@ EOF
 	run fin exec -T 'echo $(id -u):$(id -g)'
 	[[ "$output" == "$(id -u):$(id -g)" ]]
 	unset output
+
+	# setting target container with --in
+	run fin exec --in=web -T cat /etc/hostname
+	[[ "$output" == "web" ]]
+	unset output
 }
 
 @test "fin run-cli" {


### PR DESCRIPTION
Add ability for containers to use `--container` option when running `fin exec`

Solves https://github.com/docksal/docksal/issues/609