### PR TITLE
Cron Docs and Command

### DIFF
--- a/docs/advanced/cron.md
+++ b/docs/advanced/cron.md
@@ -1,0 +1,24 @@
+# Running Cron
+
+!!! note "CLI Container"
+	Currently custom crontab files are only supported within the `cli` container.
+
+## Crontab file Explained
+
+A crontab file has six fields for specifying minute, hour, day of month, month, day of week and the command to be run at that interval. See below:
+
+```bash
+*     *     *     *     *  command to be executed
+-     -     -     -     -
+|     |     |     |     |
+|     |     |     |     +----- day of week (0 - 6) (Sunday=0)
+|     |     |     +------- month (1 - 12)
+|     |     +--------- day of month (1 - 31)
+|     +----------- hour (0 - 23)
++------------- min (0 - 59)
+```
+
+## Configuring Cron
+
+Cron can be started within a project by creating a `crontab` file within the projects `.docksal/etc/services/cli` folder.
+Once that file has been created or file, the `cli` container should be restarted by running `fin restart cli`.

--- a/docs/advanced/cron.md
+++ b/docs/advanced/cron.md
@@ -21,4 +21,4 @@ A crontab file has six fields for specifying minute, hour, day of month, month, 
 ## Configuring Cron
 
 Cron can be started within a project by creating a `crontab` file within the projects `.docksal/etc/services/cli` folder.
-Once that file has been created or file, the `cli` container should be restarted by running `fin restart cli`.
+Once that file has been created or modified, the `cli` container should be restarted by running `fin restart cli`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ pages:
       - Networking: advanced/networking.md
       - DNS resolver: advanced/dns-resolver.md
       - Extending stock images: advanced/extend-images.md
+      - Cron: advanced/cron.md
     - SSH agent: advanced/ssh-agent.md
     - Database:
       - Database access: advanced/db-access.md


### PR DESCRIPTION
* Added command to run crontab commands within the `cli` container.
* Added docs for configuring `crontab` file within project.

**Pending PR https://github.com/docksal/service-cli/pull/64**
Solves https://github.com/docksal/docksal/issues/238