### PR TITLE
Remove COLUMNS/LINES workaround

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -4624,14 +4624,13 @@ _exec ()
 
 	# Enter project containers
 	# Use the docker user in cli (-u docker) instead of root (default user).
-	# COLUMNS and LINES have to be passed to workaround a bug in Docker. See https://github.com/moby/moby/issues/35407#issuecomment-355753176
 	if is_tty && [[ "$no_tty" != true ]]; then
 		# interactive
 		# (exit \$?) is a hack to return correct exit codes when docker exec is run with tty (-t).
-		${winpty} docker exec -e COLUMNS -e LINES -it ${container_user} ${container_id} bash -ilc "$cmd; (exit \$?)"
+		${winpty} docker exec -it ${container_user} ${container_id} bash -ilc "$cmd; (exit \$?)"
 	else
 		# non-interactive
-		docker exec -e COLUMNS -e LINES ${container_user} ${container_id} bash -lc "$cmd"
+		docker exec ${container_user} ${container_id} bash -lc "$cmd"
 	fi
 	# ------------------------------------------------ #
 }
@@ -4736,7 +4735,6 @@ run_cli ()
 	if is_tty && [[ "$no_tty" != true ]]; then
 		# interactive
 		# (exit \$?) is a hack to return correct exit codes when docker exec is run with tty (-t).
-		# COLUMNS and LINES have to be passed to workaround a bug in Docker. See https://github.com/moby/moby/issues/35407#issuecomment-355753176
 		${winpty} docker run --rm -it \
 			--mount type=bind,src=$(pwd),dst=/var/www \
 			--mount ${MOUNT_HOME} \
@@ -4752,8 +4750,6 @@ run_cli ()
 			-e GIT_USER_NAME \
 			-e HOST_UID \
 			-e HOST_GID \
-			-e COLUMNS \
-			-e LINES \
 			-e DEBUG \
 			${env_str} ${RUN_IMAGE} bash -ilc "$cmd"
 	else
@@ -4773,8 +4769,6 @@ run_cli ()
 			-e GIT_USER_NAME \
 			-e HOST_UID \
 			-e HOST_GID \
-			-e COLUMNS \
-			-e LINES \
 			-e DEBUG \
 			${env_str} ${RUN_IMAGE} bash -lc "$cmd"
 	fi
@@ -6205,19 +6199,6 @@ set_project_root_permissions ()
 }
 
 #-------------------------- RUNTIME STARTS HERE ----------------------------
-
-# Figure out COLUMNS and LINES (not set in scripts) have to be passed to workaround a bug in Docker.
-# See https://github.com/moby/moby/issues/35407#issuecomment-355753176
-if is_tty; then
-	if ( which tput >/dev/null 2>&1 ); then
-		COLUMNS=$(tput cols)
-		LINES=$(tput lines)
-	# If tput is not available, try ssty. See https://stackoverflow.com/a/48016366/4550880
-	elif ( which stty >/dev/null 2>&1 ); then
-		read LINES COLUMNS < <(stty size)
-	fi
-	export LINES COLUMNS
-fi
 
 # Inherit hosts git user.email and user.name settings
 # This happens before the environment variable overrides are sources, thus can be overridden via docksal.env files.


### PR DESCRIPTION
Originally introduced by 6e53837d3 and other commits; this workaround is no
longer necessary since the bug in Docker was squashed:

https://github.com/moby/moby/issues/35407