### PR TITLE
Allow overriding built-ins. Create default init built-in

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -1175,8 +1175,8 @@ show_help ()
 			addon="$(get_addon_script $1)"
 			# If no such addon then search for command
 			[[ ! -f "$addon" ]] && addon="$(get_command_script $1)"
-
-			if [ -f "$addon" ]; then
+			# Fetch help from the file and show it
+			if [[ -f "$addon" ]]; then
 				echo
 				echo "Addon: $1"
 				echo
@@ -1193,7 +1193,7 @@ show_help ()
 
 		# Check for help function for specific command
 		local command="$1"
-		# Remove exclamation mark if provided
+		# Remove exclamation mark if present for forcing built-in help
 		[[ "$1" =~ .+! ]] && command="${1//!}"
 		type "show_help_$command" >/dev/null 2>&1
 		if [ $? -eq 0 ]; then
@@ -1414,7 +1414,6 @@ show_help_run-cli ()
 	printh "fin rc -e VAR1=hello -e VAR2=world 'echo \$VAR1 \$VAR2'" "Print hello world using ENV variables"
 
 }
-
 
 show_help_image() {
 	echo
@@ -1785,6 +1784,23 @@ show_help_config ()
 	printh "fin config set DOCKER_NATIVE=1 --global" "Adds DOCKER_NATIVE=1 into \$HOME/.docksal/docksal.env"
 	printh "fin config rm DOCKER_NATIVE --global" "	Removes DOCKER_NATIVE value from \$HOME/.docksal/docksal.env"
 }
