### PR TITLE
Updated documentation for PHPCS to include WordPress

### DIFF
--- a/docs/content/tools/phpcs.md
+++ b/docs/content/tools/phpcs.md
@@ -5,7 +5,8 @@ aliases:
 ---
 
 
-`phpcs` and `phpcbf` are readily available in the cli container.
+`phpcs` and `phpcbf` are readily available in the cli container. Both [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards) and [WordPress Coding Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) 
+have been installed and are ready to use.
 
 
 ## Using as a Custom fin Command
@@ -14,16 +15,30 @@ It's recommended to see how to [extend fin with custom commands](/fin/custom-com
 
 From your project's root folder (where the `.docksal` folder is located), download the sample `phpcs` command:
 
+### For Drupal
+
 ```bash
 mkdir -p .docksal/commands
-curl -fsSL https://raw.githubusercontent.com/docksal/docksal/master/examples/.docksal/commands/phpcs -o .docksal/commands/phpcs
+curl -fsSL https://raw.githubusercontent.com/docksal/docksal/master/examples/.docksal/commands/drupal_phpcs -o .docksal/commands/phpcs
 chmod +x .docksal/commands/phpcs
 ```
 
 Run `fin phpcs docroot/sites/all/modules/custom` or any path you want to run sniffer against.  
 See `fin help phpcs` for options.
 
-Modify `.docksal/commands/phpcs` script as you see fit.
+### For WordPress
+
+```bash
+mkdir -p .docksal/commands
+curl -fsSL https://raw.githubusercontent.com/docksal/docksal/master/examples/.docksal/commands/wordpress_phpcs -o .docksal/commands/phpcs
+chmod +x .docksal/commands/phpcs
+```
+
+Run `fin phpcs docroot/wp-content/plugins` or any path you want to run sniffer against.  
+See `fin help phpcs` for options.
+
+
+For both of the examples above modify `.docksal/commands/phpcs` script as you see fit.
 
 A command for `phpcbf` can be created in a similar fashion.
 
@@ -33,9 +48,11 @@ A command for `phpcbf` can be created in a similar fashion.
 Instead of installing or creating custom commands you can use `phpcs`/`phpcbf` directly every time.  
 From your project's root folder run:
 
+### With Drupal
+
 ```bash
 fin run phpcs \
-    --standard=Drupal -n \
+    --standard="Drupal,DrupalPractice" -n \
     --extensions="php,module,inc,install,test,profile,theme" \
     --ignore="*.features.*,*.pages*.inc" \
     docroot/sites/all/modules/custom
@@ -43,8 +60,23 @@ fin run phpcs \
 
 ```bash
 fin run phpcbf \
-    --standard=Drupal -n \
+    --standard="Drupal,DrupalPractice" -n \
     --extensions="php,module,inc,install,test,profile,theme" \
     --ignore="*.features.*,*.pages*.inc" \
     docroot/sites/all/modules/custom
 ```
+
+### With WordPress
+
+```bash
+fin run phpcs \
+    --standard="WordPress" -n \
+    docroot/wp-content/plugin
+```
+
+```bash
+fin run phpcbf \
+    --standard="WordPress" -n \
+    docroot/wp-content/plugins
+```
+

--- a/examples/.docksal/commands/drupal_phpcs
+++ b/examples/.docksal/commands/drupal_phpcs
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+## Run Code Sniffer (phpcs) against given path
+##
+## Usage: fin phpcs <path>
+##
+## Uses Drupal standards.
+##
+## Includes extensions:	php, module, inc, install, test, profile, theme
+## Ignores:		features.*, *.pages*.inc
+
+# Environment variables passed from fin:
+#
+#   $PROJECT_ROOT - (string) absolute path to NEAREST .docksal folder
+#   $VIRTUAL_HOST - (string) ex. projectname.docksal
+#   $DOCROOT - name of the docroot folder
+#   $DOCKER_RUNNING - (string) "true" or "false"
+
+if [[ "$1" == "" ]]; then
+	echo "Usage: fin phpcs <path>"
+	exit 1
+fi
+
+fin run phpcs \
+	--standard="Drupal,DrupalPractice" -n \
+	--extensions="php,module,inc,install,test,profile,theme" \
+	--ignore="*.features.*,*.pages*.inc" \
+	"$1"

--- a/examples/.docksal/commands/wordpress_phpcs
+++ b/examples/.docksal/commands/wordpress_phpcs
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+## Run Code Sniffer (phpcs) against given path
+##
+## Usage: fin phpcs <path>
+##
+## Uses WordPress standards.
+##
+# Environment variables passed from fin:
+#
+#   $PROJECT_ROOT - (string) absolute path to NEAREST .docksal folder
+#   $VIRTUAL_HOST - (string) ex. projectname.docksal
+#   $DOCROOT - name of the docroot folder
+#   $DOCKER_RUNNING - (string) "true" or "false"
+
+if [[ "$1" == "" ]]; then
+	echo "Usage: fin phpcs <path>"
+	exit 1
+fi
+
+fin run phpcs \
+	--standard="WordPress" -n \
+	"$1"


### PR DESCRIPTION
Added information to the docs for WordPress PHPCS additionally made commands for easier downloading.

Solves https://github.com/docksal/docksal/issues/927