### PR TITLE
documentation content clickability

### DIFF
--- a/docs/layouts/partials/menu-footer.html
+++ b/docs/layouts/partials/menu-footer.html
@@ -17,7 +17,7 @@
  inputSelector: '#search-by',
  debug: false // Set debug to true if you want to inspect the dropdown
  });
- jQuery(document).ready(function() {
+     jQuery(document).ready(function() {
      /*
       * Prevent left and right arrow keys from engaging previous or next links.
       */

--- a/docs/static/css/theme-docksal.css
+++ b/docs/static/css/theme-docksal.css
@@ -25,8 +25,8 @@ i.icon.docksal {
   right: 0px;
   top:0px;}
 
-#body > div.highlightable, #body > #navigation > a {
-  z-index: -1
+#body, #body > div.highlightable, pre {
+  position: inherit;
 }
 
 .searchboxed input {

--- a/docs/static/css/theme-docksal.css
+++ b/docs/static/css/theme-docksal.css
@@ -12,7 +12,7 @@ i.icon.docksal {
   background-size: 15px 15px;
 }
 
-/* Algolia Search fixes */
+/* Theme fixes for Algolia Search */
 .searchboxed {
   margin-top: 1rem;
   position: relative;
@@ -24,8 +24,13 @@ i.icon.docksal {
   right: 0px;
   top:0px;}
 
-#body, #body > div.highlightable, pre {
-  position: inherit;
+body {
+  position: relative;
+}
+
+#sidebar {
+  position: absolute;
+  height: 100%;
 }
 
 .searchboxed input {

--- a/docs/static/css/theme-docksal.css
+++ b/docs/static/css/theme-docksal.css
@@ -14,7 +14,6 @@ i.icon.docksal {
 
 /* Algolia Search fixes */
 .searchboxed {
-  width: 270px !important;
   margin-top: 1rem;
   position: relative;
   border: 1px solid #915eae;


### PR DESCRIPTION
This change fixes the content bleed-through and allows links to be clicked again.

There is still an issue with the navigation links bleeding through. The fixed used on the body does not work on the links. It will take some more investigation.