### PR TITLE
Named db_data volume for MySQL/PostreSQL

### DIFF
--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -32,6 +32,7 @@ services:
       - "${MYSQL_PORT_MAPPING:-3306}"
     volumes:
       - project_root:/var/www:ro,nocopy  # Project root volume (read-only)
+      - db_data:/var/lib/mysql  # Database data volume
     environment:
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-root}
       - MYSQL_USER=${MYSQL_USER:-user}
@@ -49,6 +50,7 @@ services:
       - "${MYSQL_PORT_MAPPING:-3306}"
     volumes:
       - project_root:/var/www:ro,nocopy  # Project root volume (read-only)
+      - db_data:/var/lib/mysql  # Database data volume
     environment:
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-root}
       - MYSQL_USER=${MYSQL_USER:-user}
@@ -68,6 +70,9 @@ services:
     image: ${DB_IMAGE:-postgres:9.6-alpine}
     ports:
       - "${PGSQL_PORT_MAPPING:-5432}"
+    volumes:
+      - project_root:/var/www:ro,nocopy  # Project root volume (read-only)
+      - db_data:/var/lib/postgresql/data  # Database data volume
     environment:
       - POSTGRES_DB=${POSTGRES_DB:-default}
       - POSTGRES_USER=${POSTGRES_USER:-user}

--- a/stacks/volumes-bind.yml
+++ b/stacks/volumes-bind.yml
@@ -4,11 +4,12 @@
 version: "2.1"
 
 volumes:
-  project_root:  # Project root volume (bind)
+  project_root:  # Project root volume (bind mount)
     driver: local
     driver_opts:
       type: none
       device: ${PROJECT_ROOT}
       o: bind
+  db_data:  # Database data volume
   docksal_ssh_agent:  # Shared ssh-agent volume
     external: true

--- a/stacks/volumes-nfs.yml
+++ b/stacks/volumes-nfs.yml
@@ -12,5 +12,6 @@ volumes:
       type: nfs
       device: :${PROJECT_ROOT}
       o: addr=${DOCKSAL_HOST_IP},vers=3,nolock,noacl,nocto,noatime,nodiratime,tcp,actimeo=1
+  db_data:  # Database data volume (bind)
   docksal_ssh_agent:  # Shared ssh-agent volume
     external: true

--- a/stacks/volumes-unison.yml
+++ b/stacks/volumes-unison.yml
@@ -6,7 +6,8 @@
 version: "2.1"
 
 volumes:
-  project_root:
+  project_root: # Project root volume
+  db_data:  # Database data volume
   # Shared ssh-agent volume
   docksal_ssh_agent:
     external: true


### PR DESCRIPTION
This gives database data volumes a name - `db_data`. This way they are easy to identify in the list of volumes (docker volume ls). E.g., `drupal8_db_data` vs `dd035157ff4f8ab90e60ece910c335c561caae6325382dc31435de56c0380346`
