### PR TITLE
Fixed "fin ssh-key add <key-name>" compatibility with Bash 3. Fixes #855

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -3173,7 +3173,7 @@ ssh_key ()
 	# If we have a key name as the argument, add it to the list of keys to load
 	if [[ "${2}" != "" ]]; then
 		if [[ -f "${ssh_path}/${2}" ]]; then
-			local SECRET_SSH_KEY_${2^^}=${2}
+			local SECRET_SSH_KEY_${2}="${2}"
 		else
 			echo-error "Key '"${ssh_path}/${2}"' does not exist"
 		fi


### PR DESCRIPTION
`${var^^}` transformations are available in Bash 4, while macOS still ships with Bash 3. Doh...
Removed uppercase transformation in `fin ssh-key add`. This was not even necessary.

Fixes #855