### PR TITLE
Make ngrok args work with config files.

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -5167,7 +5167,7 @@ ngrok_share ()
 		--link ${container_name} \
 		--name ${ngrok_container_name} \
 		wernight/ngrok \
-		sh -c "${ARGS} ${container_name}.${network}:${NGROK_PORT}"
+		sh -c "${ARGS}" ${container_name}.${network}:${NGROK_PORT}
 }
 
 # Print information required for issue diagnostics


### PR DESCRIPTION
The way the args are parsed when using the config file causes a syntax error. The following one line fixes it.
(Probably should have someone test it with their own configuration to make sure it doesn't break the other methods)