### PR TITLE
sets default SYNC_PREFER to newer to prefer most recently updated files

### DIFF
--- a/stacks/volumes-unison.yml
+++ b/stacks/volumes-unison.yml
@@ -22,6 +22,7 @@ services:
       - project_root:/destination
     environment:
       - SYNC_DESTINATION=/destination
+      - SYNC_PREFER=newer
       - SYNC_MAX_INOTIFY_WATCHES=524288
       - SYNC_VERBOSE=1
       - SYNC_NODELETE_SOURCE=0


### PR DESCRIPTION
Updates the volumes-unison settings to default to SYNC_PREFER=newer

This sets the option to sync the most recently changed files when a change conflict occurs.

fixes docksal/unison/issues/2