### PR TITLE
updates uses of db service in docs with mysql

### DIFF
--- a/docs/content/core/overview.md
+++ b/docs/content/core/overview.md
@@ -45,9 +45,9 @@ Each project usually consists of at least 3 services: `web`, `db`, and `cli`.
 
 The [web](https://github.com/docksal/service-web) service runs Apache server 2.2 or 2.4.
 
-### db
+### mysql
 
-The [db](https://github.com/docksal/service-db) service runs MySQL 5.5, 5.6, 5.7, or 8.0.
+The [mysql](https://github.com/docksal/service-db) service runs MySQL 5.5, 5.6, 5.7, or 8.0.
 
 ### cli
 

--- a/docs/content/core/volumes.md
+++ b/docs/content/core/volumes.md
@@ -13,7 +13,7 @@ If option is not Automatic, then you need to enable it manually on the global or
 All non-automatic options are enabled by placing `DOCKSAL_VOLUMES="<value from volumes column>"` into the respective
 `docksal.env` file or using `fin config set` for the same, e.g., `fin config set DOCKSAL_VOLUMES="NFS"`.
 Once you set a new volumes option, you must re-create `cli` container. The easiest way is `fin project reset`,
-but it will also remove all the data from `db` volume. If you want to retain it, remove `cli` container and start
+but it will also remove all the data from `mysql` volume. If you want to retain it, remove `cli` container and start
 the project again to recreate it: `fin p remove cli; fin p start`
 
 | OS      | Docker          | Volumes | Automatic | Comments  |

--- a/docs/content/service/db/import.md
+++ b/docs/content/service/db/import.md
@@ -5,7 +5,7 @@ aliases:
 ---
 
 
-The `db` service container can perform an automatic import of the database dump upon initialization.
+The `mysql` service container can perform an automatic import of the database dump upon initialization.
 
 ## Setup
 
@@ -18,17 +18,17 @@ You can add multiple *.sql and *.sql.gz files. All files will be imported in alp
 The `MYSQL_DATABASE` variable contains the active database.
 {{% /notice %}}
 
-Add to the `db` service in the project's `.docksal/docksal.yml` file as follows:
+Add to the `mysql` service in the project's `.docksal/docksal.yml` file as follows:
 
 ```yaml
-db:
+mysql:
   ...
   volumes:
     - ${PROJECT_ROOT}/db:/docker-entrypoint-initdb.d:ro
   ...
 ```
 
-Run `fin project reset db` (`fin p reset db`) to reinitialize the `db` service.
+Run `fin project reset mysql` (`fin p reset mysql`) to reinitialize the `mysql` service.
 
 It may take some time for the database server to initialize and import the dump.  
-Check container logs for progress and/or issues if necessary (`fin logs db`).
+Check container logs for progress and/or issues if necessary (`fin logs mysql`).

--- a/docs/content/service/db/sandbox.md
+++ b/docs/content/service/db/sandbox.md
@@ -20,29 +20,29 @@ For example, a 2.6GB DB dump file takes 14 minutes to import with MySQL.
 ## Enabling sandbox mode
 
 1) Backup the database: `fin sqld db.sql`  
-2) Update the `db` service in `docksal.yml` as follows: 
+2) Update the `mysql` service in `docksal.yml` as follows: 
 
 ```yaml
-db:
+mysql:
   ...
   command: "--datadir /var/lib/mysql-sandbox"
 ```
 
-3) Reset the db service: `fin project reset db` 
+3) Reset the mysql service: `fin project reset mysql` 
 4) Import the database: `fin sqli db.sql`  
-5) Create a snapshot image from the `db` container:
+5) Create a snapshot image from the `mysql` container:
 
 ```bash
 fin project stop
-fin docker commit $(fin docker-compose ps -q db) <tag>
+fin docker commit $(fin docker-compose ps -q mysql) <tag>
 ```
 
 Replace `<tag>` with any meaningful tag you'd like to use for the image, e.g., `db_backup` or `dbdata/myproject:snapshot1`.
 
