### PR TITLE
changes default cli image to php 7.2

### DIFF
--- a/docs/content/service/cli/settings.md
+++ b/docs/content/service/cli/settings.md
@@ -34,10 +34,14 @@ Once settings are in place, apply changes with `fin project restart` (`fin p res
 Different PHP versions are handled via using different `cli` service images.  
 
 When using the default stack (a custom project stack is not defined in `.docksal/docksal.yml`), switching can be done 
-via the `CLI_IMAGE` variable in `.docksal/docksal.env`.
+via the `CLI_IMAGE` variable in `.docksal/docksal.env`, e.g.:
 
 ```bash
 CLI_IMAGE='docksal/cli:2.5-php7.1'
+```
+This can also be set with `fin config set`.
+```bash
+fin config set CLI_IMAGE='docksal/cli:2.5-php7.1'
 ```
 
 Run `fin project reset cli` (`fin p reset cli`) to properly reset and update the `cli` service.
@@ -47,7 +51,7 @@ Available images:
 - PHP 5.6 - `docksal/cli:2.5-php5.6`
 - PHP 7.0 - `docksal/cli:2.5-php7.0`
 - PHP 7.1 - `docksal/cli:2.5-php7.1`
-- PHP 7.2 - `docksal/cli:2.5-php7.2`
+- PHP 7.2 - `docksal/cli:2.5-php7.2` (default)
 
 There are also "edge" versions available that contain code from ongoing updates, but may not be stable. Don't switch to an
 edge image unless directed to do so by the Docksal team for testing purposes only.

--- a/docs/content/service/db/settings.md
+++ b/docs/content/service/db/settings.md
@@ -16,14 +16,14 @@ Apply changes with `fin project restart` (`fin p restart`).
 ## Using Different MySQL Versions {#mysql-versions}
 
 When using the default stack (a custom project stack is not defined in `.docksal/docksal.yml`), switching can be done 
-via the `DB_IMAGE` variable in `.docksal/docksal.env`.
+via the `DB_IMAGE` variable in `.docksal/docksal.env`, e.g.:
 
 ```bash
-DB_IMAGE='docksal/db:1.1-mysql-5.6'
+DB_IMAGE='docksal/db:1.1-mysql-5.7'
 ```
 This can also be set with `fin config set`.
 ```bash
-fin config set DB_IMAGE='docksal/db:1.1-mysql-5.6'
+fin config set DB_IMAGE='docksal/db:1.1-mysql-5.7'
 ```
 
 Remember to run `fin project start` (`fin p start`) to apply the configuration.
@@ -36,7 +36,7 @@ followed by a DB re-import.
 Available images:
 
 - MySQL 5.5 - `docksal/db:1.1-mysql-5.5`
-- MySQL 5.6 - `docksal/db:1.1-mysql-5.6`
+- MySQL 5.6 - `docksal/db:1.1-mysql-5.6` (default)
 - MySQL 5.7 - `docksal/db:1.1-mysql-5.7`
 - MySQL 8.0 - `docksal/db:1.1-mysql-8.0`
 

--- a/docs/content/service/web/settings.md
+++ b/docs/content/service/web/settings.md
@@ -26,7 +26,7 @@ Use `.docksal/etc/apache/httpd-vhosts.conf` to define additional virtual hosts:
 ## Using Different Apache Versions {#apache-versions}
 
 When using the default stack (a custom project stack is not defined in `.docksal/docksal.yml`), switching can be done 
-via the `WEB_IMAGE` variable in `.docksal/docksal.env`.
+via the `WEB_IMAGE` variable in `.docksal/docksal.env`, e.g.:
 
 ```bash
 WEB_IMAGE='docksal/web:2.1-apache2.2'
@@ -40,7 +40,7 @@ Remember to run `fin project start` (`fin p start`) to apply the configuration.
 Available images:
 
 - Apache 2.2 - `docksal/web:2.1-apache2.2`
-- Apache 2.4 - `docksal/web:2.1-apache2.4`
+- Apache 2.4 - `docksal/web:2.1-apache2.4` (default)
 
 There are also "edge" versions available that contain code from ongoing updates, but may not be stable. Don't switch to an
 edge image unless directed to do so by the Docksal team for testing purposes only.

--- a/docs/content/stack/checking-configuration.md
+++ b/docs/content/stack/checking-configuration.md
@@ -41,7 +41,7 @@ networks: {}
 services:
   cli:
     hostname: cli
-    image: docksal/cli:2.5-php7.1
+    image: docksal/cli:2.5-php7.2
     volumes:
     - docksal_ssh_agent:/.ssh-agent:ro
     - project_root:/var/www:rw,nocopy

--- a/docs/content/stack/extend-images.md
+++ b/docs/content/stack/extend-images.md
@@ -49,7 +49,7 @@ Below is an example of extending the `cli` image with additional configs, apt, a
 
 ```Dockerfile
 # Use a stock Docksal image as the base
-FROM docksal/cli:php7.1
+FROM docksal/cli:php7.2
 
 # Install addtional apt packages
 RUN apt-get update && apt-get -y --no-install-recommends install \

--- a/docs/content/use-cases/docker-image.md
+++ b/docs/content/use-cases/docker-image.md
@@ -10,7 +10,7 @@ the Docksal default. Here are the steps that can be taken to build an image:
 1. Create image project, test and verify it worked as expected
 
     ```
-    FROM docksal/cli:php7.1
+    FROM docksal/cli:php7.2
     
     RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -86,7 +86,7 @@ services:
   # CLI - Used for all console commands and tools.
   cli:
     hostname: cli
-    image: ${CLI_IMAGE:-docksal/cli:2.5-php7.1}
+    image: ${CLI_IMAGE:-docksal/cli:2.5-php7.2}
     volumes:
       - project_root:/var/www:rw,nocopy  # Project root volume
       - docksal_ssh_agent:/.ssh-agent:ro  # Shared ssh-agent socket


### PR DESCRIPTION
Closes #908

The drupal7 and drupal7-advanced projects have pull requests to set the cli image to 7.1.
