### PR TITLE
Added docksal_ssh_agent to volumes for run-cli

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -4515,6 +4515,7 @@ run_cli ()
 		${winpty} docker run --rm -it \
 			--mount type=bind,src=$(pwd),dst=/var/www \
 			--mount ${MOUNT_HOME} \
+			-v docksal_ssh_agent:/.ssh-agent:ro \
 			-e SECRET_SSH_PRIVATE_KEY \
 			-e SECRET_ACAPI_EMAIL \
 			-e SECRET_ACAPI_KEY \
@@ -4531,6 +4532,7 @@ run_cli ()
 		docker run --rm \
 			--mount type=bind,src=$(pwd),dst=/var/www \
 			--mount ${MOUNT_HOME} \
+			-v docksal_ssh_agent:/.ssh-agent:ro \
 			-e SECRET_SSH_PRIVATE_KEY \
 			-e SECRET_ACAPI_EMAIL \
 			-e SECRET_ACAPI_KEY \

--- a/bin/fin
+++ b/bin/fin
@@ -4515,7 +4515,7 @@ run_cli ()
 		${winpty} docker run --rm -it \
 			--mount type=bind,src=$(pwd),dst=/var/www \
 			--mount ${MOUNT_HOME} \
-			-v docksal_ssh_agent:/.ssh-agent:ro \
+			--mount type=volume,src=docksal_ssh_agent,dst=/.ssh-agent,readonly \
 			-e SECRET_SSH_PRIVATE_KEY \
 			-e SECRET_ACAPI_EMAIL \
 			-e SECRET_ACAPI_KEY \
@@ -4532,7 +4532,7 @@ run_cli ()
 		docker run --rm \
 			--mount type=bind,src=$(pwd),dst=/var/www \
 			--mount ${MOUNT_HOME} \
-			-v docksal_ssh_agent:/.ssh-agent:ro \
+			--mount type=volume,src=docksal_ssh_agent,dst=/.ssh-agent,readonly \
 			-e SECRET_SSH_PRIVATE_KEY \
 			-e SECRET_ACAPI_EMAIL \
 			-e SECRET_ACAPI_KEY \

--- a/tests/smoke-test-general.bats
+++ b/tests/smoke-test-general.bats
@@ -203,6 +203,13 @@ EOF
 	[[ "$output" == "$(id -u):$(id -g)" ]]
 	unset output
 
+	# check loads ssh keys
+	ssh-keygen -f $HOME/.ssh/run_cli_test -t rsa -N ''
+	fin ssh-add run_cli_test
+	run fin rc ssh-add -l
+	echo $output | grep "2048 SHA256:(.*) /root/.ssh/run_cli_test (RSA)"
+	unset output
+
 	# check to make sure custom variables are passed into container
 	run fin rc -T -e TEST_VAR="TEST VARIABLES" "echo \$TEST_VAR"
 	[[ "$output" == "TEST VARIABLES" ]]

--- a/tests/smoke-test-general.bats
+++ b/tests/smoke-test-general.bats
@@ -207,7 +207,7 @@ EOF
 	ssh-keygen -f $HOME/.ssh/run_cli_test -t rsa -N ''
 	fin ssh-add run_cli_test
 	run fin rc ssh-add -l
-	echo $output | grep "2048 SHA256:(.*) /root/.ssh/run_cli_test (RSA)"
+	echo $output | grep "2048 SHA256:.* /root/.ssh/run_cli_test (RSA)"
 	unset output
 
 	# check to make sure custom variables are passed into container


### PR DESCRIPTION
Currently when running `fin run-cli` it doesn't mount the ssh-agent therefore if you have ssh keys that are used for private git repos then they aren't included and you are prompted with a password for 

```
Enter passphrase for key '/home/docker/.ssh/id_rsa':
```

This is important if we want to try and convince people to use `run-cli` for things like using `terminus` or `npm` other mechanisms that require public key authentication.