-6) Update the `db` service in `docksal.yml` as follows:
+6) Update the `mysql` service in `docksal.yml` as follows:
 
 ```yaml
-db:
+mysql:
   ...
   image: <tag>
   command: "--datadir /var/lib/mysql-sandbox"
@@ -50,20 +50,20 @@ db:
 
 7) Update the stack configuration: `fin project start` (`fin p start` for short)
 
-Now the `db` service container is using an ephemeral storage for the database (changes) - `/var/lib/mysql-sandbox`.
+Now the `mysql` service container is using an ephemeral storage for the database (changes) - `/var/lib/mysql-sandbox`.
 
-To reset it to the snapshot you took in step 1 run `fin project reset db` (`fin p reset db`).
+To reset it to the snapshot you took in step 1 run `fin project reset mysql` (`fin p reset mysql`).
 
 ## Disabling sandbox mode
 
 You will need a DB dump to revert.
 Either use the one created before enabling the sandbox mode or create a new one.
 
-1) Revert the changes done to the `db` service in `docksal.yml` 
-2) Reset the `db` service: `fin project reset db` 
+1) Revert the changes done to the `mysql` service in `docksal.yml` 
+2) Reset the `mysql` service: `fin project reset mysql` 
 3) Import the DB dump
 
-Now the `db` service container is using a persistent storage volume for the database - `/var/lib/mysql`.
+Now the `mysql` service container is using a persistent storage volume for the database - `/var/lib/mysql`.
 
 {{% notice warning %}}
 With large databases, it is not recommended to snapshot a container that is already running off of a snapshot image.  

--- a/docs/content/service/db/settings.md
+++ b/docs/content/service/db/settings.md
@@ -25,7 +25,7 @@ DB_IMAGE='docksal/db:1.1-mysql-5.6'
 Remember to run `fin project start` (`fin p start`) to apply the configuration.
 
 {{% notice warning %}}
-Different MySQL versions may not be fully compatible. A complete `db` service reset (`fin project reset db`) might be necessary
+Different MySQL versions may not be fully compatible. A complete `mysql` service reset (`fin project reset mysql`) might be necessary
 followed by a DB re-import.
 {{% /notice %}}
 

--- a/docs/content/stack/checking-configuration.md
+++ b/docs/content/stack/checking-configuration.md
@@ -45,7 +45,7 @@ services:
     volumes:
     - docksal_ssh_agent:/.ssh-agent:ro
     - project_root:/var/www:rw,nocopy
-  db:
+  mysql:
     environment:
       MYSQL_DATABASE: default
       MYSQL_PASSWORD: user

--- a/docs/content/stack/understanding-stack-config.md
+++ b/docs/content/stack/understanding-stack-config.md
@@ -102,5 +102,5 @@ fin image registry
 To get all tags of a certain image provide its name with the same command. For example:
 
 ```bash
-fin image registry docksal/db
+fin image registry docksal/mysql
 ```

--- a/docs/content/stack/zero-configuration.md
+++ b/docs/content/stack/zero-configuration.md
@@ -24,6 +24,6 @@ DOCKSAL_STACK="acquia"
 
 The following stacks are available:
 
-- `default` - web, db, cli (assumed, when none specified)
-- `acquia` - web, db, cli, varnish, memcached, solr (used specifically for [Acquia](https://www.acquia.com/) hosted projects)
+- `default` - web, mysql, cli (assumed, when none specified)
+- `acquia` - web, mysql, cli, varnish, memcached, solr (used specifically for [Acquia](https://www.acquia.com/) hosted projects)
 - `node` - cli

--- a/docs/content/troubleshooting/common-issues.md
+++ b/docs/content/troubleshooting/common-issues.md
@@ -96,7 +96,7 @@ Drupal 8 project and composer.
 
 ### How to resolve
 
-1. If the VM keeps running out of memory or you are getting weird issue with the `db` (or other) services failing, then
+1. If the VM keeps running out of memory or you are getting weird issue with the `mysql` (or other) services failing, then
 try stopping all active projects (`fin stop --all`) and only start the one you need.
 
 2. Alternatively give the VM more RAM (e.g., 4096 MB). This may only be necessary when running several very heavy


### PR DESCRIPTION
This updates documentation where the `db` service was used. I know that not every occurrence of `db` should be replaced with mysql, so please check that all the right places have been updated.