### PR TITLE
adds ELASTICSEARCH_PORT_MAPPING env variable option

### DIFF
--- a/docs/content/service/db/access.md
+++ b/docs/content/service/db/access.md
@@ -35,7 +35,7 @@ To have a static port assigned, override the `MYSQL_PORT_MAPPING` variable value
 MYSQL_PORT_MAPPING='33061:3306'
 ```
 
-In this case current project db will be accessible at `192.168.64.100:33061`.
+In this case, the current project db will be accessible at `192.168.64.100:33061`.
 
 {{% notice note %}}
 If you plan to run several Docksal projects with exposed static ports at once, then use unique exposed port numbers.

--- a/docs/content/tools/elasticsearch.md
+++ b/docs/content/tools/elasticsearch.md
@@ -17,7 +17,7 @@ Add the `elasticsearch` service under the `services` section in `.docksal/docksa
 
 Apply new configuration with `fin project start` (`fin p start`).
 
-Use `fin project status` to determine which port Elastic Search is exposed on. E.g.
+Use `fin project status` to determine which port Elastic Search is exposed on, e.g.,
 
 ```
 14:06:05 ~/Projects/drupal8
@@ -30,16 +30,13 @@ drupal8_elasticsearch_1   /usr/local/bin/docker-entr ...   Up             0.0.0.
 drupal8_web_1             httpd-foreground   
 ```
 
-In the example above Elastic Search port `9200` is exposed on the host as `32770` and can be accessed at `192.168.64.100:32770`.
+In the example above, Elastic Search port `9200` is exposed on the host as `32770` and can be accessed at `192.168.64.100:32770`.
 
-Alternatively manually export Elastic Search on the port `9200` on the host:
+## Assigning a Static Port
 
-```yaml
-  # Elastic Search
-  elasticsearch:
-    extends:
-      file: ${HOME}/.docksal/stacks/services.yml
-      service: elasticsearch
-    ports:
-      - "9200:9200"
+To have a static port assigned, override the `ELASTICSEARCH_PORT_MAPPING` variable in `.docksal/docksal-local.env`:
+
 ```
+ELASTICSEARCH_PORT_MAPPING='92001:9200'
+```
+In this case, the current project elastic search will be accessible at `192.168.64.100:92001`.

--- a/docs/content/tools/elasticsearch.md
+++ b/docs/content/tools/elasticsearch.md
@@ -37,6 +37,6 @@ In the example above, Elastic Search port `9200` is exposed on the host as `3277
 To have a static port assigned, override the `ELASTICSEARCH_PORT_MAPPING` variable in `.docksal/docksal-local.env`:
 
 ```
-ELASTICSEARCH_PORT_MAPPING='92001:9200'
+ELASTICSEARCH_PORT_MAPPING='9200:9200'
 ```
 In this case, the current project elastic search will be accessible at `192.168.64.100:92001`.

--- a/docs/content/tools/elasticsearch.md
+++ b/docs/content/tools/elasticsearch.md
@@ -17,7 +17,7 @@ Add the `elasticsearch` service under the `services` section in `.docksal/docksa
 
 Apply new configuration with `fin project start` (`fin p start`).
 
-Use `fin project status` to determine which port Elastic Search is exposed on, e.g.,
+Elastic Search will be exposed on a random port. Use `fin project status` to determine which port Elastic Search is exposed on, e.g.,
 
 ```
 14:06:05 ~/Projects/drupal8
@@ -39,4 +39,4 @@ To have a static port assigned, override the `ELASTICSEARCH_PORT_MAPPING` variab
 ```
 ELASTICSEARCH_PORT_MAPPING='9200:9200'
 ```
-In this case, the current project elastic search will be accessible at `192.168.64.100:92001`.
+In this case, the current project elastic search will be accessible at `192.168.64.100:9200`.

--- a/examples/.docksal/docksal.env
+++ b/examples/.docksal/docksal.env
@@ -25,12 +25,6 @@ DOCKSAL_STACK=default
 # and replace the host port "0" with a unique host port number (e.g., MYSQL_PORT_MAPPING='33061:3306')
 MYSQL_PORT_MAPPING='0:3306'
 
-# Elastic Search settings.
-# Elastic Search will be exposed on a random port. Use "fin ps" to check the port.
-# To have a static Elastic Search port assigned, copy the line below into the .docksal/docksal-local.env file
-# and replace the host port "0" with a unique host port number (e.g., ELASTICSEARCH_PORT_MAPPING='92001:9200')
-ELASTICSEARCH_PORT_MAPPING='0:9200'
-
 # Enable/disable xdebug
 # To override locally, copy the two lines below into .docksal/docksal-local.env and adjust as necessary
 XDEBUG_ENABLED=0

--- a/examples/.docksal/docksal.env
+++ b/examples/.docksal/docksal.env
@@ -22,8 +22,14 @@ DOCKSAL_STACK=default
 # MySQL settings.
 # MySQL will be exposed on a random port. Use "fin ps" to check the port.
 # To have a static MySQL port assigned, copy the line below into the .docksal/docksal-local.env file
-# and replace the host port "0" with a unique host port number (e.g. MYSQL_PORT_MAPPING='33061:3306')
+# and replace the host port "0" with a unique host port number (e.g., MYSQL_PORT_MAPPING='33061:3306')
 MYSQL_PORT_MAPPING='0:3306'
+
+# Elastic Search settings.
+# Elastic Search will be exposed on a random port. Use "fin ps" to check the port.
+# To have a static Elastic Search port assigned, copy the line below into the .docksal/docksal-local.env file
+# and replace the host port "0" with a unique host port number (e.g., ELASTICSEARCH_PORT_MAPPING='92001:9200')
+ELASTICSEARCH_PORT_MAPPING='0:9200'
 
 # Enable/disable xdebug
 # To override locally, copy the two lines below into .docksal/docksal-local.env and adjust as necessary

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -166,7 +166,7 @@ services:
     hostname: elasticsearch
     image: elasticsearch:6.5.3
     ports:
-      - "9200"
+      - "${ELASTICSEARCH_PORT_MAPPING:-9200}"
     dns:
       - ${DOCKSAL_DNS1}
       - ${DOCKSAL_DNS2}


### PR DESCRIPTION
To make port forwarding comparable to MySQL and PostgreSQL, I added `"${ELASTICSEARCH_PORT_MAPPING:-9200}"` option in the `~/.docksal/stacks/services.yml` file. Running `fin develop` version and following this same pattern of setting the variable in my `docksal-local.env` file, I am not getting the results I expected. I'm still seeing port 32771.

```
testproject_elasticsearch_1_a9e0d576c113   /usr/local/bin/docker-entr ...   Up             0.0.0.0:32771->9200/tcp, 9300/tcp
```

I did a search for the `MYSQL_PORT_MAPPING` variable that does exist and work, but I can't find it, so I thought these were the only steps I needed to take. Am I missing a step?