### PR TITLE
Fix detecting first nameserver in resolv.conf

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -3315,6 +3315,7 @@ detect_dns ()
 				if [[ "$server" =~ [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} ]] &&
 					[[ "$server" != "$DOCKSAL_IP" ]]; then
 					DOCKSAL_DNS_UPSTREAM="$server"
+					break
 				fi
 			done
 		else


### PR DESCRIPTION
The comments said that the first suitable nameserver is used, but it actually took the _last_ suitable nameserver in `resolv.conf`. This PR fixes that behavior.