### PR TITLE
Fix help for project/global commands on Ubuntu 18.04.

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -1297,7 +1297,7 @@ show_help_list_commands_in_help ()
 	fi
 
 	local executable="-executable"
-	[[ is_mac ]] && executable="-perm +100"
+	is_mac && executable="-perm +100"
 
 	local addons_list=$(find "$addons_path" -type f ${executable} 2>/dev/null | sort -n 2>/dev/null)
 	if [[ "$addons_list" != "" ]]; then


### PR DESCRIPTION
`fin help` console output
Before:
![image](https://user-images.githubusercontent.com/3902392/43519722-363eac2a-9599-11e8-9f6c-15e28914a6da.png)

After:
![image](https://user-images.githubusercontent.com/3902392/43519700-280b5dec-9599-11e8-88cd-0b1e120e7736.png)
