### PR TITLE
Drop volume when resetting db container

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -1475,8 +1475,7 @@ show_help_project() {
 	echo
 	printh "status" "List project services (alias: fin ps)"
 	printh "restart" "Restart project services (alias: fin restart)"
-	printh "reset [service]" "Recreate all or specified project services, their containers and named volumes"
-	printh "" "Changes to home directory in \`cli\` are preserved."
+	printh "reset [service]" "Recreate all or specified project services, their containers and volumes"
 	echo
 	printh "remove [option] [service]" "Remove all project services, networks and all their volumes, or specified services only"
 	printh "    rm [option] [service]" ""

--- a/bin/fin
+++ b/bin/fin
@@ -1055,10 +1055,11 @@ _remove_containers ()
 		# Removing requested containers only
 		docker-compose kill "$@" &&
 			docker-compose rm -vf "$@" &&
-			# For cli, we have to manually drop the home volume, since named volumes are omitted by the "-v" option below
+			# For cli and db, we have to manually drop the volumes, since named volumes are omitted by the "-v" option above
 			{
 				for i in "$@"; do
 					[[ "$i" == "cli" ]] && docker volume rm -f "${COMPOSE_PROJECT_NAME_SAFE}_cli_home" >/dev/null
+					[[ "$i" == "db" ]] && docker volume rm -f "${COMPOSE_PROJECT_NAME_SAFE}_db_data" >/dev/null
 				done
 			}
 	fi


### PR DESCRIPTION
This PR changes the behavior of the command `fin reset db`. The usage string in the command line says `fin reset` does this:

    reset [service]            Recreate all or specified project services, their containers and named volumes
                               Changes to home directory in `cli` are preserved.

So I expect `fin reset db` to throw away the database volumes. Instead, what it currently does is keep the volume so the only easy way to get rid of them is to reset your entire project. The reason it works this way this is that it used `docker-compose rm -v` to remove the volumes, but the DB volume is not anonymous.

I've interpreted this to be a bug and fixed it in this pull request. In this PR, `fin reset db` does what it previously did, and also removes the database volume.

If there are any questions or remarks, please go ahead! :)