### PR TITLE
Updated README and Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,7 +1,7 @@
-DOCKER       = docker
-HUGO_VERSION = 0.50
-DOCKER_IMAGE = jojomi/hugo:$(HUGO_VERSION)
-DOCKER_RUN   = $(DOCKER) run --rm --interactive --tty --volume $(PWD):/src
+DOCKER       ?= docker
+HUGO_VERSION ?= latest
+DOCKER_IMAGE ?= jojomi/hugo:$(HUGO_VERSION)
+DOCKER_RUN   ?= $(DOCKER) run --rm --interactive --tty --volume $(PWD):/src
 
 .PHONY: all build build-preview help serve test
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,5 +1,5 @@
 DOCKER       ?= docker
-HUGO_VERSION ?= latest
+HUGO_VERSION ?= 0.50
 DOCKER_IMAGE ?= jojomi/hugo:$(HUGO_VERSION)
 DOCKER_RUN   ?= $(DOCKER) run --rm --interactive --tty --volume $(PWD):/src
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,13 +20,13 @@ For more info, see [Directory Structure](https://gohugo.io/getting-started/direc
 
 ## Building
 
-Before starting you must install the [Learn Theme](https://github.com/matcornic/hugo-theme-learn). This can be done by running `git submodule update` within the local repository.
+Before starting, you must install the [Learn Theme](https://github.com/matcornic/hugo-theme-learn). This can be done by running `git submodule update` within the local repository.
 
 Building and previewing docs is done via a docker container.
 
 Run `make serve` and point your browser to http://localhost:1313 to open the site.
 
-If you do not have Docker installed natively and are using VirtualBox you can run using the `fin` commmand. When accessing you would use the IP address assigned to your VirtualBox machine (ie. http://192.168.64.100:1313).
+If you do not have Docker installed natively and are using VirtualBox, you can run using the `fin` commmand. When accessing, you would use the IP address assigned to your VirtualBox machine (i.e., http://192.168.64.100:1313).
 
 ```bash
 DOCKER="fin docker" make serve

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ Building and previewing docs is done via a docker container.
 
 Run `make serve` and point your browser to http://localhost:1313 to open the site.
 
-If you do not have Docker installed natively and are using VirtualBox you can run using the `fin` commmand.
+If you do not have Docker installed natively and are using VirtualBox you can run using the `fin` commmand. When accessing you would use the IP address assigned to your VirtualBox machine (ie. http://192.168.64.100:1313).
 
 ```bash
 DOCKER="fin docker" make serve

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,17 +28,9 @@ To have submodules pulled automatically in the future set this within your globa
 git config --global submodule.recurse true
 ```
 
-Building and previewing docs is done via a docker container.
+Run `make serve` and point your browser to http://localhost:1313 to open the site. Building is done via a docker container. Docker binary is expected in $PATH (see below if you use Docker via VirtualBox).
 
-Run `make serve` and point your browser to http://localhost:1313 to open the site.
-
-If you do not have Docker installed natively and are using VirtualBox, you can run using the `fin` commmand. When accessing, you would use the IP address assigned to your VirtualBox machine (i.e., http://192.168.64.100:1313).
-
-```bash
-DOCKER="fin docker" make serve
-```
-
-Available `make` commands (`make` required):
+Other available `make` commands (`make` required):
 
 ```bash
 $ make
@@ -51,3 +43,13 @@ serve                Boot the development server
 ```
 
 It is also possible to use a locally installed `hugo` binary. `hugo` version must match the version defined in `Makefile`.
+
+### Building without Docker binary on local
+
+If you use Docksal via VirtualBox, then `fin docker` command can be used as a replacement for Docker binary:
+
+```bash
+DOCKER="fin docker" make serve
+```
+
+In this case to access the site you would use the IP address assigned to your VirtualBox machine (i.e., http://192.168.64.100:1313).

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,13 @@ For more info, see [Directory Structure](https://gohugo.io/getting-started/direc
 
 ## Building
 
-Before starting, you must install the [Learn Theme](https://github.com/matcornic/hugo-theme-learn). This can be done by running `git submodule update` within the local repository.
+Before starting, you must install the [Learn Theme](https://github.com/docksal/hugo-theme-learn). This can be done by running `git submodule update` within the local repository.
+
+To have submodules pulled automatically in the future set this within your global git configuration.
+
+```
+git config --global submodule.recurse true
+```
 
 Building and previewing docs is done via a docker container.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,9 +20,17 @@ For more info, see [Directory Structure](https://gohugo.io/getting-started/direc
 
 ## Building
 
+Before starting you must install the [Learn Theme](https://github.com/matcornic/hugo-theme-learn). This can be done by running `git submodule update` within the local repository.
+
 Building and previewing docs is done via a docker container.
 
 Run `make serve` and point your browser to http://localhost:1313 to open the site.
+
+If you do not have Docker installed natively and are using VirtualBox you can run using the `fin` commmand.
+
+```bash
+DOCKER="fin docker" make serve
+```
 
 Available `make` commands (`make` required):
 

--- a/docs/content/core/volumes.md
+++ b/docs/content/core/volumes.md
@@ -78,7 +78,7 @@ volumes:
     external: true
 ```
 
-In the example above, `project_root` and `docksal_ssh_agent` are "named volumes". The first one is a project level one,
+In the example above, `project_root` and `docksal_ssh_agent` are "named volumes." The first one is a project level one,
 while the second one is a global volume and is used by all projects.
 
 See [stacks/volumes-bind.yml](https://github.com/docksal/docksal/blob/master/stacks/volumes-bind.yml).


### PR DESCRIPTION
Included information for people who are using boot2docker (VirtualBox).

Was having issues learning how to build the docs locally when I found the Make file references docker directly. I am working with Boot2Docker. Made all of the commands set to defaults if not defined. Additionally, added info on committing updates to the docs.