+
+show_help_init ()
+{
+	echo
+	echo "Creates default project configuration and starts a project."
+	echo "This built-in is meant to be overridden with custom command or addon."
+	echo "Unlike other built-ins it will not trigger a warning when this happens."
+	echo -e "See ${yellow}https://docs.docksal.io/en/master/fin/custom-commands${NC} on creating custom commands."
+
+	echo
+	echo "Usage: init"
+
+	echo
+	echo "Options: [none]"
+}
+
+
 
 show_help_cleanup ()
 {

--- a/bin/fin
+++ b/bin/fin
@@ -204,11 +204,14 @@ PATH="$CONFIG_BIN_DIR:$PATH"
 DOCKER_NATIVE="${DOCKER_NATIVE:-0}"
 
 # List of built-ins, update every time you add a new built-in
-DOCKSAL_INTERNAL_COMMANDS_LIST="bash_comp_words build start up stop restart reset remove
+# `init` is not included here, so that overriding it would not trigger a warning
+DOCKSAL_BUILTIN_LIST="bash_comp_words build start up stop restart reset remove
  rm image project p system sys status ps projects pl vm update bash exec run run-cli rc mysql
  sqlc mysql-list sqls mysql-import sqli mysql-dump sqld db drush drupal terminus platform wp
  composer ssh-add docker d docker-compose dc docker-machine dm debug exec-url share cleanup -v v
  --version version logs help sysinfo diagnose config fix-smb alias hosts vhosts addon a"
+# These built-ins can be overridden with addons (warning displayed)
+DOCKSAL_ALLOWED_BUILTIN_OVERRIDES="build composer drupal drush platform terminus wp"
 
 #---------------------------- URL references --------------------------------
 URL_REPO="https://raw.githubusercontent.com/docksal/docksal"
@@ -1175,6 +1178,13 @@ show_help ()
 			addon="$(get_addon_script $1)"
 			# If no such addon then search for command
 			[[ ! -f "$addon" ]] && addon="$(get_command_script $1)"
+			if [[ ("$DOCKSAL_BUILTIN_LIST" =~ "$1 " || "$DOCKSAL_BUILTIN_LIST" =~ " $1") && \
+				! ("$DOCKSAL_ALLOWED_BUILTIN_OVERRIDES" =~ "$1 " || "$DOCKSAL_ALLOWED_BUILTIN_OVERRIDES" =~ " $1") ]]; then
+				echo-error "Overriding '$1' built-in is not allowed" \
+					"To avoid conflict with fin built-in rename:" \
+					"${yellow}$addon${NC}"
+				return 1
+			fi
 			# Fetch help from the file and show it
 			if [[ -f "$addon" ]]; then
 				echo
@@ -6102,8 +6112,15 @@ else
 fi
 
 if [[ -f "$addon" ]]; then
-	if [[ "$DOCKSAL_INTERNAL_COMMANDS_LIST" =~ " $1 " ]]; then
-		>&2 echo-warning "Built-in command '$1' was overridden. To force built-in execution run 'fin $1!'"
+	if [[ "$DOCKSAL_BUILTIN_LIST" =~ "$1 " || "$DOCKSAL_BUILTIN_LIST" =~ " $1" ]]; then
+		if [[ "$DOCKSAL_ALLOWED_BUILTIN_OVERRIDES" =~ "$1 " || "$DOCKSAL_ALLOWED_BUILTIN_OVERRIDES" =~ " $1" ]]; then
+			>&2 echo-warning "Built-in command '$1' was overridden. To force built-in execution run 'fin $1!'"
+		else
+			echo-error "Overriding '$1' built-in is not allowed" \
+				"To avoid conflict with fin built-in rename:" \
+				"${yellow}$addon${NC}"
+			exit 1
+		fi
 	fi
 
 	export ADDON_ROOT=$(dirname "$addon")

--- a/bin/fin
+++ b/bin/fin
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-FIN_VERSION=1.64.1
+FIN_VERSION=1.65.0
 
 if [[ "$TERM" != "dumb" ]]; then
 	# Console colors

--- a/bin/fin
+++ b/bin/fin
@@ -153,6 +153,7 @@ CONFIG_CERTS=${CONFIG_CERTS:-$CONFIG_DIR/certs}
 
 # Where custom commands live (relative path)
 DOCKSAL_COMMANDS_PATH=".docksal/commands"
+
 # Where addons live (relative path)
 DOCKSAL_ADDONS_PATH=".docksal/addons"
 
@@ -160,15 +161,14 @@ DOCKSAL_ADDONS_PATH=".docksal/addons"
 DOCKSAL_ENVIRONMENT="${DOCKSAL_ENVIRONMENT:-local}"
 
 # Network settings
+
 export DOCKSAL_IP="192.168.64.100"
 export DOCKSAL_HOST_IP="192.168.64.1"
 export DOCKSAL_SUBNET="192.168.64.1/24"
-
 # For environments, where access to external DNS servers is blocked, DOCKSAL_DNS_UPSTREAM should be set to the LAN DNS server
 DOCKSAL_DEFAULT_DNS="8.8.8.8"
 # For visibility on this variable
 DOCKSAL_DNS_UPSTREAM="${DOCKSAL_DNS_UPSTREAM}"
-
 DOCKSAL_DNS_DOMAIN="${DOCKSAL_DNS_DOMAIN:-docksal}"
 # Allow disabling the DNS resolver configuration (in case there are issues with it). Set to "true" to activate.
 DOCKSAL_NO_DNS_RESOLVER="${DOCKSAL_NO_DNS_RESOLVER}"
@@ -202,6 +202,13 @@ PATH="$CONFIG_BIN_DIR:$PATH"
 
 # Set global variable in case native Docker app is used/not-used
 DOCKER_NATIVE="${DOCKER_NATIVE:-0}"
+
+# List of built-ins, update every time you add a new built-in
+DOCKSAL_INTERNAL_COMMANDS_LIST="bash_comp_words build start up stop restart reset remove
+ rm image project p system sys status ps projects pl vm update bash exec run run-cli rc mysql
+ sqlc mysql-list sqls mysql-import sqli mysql-dump sqld db drush drupal terminus platform wp
+ composer ssh-add docker d docker-compose dc docker-machine dm debug exec-url share cleanup -v v
+ --version version logs help sysinfo diagnose config fix-smb alias hosts vhosts addon a"
 
 #---------------------------- URL references --------------------------------
 URL_REPO="https://raw.githubusercontent.com/docksal/docksal"
@@ -1161,26 +1168,38 @@ show_help ()
 	local custom_commands_list
 
 	# If nonempty param then show help for a certain command
-	if [[ ! -z "$1" ]]; then
-		# Check for help function for specific command
-		type "show_help_$1" >/dev/null 2>&1
-		if [ $? -eq 0 ]; then
-			show_help_$1
-			exit
+	if [[ "$1" != "" ]]; then
+		# When command is postfixed with exclamation mark, exclude addon overrides
+		if [[ ! "$1" =~ .+! ]]; then
+			# Search for addons
+			addon="$(get_addon_script $1)"
+			# If no such addon then search for command
+			[[ ! -f "$addon" ]] && addon="$(get_command_script $1)"
+
+			if [ -f "$addon" ]; then
+				echo
+				echo "Addon: $1"
+				echo
+				local _help_contents=$(cat "$addon" | grep '^##' | sed -E "s/^##[ ]?//g")
+				if [[ "$_help_contents" != "" ]]; then
+					echo -e "$_help_contents"
+					echo
+				else
+					echo "No help description found"
+				fi
+				exit
+			fi
 		fi
 
-		# Search for addons
-		addon="$(get_addon_script $1)"
-		# If no such addon then search for command
-		[[ ! -f "$addon" ]] && addon="$(get_command_script $1)"
-
-		if [ -f "$addon" ]; then
-			echo -en "${green}fin $1${NC} - "
-			local _help_contents=$(cat "$addon" | grep '^##' | sed -E "s/^##[ ]?//g")
-			echo -e "$_help_contents"
-			echo
+		# Check for help function for specific command
+		local command="$1"
+		# Remove exclamation mark if provided
+		[[ "$1" =~ .+! ]] && command="${1//!}"
+		type "show_help_$command" >/dev/null 2>&1
+		if [ $? -eq 0 ]; then
+			show_help_${command}
 			exit
-			fi
+		fi
 	fi
 
 	echo "Docksal control cli utility v$FIN_VERSION"
@@ -1215,6 +1234,7 @@ show_help ()
 	printh "docker-compose [command]" "Run docker-compose commands directly"
 
 	echo
+	printh "init" "Initialize a project (override it with your own automation ${yellow}fin help init${NC})"
 	printh "addon <command>" "Addons management commands: install, remove (${yellow}fin help addon${NC})"
 	printh "ssh-add [-lD] [key]" "Adds ssh private key to the authentication agent (${yellow}fin help ssh-add${NC})"
 	printh "alias" "Manage aliases that allow ${yellow}fin @alias${NC} execution (${yellow}fin help alias${NC})"
@@ -1324,30 +1344,32 @@ show_help_list_addons_in_help ()
 show_help_ssh-add ()
 {
 	echo
-	echo "Usage: fin ssh-add [-lD] [key]"
+	echo "Add private key identities stored in \$HOME/.ssh to the docksal/ssh-agent."
+	echo "When run without arguments, automatically adds the default key files (id_rsa, id_dsa, id_ecdsa)."
+	echo "A custom key name can be given as an argument: fin ssh-add [keyname]."
+	echo "[keyname] is the file name within \$HOME/.ssh"
 
 	echo
-	echo "Add private key identities to the docksal/ssh-agent."
-	echo "When run without arguments, automatically picks up the default key files (~/.ssh/id_rsa, ~/.ssh/id_dsa, ~/.ssh/id_ecdsa)."
-	echo "A custom key name can be given as an argument: fin ssh-add [keyname]."
-	echo
-	echo "NOTE: [keyname] is the file name within ~/.ssh (not a full path to file)."
-	echo "Example: fin ssh-add my_custom_rsa_key"
+	echo "Usage: ssh-add [-lD] [key]"
 
 	echo
 	echo "Options:"
 	printh "-D" "Deletes all keys from the agent."
 	printh "-l" "Lists all keys currently loaded by the agent."
+
+	echo
+	echo "Examples:"
+	printh "fin ssh-add my_custom_key" "Add \$HOME/.ssh/my_custom_key to SSH Agent."
 }
 
 show_help_exec ()
 {
 	echo
-	echo "Usage: fin exec [options] <command | file>"
-
-	echo
 	echo "Execute command or file in \`cli\` service container."
 	echo "fin exec will automatically cd into the same folder inside \`cli\`."
+
+	echo
+	echo "Usage: exec [options] <command | file>"
 
 	echo
 	echo "Options:"
@@ -1362,19 +1384,19 @@ show_help_exec ()
 	printh "fin exec \"ls -la > /tmp/list\"" "		Execute advanced shell command with pipes or stdout redirects happening inside \`cli\`"
 	printh "res=\$(fin exec -T drush st)" "		Use -T switch when using exec output"
 	printh "fin exec .docksal/script.sh" "		Execute a whole file inside \`cli\` container"
-	printh "fin exec --in=db mysql -uroot -p" "	Execute command in \`db\` container"
+	printh "fin exec --in=db mysql -uroot -p" "	Execute command in \`db\` container (will NOT cd into the same folder)"
 }
 
 show_help_run-cli ()
 {
 	echo
-	echo "Usage: fin run-cli [options] <command>"
-	echo "       fin rc [options] <command>"
+	echo "Runs commands in a standalone \`cli\` container mapped to the current directory."
+	echo "Container has a persistent \$HOME directory where something can be saved in between laucnhes."
+	echo "NOTE: \`fin cleanup\` will clean the persistent \$HOME directory"
 
 	echo
-	echo "Run command in a standalone \`cli\` container in the current directory"
-	echo "with a persistent \$HOME directory."
-	echo "NOTE: \`fin cleanup\` will clean the persistent \$HOME directory"
+	echo "Usage: run-cli [options] <command>"
+	echo "       rc [options] <command>"
 
 	echo
 	echo "Options:"
@@ -1396,7 +1418,10 @@ show_help_run-cli ()
 
 show_help_image() {
 	echo
-	echo "Usage: fin image <command>"
+	echo "Docksal images listing and saving"
+
+	echo
+	echo "Usage: image <command>"
 
 	echo
 	echo "Commands:"
@@ -1416,10 +1441,10 @@ show_help_image() {
 
 show_help_project() {
 	echo
-	echo "Usage: fin project <command> [params]"
+	echo "Project management"
 
 	echo
-	echo "Project management"
+	echo "Usage: project <command> [params]"
 
 	echo
 	echo "Commands:"
@@ -1472,10 +1497,10 @@ show_help_remove ()
 
 show_help_system() {
 	echo
-	echo "Usage: fin system <command> [params]"
+	echo "Manage Docksal system status (Docker should be running)"
 
 	echo
-	echo "Manage Docksal system status"
+	echo "Usage: system <command> [params]"
 
 	echo
 	echo "Commands:"
@@ -1495,10 +1520,10 @@ show_help_system() {
 show_help_update ()
 {
 	echo
-	echo "Usage: fin update"
+	echo "Update Docksal system components to the latest stable version"
 
 	echo
-	echo "Update Docksal system components to the latest stable version"
+	echo "Usage: update"
 
 	echo
 	echo "Options:"
@@ -1508,20 +1533,21 @@ show_help_update ()
 show_help_exec-url ()
 {
 	echo
-	echo "Usage: fin exec-url <url>"
+	echo "Fetch script from the public URL and evaluate locally"
 
 	echo
-	echo "Fetch script from the public URL and evaluate locally"
+	echo "Usage: fin exec-url <url>"
+
 }
 
 show_help_sqlc ()
 {
 	echo
-	echo "Usage: fin sqlc [options]"
-	echo "       fin mysql [options]"
+	echo "Open MySql command line to the current db server"
 
 	echo
-	echo "Open MySql command line to the current db server"
+	echo "Usage: sqlc [options]"
+	echo "       mysql [options]"
 
 	echo
 	echo "Options:"
@@ -1536,11 +1562,11 @@ show_help_mysql ()
 show_help_sqls ()
 {
 	echo
-	echo "Usage: fin sqls [options]"
-	echo "       fin mysql-list [options]"
+	echo-green "Show list of available databases (alias: )"
 
 	echo
-	echo-green "Show list of available databases (alias: )"
+	echo "Usage: sqls [options]"
+	echo "       mysql-list [options]"
 
 	echo
 	echo-green "Options:"
@@ -1555,11 +1581,11 @@ show_help_mysql_list ()
 show_help_sqli ()
 {
 	echo
-	echo "Usage: fin sqli [dump_file.sql] [options]"
-	echo "       fin mysql-import [dump_file.sql] [options]"
+	echo "Truncate database and import SQL dump from a file or stdin"
 
 	echo
-	echo "Truncate database and import SQL dump from a file or stdin"
+	echo "Usage: fin sqli [dump_file.sql] [options]"
+	echo "       fin mysql-import [dump_file.sql] [options]"
 
 	echo
 	echo "Options:"
@@ -1581,10 +1607,10 @@ show_help_mysql-import ()
 show_help_sqld ()
 {
 	echo
-	echo "Usage: fin sqld [dump_file] [options]"
+	echo "Export database from db container into file or stdout (alias: mysql-dump)"
 
 	echo
-	echo "Export database from db container into file or stdout (alias: mysql-dump)"
+	echo "Usage: sqld [dump_file] [options]"
 
 	echo
 	echo "Options:"
@@ -1605,10 +1631,10 @@ show_help_mysql-dump ()
 show_help_db ()
 {
 	echo
-	echo "Usage: fin db <command> [file] [options]"
+	echo "Database management commands"
 
 	echo
-	echo "Database related commands"
+	echo "Usage: db <command> [file] [options]"
 
 	echo
 	echo "Commands:"
@@ -1649,10 +1675,10 @@ show_help_db ()
 show_help_vm ()
 {
 	echo
-	echo "Usage: fin vm <command>"
+	echo "Control Docksal virtual machine"
 
 	echo
-	echo "Control Docksal virtual machine"
+	echo "Usage: vm <command>"
 
 	echo
 	echo "Commands:"
@@ -1680,35 +1706,36 @@ show_help_vm ()
 show_help_alias ()
 {
 	echo
-	echo "Usage: fin alias <command or path> [alias_name]"
-
-	echo
-	echo "Create/delete project alias"
+	echo "Create, update, or delete project aliases."
 	echo "Aliases provide functionality that is similar to drush aliases."
-	echo "Using alias you are able to execute a command in a project without navigating to the project folder."
+	echo "With alias you are able to execute a command in a project without navigating to the project folder."
 	echo "You can precede any command with an alias."
 	echo "Aliases are effectively symlinks stored in \$HOME/.docksal/alias"
 	echo
-	echo "Usage:"
-	printh "fin alias [list]" "Show aliases list"
-	printh "fin alias <path> <alias_name>" "Create or update an alias that links to target path"
-	printh "fin alias remove <alias_name>" "Remove alias"
+
+	echo "Usage: alias <command or path> [alias_name]"
+	echo
+
+	echo "Commands:"
+	printh "list" "Show aliases list"
+	printh "<path> <alias_name>" "Create/update alias with <alias_name> that links to <path>"
+	printh "remove <alias_name>" "Remove alias"
 
 	echo
 	echo "Examples:"
 	printh "fin alias ~/site1/docroot dev" "	Create or update an alias ${yellow}dev${NC} that is linked to ${yellow}~/site1/docroot${NC}"
-	printh "fin @dev drush st" "	Execute \`drush st\` command in directory linked by ${yellow}dev${NC} alias"
+	printh "fin @project1 drush st" "	Execute \`drush st\` command in directory linked by ${yellow}project1${NC} alias"
 	printh "" "	Hint: create alias linking to Drupal sub-site to launch targeted commands"
-	printh "fin alias remove dev" "	Delete ${yellow}dev${NC} alias"
+	printh "fin alias remove project1" "	Delete ${yellow}project1${NC} alias"
 }
 
 show_help_share ()
 {
 	echo
-	echo "Usage: fin share [options]"
+	echo "Share the project via public url generated with ngrok"
 
 	echo
-	echo "Share the project via public url generated with ngrok"
+	echo "Usage: share [options]"
 
 	echo
 	echo "Options:"
@@ -1727,10 +1754,10 @@ show_help_share ()
 show_help_config ()
 {
 	echo
-	echo "Usage: fin config [command]"
+	echo "Display, generate, or change project configuration"
 
 	echo
-	echo "Display, generate, or change project configuration"
+	echo "Usage: config [command]"
 
 	echo
 	echo "Commands:"
@@ -1762,12 +1789,12 @@ show_help_config ()
 show_help_cleanup ()
 {
 	echo
-	echo "Usage: fin cleanup [options]"
-
-	echo
 	echo "Remove unused docker images and orphaned containers to save disk space."
 	echo "Orphaned are containers which folders were deleted from the filesystem,"
 	echo "but their containers still linger in the Docker."
+
+	echo
+	echo "Usage: cleanup [options]"
 
 	echo
 	echo "Options:"
@@ -1777,10 +1804,10 @@ show_help_cleanup ()
 show_help_hosts ()
 {
 	echo
-	echo "Usage: fin hosts [command]"
+	echo "Add or remove lines to/from OS-dependent hosts file (e.g., /etc/hosts)"
 
 	echo
-	echo "Add or remove lines to/from OS-dependent hosts file (e.g., /etc/hosts)"
+	echo "Usage: hosts [command]"
 
 	echo
 	echo "Commands:"
@@ -1800,19 +1827,19 @@ show_help_hosts ()
 show_help_addon ()
 {
 	echo
-	echo "Usage: fin addon <command> <name>"
-
-	echo
 	echo "Docksal Addons management commands."
 	echo -e "See available addons in the Addons Repository ${yellow}https://github.com/docksal/addons${NC}"
 
 	echo
-	echo-green "Commands:"
+	echo "Usage: addon <command> <name>"
+
+	echo
+	echo "Commands:"
 	printh "install <name>" "Install addon"
 	printh "remove <name>" "Remove addon"
 
 	echo
-	echo-green "Examples:"
+	echo "Examples:"
 	printh "fin addon install solr" "Install solr addon to the current project"
 	printh "fin addon remove solr" "Uninstall solr addon from the current project"
 }
@@ -5297,6 +5324,15 @@ load_configuration ()
 	export COMPOSE_CONVERT_WINDOWS_PATHS=1
 }
 
+# Default init command. Initializes default config and starts containers
+init ()
+{
+	_confirm "Initialize a project in $(pwd)?"
+	config_generate
+	# Running like this forces configuration re-read
+	fin up
+}
+
 config_show ()
 {
 	check_docksal_environment
@@ -6033,8 +6069,62 @@ if [[ "$1" == "@"* ]]; then
 	if_failed_error "Could not navigate to directory linked by $1 alias"
 fi
 
-# Parse command line parameters
-case "$1" in
+## ----- RUN ADDON/COMMAND IF EXISTS -----
+
+# Will be used later in command parsing if no addon will be found
+command="$1"
+
+# When command is postfixed with exclamation mark, exclude addon overrides
+if [[ "$1" =~ .+! ]]; then
+	command="${1//!}"
+else
+	addon="$(get_addon_script $1)"
+	if [[ ! -f "$addon" ]]; then
+		# If no addon was found then try command
+		addon="$(get_command_script $1)"
+	fi
+fi
+
+if [[ -f "$addon" ]]; then
+	if [[ "$DOCKSAL_INTERNAL_COMMANDS_LIST" =~ " $1 " ]]; then
+		>&2 echo-warning "Built-in command '$1' was overridden. To force built-in execution run 'fin $1!'"
+	fi
+
+	export ADDON_ROOT=$(dirname "$addon")
+	load_global_configuration
+	[[ "$PROJECT_ROOT" != "" ]] && load_configuration
+
+	# If executable is not set, then fix it
+	if [[ ! -x "$addon" ]]; then
+		echo -e "${yellow}$addon${NC} is not set to be executable."
+		_confirm "Fix automatically?"
+		chmod +x "$addon"
+		if_failed "Could not make $addon executable"
+	fi
+
+	# If it has windows line endings, then fix it
+	fix_crlf_warning "$addon"
+
+	# Read host/cli execution settings
+	_exec_target=$(cat "$addon" | grep '^#:[ ]*exec_target[ ]*=' | sed -E "s/^#:[ ]*exec_target[ ]*=[ ]*//g")
+
+	shift
+	if [[ "$_exec_target" != "" ]]; then
+		# Replace host addon path with the matching path inside cli
+		# "\$PROJECT_ROOT" will be resolved in cli to /var/www
+		cli_addon_path="\$PROJECT_ROOT${addon/$PROJECT_ROOT/}"
+		# Escape spaces that are "spaces" and not parameter delimiters (i.e. param1 param2\ with\ spaces param3)
+		cmd="$cli_addon_path "$(printf " %q" "$@")
+		CONTAINER_NAME="$_exec_target" _exec "$cmd"
+	else
+		exec "$addon" "$@"
+	fi
+fi
+
+## ----- RUN FIN BUILT-IN COMMAND -----
+
+# TODO: [!] Update DOCKSAL_INTERNAL_COMMANDS_LIST variable every time you add/remove/change command here
+case "$command" in
 	bash_comp_words)
 		# no load_configuration
 		shift
@@ -6044,6 +6134,11 @@ case "$1" in
 		load_configuration
 		shift
 		docker-compose build "$@"
+		;;
+	init)
+		# no load configuration
+		shift
+		init "$@"
 		;;
 	start)
 		load_configuration
@@ -6524,44 +6619,6 @@ case "$1" in
 		addon "$@"
 		;;
 	*)
-		addon="$(get_addon_script $1)"
-		if [[ ! -f "$addon" ]]; then
-			# If no addon was found then try command
-			addon="$(get_command_script $1)"
-		# If no command was found either then show error
-			[[ ! -f "$addon" ]] &&
-				echo-yellow "Unknown command ${NC}$*${yellow}. See 'fin help' for list of available commands" &&
-				exit 1
-		else
-			export ADDON_ROOT=$(dirname "$addon")
-		fi
-
-		load_global_configuration
-		[[ "$PROJECT_ROOT" != "" ]] && load_configuration
-
-		# If executable is not set, then fix it
-		if [[ ! -x "$addon" ]]; then
-			echo -e "${yellow}$addon${NC} is not set to be executable."
-			_confirm "Fix automatically?"
-			chmod +x "$addon"
-			if_failed "Could not make $addon executable"
-		fi
-
-		# If it has windows line endings, then fix it
-		fix_crlf_warning "$addon"
-
-		# Read host/cli execution settings
-		_exec_target=$(cat "$addon" | grep '^#:[ ]*exec_target[ ]*=' | sed -E "s/^#:[ ]*exec_target[ ]*=[ ]*//g")
-
-		shift
-		if [[ "$_exec_target" != "" ]]; then
-			# Replace host addon path with the matching path inside cli
-			# "\$PROJECT_ROOT" will be resolved in cli to /var/www
-			cli_addon_path="\$PROJECT_ROOT${addon/$PROJECT_ROOT/}"
-			# Escape spaces that are "spaces" and not parameter delimiters (i.e. param1 param2\ with\ spaces param3)
-			cmd="$cli_addon_path "$(printf " %q" "$@")
-			CONTAINER_NAME="$_exec_target" _exec "$cmd"
-		else
-			exec "$addon" "$@"
-		fi
+		echo-yellow "Unknown command ${NC}$*${yellow}. See 'fin help' for list of available commands" &&
+		exit 1
 esac

--- a/docs/fin/custom-commands.md
+++ b/docs/fin/custom-commands.md
@@ -182,6 +182,22 @@ Commands are ran in the same exact way as normal except include the folder they 
 fin drupal/updb
 ```
 
+## Overriding built-in commands
+
+If your custom command or addon shares the name with one of built-in fin commands, 
+then your custom command will take precedence.
+
+For example if your command name is `build`, then it will override `fin build`. 
+Running `fin build` will now invoke your custom command, instead of built-in one.
+A warning will be shown to the user, that built-in was overridden.
+`fin help build` will now show help for your custom command, instead of built-in.
+You can suppress that warning in your scripts by redirecting stderr: `fin build 2>/dev/null`. 
+
+To force execution of the built-in that is overridden, user can put an
+exclamation mark after the command name: `fin build!`. 
+In this case built-in will be executed even if custom command with the same name exists.
+Same applies to the help:`fin help build!` will force built-in help.  
+
 ## More examples
 
 Check the commands directory (examples/.docksal/commands) located in the [Docksal project](https://github.com/docksal/docksal).

--- a/docs/fin/custom-commands.md
+++ b/docs/fin/custom-commands.md
@@ -182,14 +182,16 @@ Commands are ran in the same exact way as normal except include the folder they 
 fin drupal/updb
 ```
 
-## Overriding built-in commands
+## Overriding some built-in commands
 
-If your custom command or addon shares the name with one of built-in fin commands, 
+If your custom command or addon shares the name with one of the allowed built-in fin commands, 
 then your custom command will take precedence.
+
+Allowed for override are: `build composer drupal drush init platform terminus wp`
 
 For example if your command name is `build`, then it will override `fin build`. 
 Running `fin build` will now invoke your custom command, instead of built-in one.
-A warning will be shown to the user, that built-in was overridden.
+A warning will be shown to the user, that built-in was overridden (except for `init`).
 You can suppress that warning in your scripts by redirecting stderr: `fin build 2>/dev/null`. 
 `fin help build` will now show help for your custom command, instead of built-in.
 

--- a/docs/fin/custom-commands.md
+++ b/docs/fin/custom-commands.md
@@ -190,8 +190,8 @@ then your custom command will take precedence.
 For example if your command name is `build`, then it will override `fin build`. 
 Running `fin build` will now invoke your custom command, instead of built-in one.
 A warning will be shown to the user, that built-in was overridden.
-`fin help build` will now show help for your custom command, instead of built-in.
 You can suppress that warning in your scripts by redirecting stderr: `fin build 2>/dev/null`. 
+`fin help build` will now show help for your custom command, instead of built-in.
 
 To force execution of the built-in that is overridden, user can put an
 exclamation mark after the command name: `fin build!`. 

--- a/tests/smoke-test-general.bats
+++ b/tests/smoke-test-general.bats
@@ -78,7 +78,7 @@ EOF
 }
 
 @test "fin built-in override" {
-	# [[ $SKIP == 1 ]] && skip
+	[[ $SKIP == 1 ]] && skip
 
 	mkdir -p .docksal/commands
 	cat <<EOF > .docksal/commands/logs
@@ -94,7 +94,7 @@ EOF
 }
 
 @test "fin built-in override help" {
-	# [[ $SKIP == 1 ]] && skip
+	[[ $SKIP == 1 ]] && skip
 
 	run fin help logs
 	[[ "${output}" =~ "Overrides logs" ]]
@@ -102,7 +102,7 @@ EOF
 }
 
 @test "fin built-in override, force built-in" {
-	# [[ $SKIP == 1 ]] && skip
+	[[ $SKIP == 1 ]] && skip
 
 	run fin logs! web
 	[[ ! "${output}" =~ "Built-in command 'logs' was overridden" ]]
@@ -111,7 +111,7 @@ EOF
 }
 
 @test "fin built-in override, force built-in help" {
-	# [[ $SKIP == 1 ]] && skip
+	[[ $SKIP == 1 ]] && skip
 
 	run fin help logs!
 	[[ ! "${output}" =~ "Overrides logs" ]]

--- a/tests/smoke-test-general.bats
+++ b/tests/smoke-test-general.bats
@@ -110,7 +110,7 @@ EOF
 	unset output
 }
 
-@test "fin built-in override help" {
+@test "fin built-in override, force built-in help" {
 	# [[ $SKIP == 1 ]] && skip
 
 	run fin help logs!

--- a/tests/smoke-test-general.bats
+++ b/tests/smoke-test-general.bats
@@ -77,6 +77,48 @@ EOF
 	unset output
 }
 
+@test "fin built-in override" {
+	# [[ $SKIP == 1 ]] && skip
+
+	mkdir -p .docksal/commands
+	cat <<EOF > .docksal/commands/logs
+'#!/bin/bash
+## Overrides logs
+echo "Override logs"
+EOF
+	chmod +x .docksal/commands/logs
+
+	run fin logs
+	[[ "${output}" =~ "Built-in command 'logs' was overridden" ]]
+	unset output
+}
+
+@test "fin built-in override help" {
+	# [[ $SKIP == 1 ]] && skip
+
+	run fin help logs
+	[[ "${output}" =~ "Overrides logs" ]]
+	unset output
+}
+
+@test "fin built-in override, force built-in" {
+	# [[ $SKIP == 1 ]] && skip
+
+	run fin logs! web
+	[[ ! "${output}" =~ "Built-in command 'logs' was overridden" ]]
+	[[ "${output}" =~ "web_1" ]]
+	unset output
+}
+
+@test "fin built-in override help" {
+	# [[ $SKIP == 1 ]] && skip
+
+	run fin help logs!
+	[[ ! "${output}" =~ "Overrides logs" ]]
+	[[ "${output}" =~ "fin logs web" ]]
+	unset output
+}
+
 @test "fin stop" {
 	[[ $SKIP == 1 ]] && skip
 	

--- a/tests/smoke-test-general.bats
+++ b/tests/smoke-test-general.bats
@@ -77,36 +77,52 @@ EOF
 	unset output
 }
 
+@test "fin built-in override, illegal" {
+	[[ $SKIP == 1 ]] && skip
+
+	mkdir -p .docksal/commands
+	cat <<EOF > .docksal/commands/addons
+'#!/bin/bash
+## Overrides addon
+echo "Overridden addon! Alarm!"
+EOF
+	chmod +x .docksal/commands/addon
+
+	run fin logs
+	[[ "${output}" =~ "Overriding 'addon' built-in is not allowed" ]]
+	unset output
+}
+
 @test "fin built-in override" {
 	[[ $SKIP == 1 ]] && skip
 
 	mkdir -p .docksal/commands
-	cat <<EOF > .docksal/commands/logs
+	cat <<EOF > .docksal/commands/build
 '#!/bin/bash
-## Overrides logs
-echo "Override logs"
+## Overrides build
+echo "Override build"
 EOF
-	chmod +x .docksal/commands/logs
+	chmod +x .docksal/commands/build
 
 	run fin logs
-	[[ "${output}" =~ "Built-in command 'logs' was overridden" ]]
+	[[ "${output}" =~ "Built-in command 'build' was overridden" ]]
 	unset output
 }
 
 @test "fin built-in override help" {
 	[[ $SKIP == 1 ]] && skip
 
-	run fin help logs
-	[[ "${output}" =~ "Overrides logs" ]]
+	run fin help build
+	[[ "${output}" =~ "Overrides build" ]]
 	unset output
 }
 
 @test "fin built-in override, force built-in" {
 	[[ $SKIP == 1 ]] && skip
 
-	run fin logs! web
+	run fin build!
 	[[ ! "${output}" =~ "Built-in command 'logs' was overridden" ]]
-	[[ "${output}" =~ "web_1" ]]
+	[[ "${output}" =~ "cli uses an image, skipping" ]]
 	unset output
 }
 
@@ -114,7 +130,6 @@ EOF
 	[[ $SKIP == 1 ]] && skip
 
 	run fin help logs!
-	[[ ! "${output}" =~ "Overrides logs" ]]
 	[[ "${output}" =~ "fin logs web" ]]
 	unset output
 }


### PR DESCRIPTION
- Allow overriding: `build composer drupal drush init platform terminus wp`
- Shows warning when custom command/addon overrides built-in (except for init, no warning there)
- Ability to force run built-in by suffixing command with an exclamation mark (`fin build!`)
- Help improved to match docker-compose style

Closes #607 