### PR TITLE
Skip keys quietly

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -3183,8 +3183,6 @@ ssh_add ()
 			if ! _ssh_key_exists ${ssh_key_path}; then
 				# Call ssh-add in the ssh-agent container
 				_ssh_add ${ssh_key_name}
-			else
-				echo "Key '${ssh_key_name}' already loaded in the agent. Skipping."
 			fi
 		else
 			echo-error "Key '${ssh_key_path}' does not exist"


### PR DESCRIPTION
@lmakarov the reason for the change is that it inundates with this message far too often. With every up, restart and reset. And it is especially inundating when you have several keys.

```bash
§ fin up
Key 'id_rsa' already loaded in the agent. Skipping.
Key 'id_dsa' already loaded in the agent. Skipping.
Starting services...
vision_us_cli_1 is up-to-date
vision_us_db_1 is up-to-date
vision_us_web_1 is up-to-date
Virtual Host: http://vision-us.docksal
```

I do not see much harm in removing this message, since I genuinely believe that in majority of cases users are smart enough to understand that if key is already added then it will not be re-added. Basically we sacrifice those several edge cases when users would not understand this to make using far more used commands (like `up`) much friendlier.

If you're ok with this proposition, then approve/merge. If you still want to have the message despite its inundating nature, just decline and close.

p.s. In the next version (1.12) I would return this message, but make `--quiet` switch for `ssh-add` which would be used when no such messaging required.