### PR TITLE
Handle Blackfire secrets as a special case. Closes #783

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -4608,8 +4608,8 @@ run_cli ()
 			--mount ${MOUNT_HOME} \
 			--mount "$MOUNT_DOCKSAL_HOME" \
 			--mount type=volume,src=docksal_ssh_agent,dst=/.ssh-agent,readonly \
-			-e SECRET_BLACKFIRE_CLIENT_ID \
-			-e SECRET_BLACKFIRE_CLIENT_TOKEN \
+			-e BLACKFIRE_CLIENT_ID \
+			-e BLACKFIRE_CLIENT_TOKEN \
 			-e SECRET_SSH_PRIVATE_KEY \
 			-e SECRET_ACAPI_EMAIL \
 			-e SECRET_ACAPI_KEY \
@@ -4630,8 +4630,8 @@ run_cli ()
 			--mount ${MOUNT_HOME} \
 			--mount "$MOUNT_DOCKSAL_HOME" \
 			--mount type=volume,src=docksal_ssh_agent,dst=/.ssh-agent,readonly \
-			-e SECRET_BLACKFIRE_CLIENT_ID \
-			-e SECRET_BLACKFIRE_CLIENT_TOKEN \
+			-e BLACKFIRE_CLIENT_ID \
+			-e BLACKFIRE_CLIENT_TOKEN \
 			-e SECRET_SSH_PRIVATE_KEY \
 			-e SECRET_ACAPI_EMAIL \
 			-e SECRET_ACAPI_KEY \
@@ -5430,10 +5430,19 @@ config_show ()
 	if [[ "$showsecrets" != "showsecrets" ]]; then
 		# Any env variable, that starts with the "SECRET_" prefix, is rewritten to only show beginning and end
 		eval 'secrets=(${!SECRET_@})'
+
+		# Special case to handle BLACKFIRE variables as secrets
+		# TODO: figure out a way to handle this better
+		# See: https://github.com/docksal/docksal/pull/783#issuecomment-415080823
+		secrets+=('BLACKFIRE_SERVER_ID')
+		secrets+=('BLACKFIRE_SERVER_TOKEN')
+		secrets+=('BLACKFIRE_CLIENT_ID')
+		secrets+=('BLACKFIRE_CLIENT_TOKEN')
+
 		for secret in "${secrets[@]}"
 		do
 			local secret_value=${!secret}
-			# Define how many characters to show on the beginning and the ned
+			# Define how many characters to show on the beginning and the end
 			local cut_length;
 			if [[ ${#secret_value} < 10 ]]; then
 				cut_length=3;

--- a/docs/tools/blackfire.md
+++ b/docs/tools/blackfire.md
@@ -13,10 +13,10 @@ Open [Blackfire Account Credentials](https://blackfire.io/my/settings/credential
 With this option, the API keys are stored on your host and not exposed in the project's codebase.
 
 ```bash
-fin config set --global SECRET_BLACKFIRE_CLIENT_ID=<blackfire-client-id>
-fin config set --global SECRET_BLACKFIRE_CLIENT_TOKEN=<blackfire-client-token>
-fin config set --global SECRET_BLACKFIRE_SERVER_ID=<blackfire-server-id>
-fin config set --global SECRET_BLACKFIRE_SERVER_TOKEN=<blackfire-server-token>
+fin config set --global BLACKFIRE_CLIENT_ID=<blackfire-client-id>
+fin config set --global BLACKFIRE_CLIENT_TOKEN=<blackfire-client-token>
+fin config set --global BLACKFIRE_SERVER_ID=<blackfire-server-id>
+fin config set --global BLACKFIRE_SERVER_TOKEN=<blackfire-server-token>
 ```
 
 Note: The values will be stored in `$HOME/.docksal/docksal.env` on your host.
@@ -28,10 +28,10 @@ Note: The values will be stored in `$HOME/.docksal/docksal.env` on your host.
 With this option, the API keys are stored in the project's codebase. 
 
 ```bash
-fin config set SECRET_BLACKFIRE_CLIENT_ID=<blackfire-client-id>
-fin config set SECRET_BLACKFIRE_CLIENT_TOKEN=<blackfire-client-token>
-fin config set SECRET_BLACKFIRE_SERVER_ID=<blackfire-server-id>
-fin config set SECRET_BLACKFIRE_SERVER_TOKEN=<blackfire-server-token>
+fin config set BLACKFIRE_CLIENT_ID=<blackfire-client-id>
+fin config set BLACKFIRE_CLIENT_TOKEN=<blackfire-client-token>
+fin config set BLACKFIRE_SERVER_ID=<blackfire-server-id>
+fin config set BLACKFIRE_SERVER_TOKEN=<blackfire-server-token>
 ```
 
 Note: The values will be stored in `.docksal/docksal.env` in the project's codebase.

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -98,8 +98,8 @@ services:
       - VIRTUAL_HOST
       - XDEBUG_ENABLED=${XDEBUG_ENABLED:-0}
       - XDEBUG_CONFIG=remote_connect_back=0 remote_host=${DOCKSAL_HOST_IP}  # Point xdebug to the host IP
-      - SECRET_BLACKFIRE_CLIENT_ID
-      - SECRET_BLACKFIRE_CLIENT_TOKEN
+      - BLACKFIRE_CLIENT_ID
+      - BLACKFIRE_CLIENT_TOKEN
       - SECRET_SSH_PRIVATE_KEY
       - SECRET_ACAPI_EMAIL
       - SECRET_ACAPI_KEY


### PR DESCRIPTION
Treat Blackfire keys as secrets without using the `SECRET_` prefix. See https://github.com/docksal/docksal/pull/783#issuecomment-415080823 for details.

This replaces #783.