### PR TITLE
Updated phpcs command

### DIFF
--- a/examples/.docksal/commands/phpcs
+++ b/examples/.docksal/commands/phpcs
@@ -22,7 +22,7 @@ if [[ "$1" == "" ]]; then
 fi
 
 fin run phpcs \
-	--standard=Drupal -n \
+	--standard="Drupal,DrupalPractice" -n \
 	--extensions="php,module,inc,install,test,profile,theme" \
 	--ignore="*.features.*,*.pages*.inc" \
 	"$1"


### PR DESCRIPTION
Updated phpcs command to include coding standards of DrupalPractice and Drupal standard.

Closes #724