### PR TITLE
Only mount custom certificates folder to the proxy if it is mapped to Docker (fixes #850)

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -3420,7 +3420,6 @@ install_proxy_service ()
 	local mount_certs
 	if [[ -d "${CONFIG_CERTS}" ]] && is_docker_path "${CONFIG_CERTS}"; then
 			mount_certs="--mount type=bind,src=${CONFIG_CERTS},dst=/etc/certs/custom"
-		fi
 	fi
 
 	# PROJECT_INACTIVITY_TIMEOUT, PROJECT_DANGLING_TIMEOUT and PROJECTS_ROOT (docksal_projects volume) are used in CI

--- a/bin/fin
+++ b/bin/fin
@@ -3419,7 +3419,7 @@ install_proxy_service ()
 	# Mount custom certs folder if available
 	local mount_certs
 	if [[ -d "${CONFIG_CERTS}" ]] && is_docker_path "${CONFIG_CERTS}"; then
-			mount_certs="--mount type=bind,src=${CONFIG_CERTS},dst=/etc/certs/custom"
+		mount_certs="--mount type=bind,src=${CONFIG_CERTS},dst=/etc/certs/custom"
 	fi
 
 	# PROJECT_INACTIVITY_TIMEOUT, PROJECT_DANGLING_TIMEOUT and PROJECTS_ROOT (docksal_projects volume) are used in CI

--- a/bin/fin
+++ b/bin/fin
@@ -3418,7 +3418,10 @@ install_proxy_service ()
 
 	# Mount custom certs folder if available
 	local mount_certs
-	[[ -d ${CONFIG_CERTS} ]] && mount_certs="--mount type=bind,src=${CONFIG_CERTS},dst=/etc/certs/custom"
+	if [[ -d "${CONFIG_CERTS}" ]] && is_docker_path "${CONFIG_CERTS}"; then
+			mount_certs="--mount type=bind,src=${CONFIG_CERTS},dst=/etc/certs/custom"
+		fi
+	fi
 
 	# PROJECT_INACTIVITY_TIMEOUT, PROJECT_DANGLING_TIMEOUT and PROJECTS_ROOT (docksal_projects volume) are used in CI
 	# and are inactive unless configured.


### PR DESCRIPTION
Check that certificates folder is mapped into Docker with new function introduced in #657. Fixes #850 

[ Squash merge when merging ]