### PR TITLE
Fix "forcibely" typo in commands

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -1765,7 +1765,7 @@ show_help_vm ()
 	echo "Commands:"
 	printh "start" "Start the machine (create if needed)"
 	printh "stop" "Stop the machine"
-	printh "kill" "Forcibely stop the machine"
+	printh "kill" "Forcibly stop the machine"
 	printh "restart" "Restart the machine"
 	printh "status" "Get the status"
 	printh "ssh [command]" "Log into ssh or run a command via ssh"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docksal/docksal/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Write a short summary that describes the changes in this pull request:
-->

Fixes a typo in the commands list:
>   kill                     	_Forcibely_ stop the machine