### PR TITLE
Fix wrong name of some blackfire env variables

### DIFF
--- a/docs/tools/blackfire.md
+++ b/docs/tools/blackfire.md
@@ -15,8 +15,8 @@ With this option, the API keys are stored on your host and not exposed in the pr
 ```bash
 fin config set --global SECRET_BLACKFIRE_CLIENT_ID=<blackfire-client-id>
 fin config set --global SECRET_BLACKFIRE_CLIENT_TOKEN=<blackfire-client-token>
-fin config set --global SECRET_BLACKFIRE_SERVER_ID=<blackfire-server-id>
-fin config set --global SECRET_BLACKFIRE_SERVER_TOKEN=<blackfire-server-token>
+fin config set --global BLACKFIRE_SERVER_ID=<blackfire-server-id>
+fin config set --global BLACKFIRE_SERVER_TOKEN=<blackfire-server-token>
 ```
 
 Note: The values will be stored in `$HOME/.docksal/docksal.env` on your host.
@@ -30,8 +30,8 @@ With this option, the API keys are stored in the project's codebase.
 ```bash
 fin config set SECRET_BLACKFIRE_CLIENT_ID=<blackfire-client-id>
 fin config set SECRET_BLACKFIRE_CLIENT_TOKEN=<blackfire-client-token>
-fin config set SECRET_BLACKFIRE_SERVER_ID=<blackfire-server-id>
-fin config set SECRET_BLACKFIRE_SERVER_TOKEN=<blackfire-server-token>
+fin config set BLACKFIRE_SERVER_ID=<blackfire-server-id>
+fin config set BLACKFIRE_SERVER_TOKEN=<blackfire-server-token>
 ```
 
 Note: The values will be stored in `.docksal/docksal.env` in the project's codebase.


### PR DESCRIPTION
Hola 👋

if we check https://github.com/docksal/docksal/blob/develop/stacks/services.yml

```yml
 # Blackfire
  blackfire:
    image: blackfire/blackfire
    environment:
      - BLACKFIRE_SERVER_ID
      - BLACKFIRE_SERVER_TOKEN
```

we can notice that variables are 
`BLACKFIRE_SERVER_ID` and `BLACKFIRE_SERVER_TOKEN` instead of their `SECRET_` version.

so, there are 2 options:
1. fix docs (**done** in this PR)
2. fix services.yml