### PR TITLE
Remove an ability for addons to use target run-cli

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -4693,9 +4693,6 @@ run_cli ()
 		MOUNT_HOME="dst=/home/docker"
 	fi
 
-	# Allows run-cli to run global addons
-	local MOUNT_DOCKSAL_HOME="type=bind,src=$CONFIG_DIR,dst=$CONFIG_DIR"
-
 	# Address an edge case when run-cli is run in the home folder (/root) on PWD/Katacoda
 	# See https://github.com/docksal/docksal/issues/661
 	if [[ "$(pwd)" == "$HOME" ]] && (is_pwd || is_katacoda); then
@@ -4709,7 +4706,6 @@ run_cli ()
 		${winpty} docker run --rm -it \
 			--mount type=bind,src=$(pwd),dst=/var/www \
 			--mount ${MOUNT_HOME} \
-			--mount "$MOUNT_DOCKSAL_HOME" \
 			--mount type=volume,src=docksal_ssh_agent,dst=/.ssh-agent,readonly \
 			-e BLACKFIRE_CLIENT_ID \
 			-e BLACKFIRE_CLIENT_TOKEN \
@@ -4731,7 +4727,6 @@ run_cli ()
 		docker run --rm \
 			--mount type=bind,src=$(pwd),dst=/var/www \
 			--mount ${MOUNT_HOME} \
-			--mount "$MOUNT_DOCKSAL_HOME" \
 			--mount type=volume,src=docksal_ssh_agent,dst=/.ssh-agent,readonly \
 			-e BLACKFIRE_CLIENT_ID \
 			-e BLACKFIRE_CLIENT_TOKEN \
@@ -6126,11 +6121,7 @@ addon_execute ()
 	_exec_target=$(cat "$addon" | grep '^#:[ ]*exec_target[ ]*=' | sed -E "s/^#:[ ]*exec_target[ ]*=[ ]*//g")
 
 	shift
-	if [[ "$_exec_target" == "run-cli" ]]; then
-		cmd="$addon"
-		[[ "$@" != "" ]] && cmd="$addon "$(printf " %q" "$@")
-		run_cli "$cmd"
-	elif [[ "$_exec_target" != "" ]]; then
+	if [[ "$_exec_target" != "" ]]; then
 		# Replace host addon path with the matching path inside cli
 		# "\$PROJECT_ROOT" will be resolved in cli to /var/www
 		cli_addon_path="\$PROJECT_ROOT${addon/$PROJECT_ROOT/}"

--- a/docs/content/fin/custom-commands.md
+++ b/docs/content/fin/custom-commands.md
@@ -168,18 +168,6 @@ services:
       - VIRTUAL_HOST
 ```
 
-## Executing commands inside standalone ad-hoc cli container
-
-This allows you to define a global command that will execute in a standalone cli container spawned on demand.
-It is like running `fin run-cli ...`.
-This will allow you to create a command in node or php that would not actually require them to be installed locally.
-
-In your script define:
-
-```
-#: exec_target = run-cli
-```
-
 ## Grouping Commands
 
 Docksal allows for commands to be grouped together within folders. This is particulary useful when creating a toolkit to share with other developers. Commands can be grouped within the Global Scope `~/.docksal/commands` and on a per project basis.

--- a/tests/general.bats
+++ b/tests/general.bats
@@ -261,16 +261,6 @@ EOF
 	run fin rc --cleanup -T ls /home/docker/test
 	[[ "$output" == "ls: cannot access '/home/docker/test': No such file or directory" ]]
 	unset output
-
-	# Check exec_target = run-cli
-	mkdir -p $HOME/.docksal/commands
-	echo "#!/bin/bash" > $HOME/.docksal/commands/target_cli
-	echo "#: exec_target = run-cli" >> $HOME/.docksal/commands/target_cli
-	echo "echo 'Running from run-cli'" >> $HOME/.docksal/commands/target_cli
-	chmod +x $HOME/.docksal/commands/target_cli
-	run fin target_cli
-	[[ "$output" =~ "Running from run-cli" ]]
-	unset output
 }
 
 @test "fin rm -f" {


### PR DESCRIPTION
Remove an ability for addons to use target run-cli. (Fixes #771)

+ Also sync Unison changes from develop