### PR TITLE
Document uuid-runtime dependency for Linux systems

### DIFF
--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -113,6 +113,7 @@ and Fedora with derivatives are supported out of the box with automatic installa
 
     Check that you have installed and configured
     - curl
+    - uuid runtime utilities (`uuid-runtime` package)   
     - sudo
     
 1. Open Terminal and run


### PR DESCRIPTION
Otherwise, fin throws an error uuidgen: command not found

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docksal/docksal/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Write a short summary that describes the changes in this pull request:
-->
