### PR TITLE
Remove an ability for global addons to use run-cli

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -4683,9 +4683,6 @@ run_cli ()
 		MOUNT_HOME="dst=/home/docker"
 	fi
 
-	# Allows run-cli to run global addons
-	local MOUNT_DOCKSAL_HOME="type=bind,src=$CONFIG_DIR,dst=$CONFIG_DIR"
-
 	# Address an edge case when run-cli is run in the home folder (/root) on PWD/Katacoda
 	# See https://github.com/docksal/docksal/issues/661
 	if [[ "$(pwd)" == "$HOME" ]] && (is_pwd || is_katacoda); then
@@ -4699,7 +4696,6 @@ run_cli ()
 		${winpty} docker run --rm -it \
 			--mount type=bind,src=$(pwd),dst=/var/www \
 			--mount ${MOUNT_HOME} \
-			--mount "$MOUNT_DOCKSAL_HOME" \
 			--mount type=volume,src=docksal_ssh_agent,dst=/.ssh-agent,readonly \
 			-e BLACKFIRE_CLIENT_ID \
 			-e BLACKFIRE_CLIENT_TOKEN \
@@ -4721,7 +4717,6 @@ run_cli ()
 		docker run --rm \
 			--mount type=bind,src=$(pwd),dst=/var/www \
 			--mount ${MOUNT_HOME} \
-			--mount "$MOUNT_DOCKSAL_HOME" \
 			--mount type=volume,src=docksal_ssh_agent,dst=/.ssh-agent,readonly \
 			-e BLACKFIRE_CLIENT_ID \
 			-e BLACKFIRE_CLIENT_TOKEN \

--- a/tests/general.bats
+++ b/tests/general.bats
@@ -263,11 +263,11 @@ EOF
 	unset output
 
 	# Check exec_target = run-cli
-	mkdir -p $HOME/.docksal/commands
-	echo "#!/bin/bash" > $HOME/.docksal/commands/target_cli
-	echo "#: exec_target = run-cli" >> $HOME/.docksal/commands/target_cli
-	echo "echo 'Running from run-cli'" >> $HOME/.docksal/commands/target_cli
-	chmod +x $HOME/.docksal/commands/target_cli
+	mkdir -p .docksal/commands
+	echo "#!/bin/bash" > .docksal/commands/target_cli
+	echo "#: exec_target = run-cli" >> .docksal/commands/target_cli
+	echo "echo 'Running from run-cli'" >> .docksal/commands/target_cli
+	chmod +x .docksal/commands/target_cli
 	run fin target_cli
 	[[ "$output" =~ "Running from run-cli" ]]
 	unset output


### PR DESCRIPTION
Remove an ability for global addons to use run-cli because we cannot guarantee that `$HOME/.docksal directory` is mapped inside Docker. (Fixes #771)
