### PR TITLE
Stack updates

### DIFF
--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -160,7 +160,7 @@ services:
   # Redis
   redis:
     hostname: redis
-    image: ${REDIS_IMAGE:-wodby/redis:4.0}
+    image: ${REDIS_IMAGE:-wodby/redis:5.0}
     environment:
       - REDIS_MAXMEMORY=${REDIS_MAXMEMORY:-256m}
       # Additional variables can be found https://github.com/wodby/redis

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -18,6 +18,7 @@ services:
       - io.docksal.permanent=${SANDBOX_PERMANENT:-false}
     environment:
       - APACHE_DOCUMENTROOT=/var/www/${DOCROOT:-docroot}
+      - APACHE_FCGI_HOST_PORT=cli:9000
       - APACHE_BASIC_AUTH_USER
       - APACHE_BASIC_AUTH_PASS
     dns:
@@ -38,6 +39,7 @@ services:
       - io.docksal.permanent=${SANDBOX_PERMANENT:-false}
     environment:
       - APACHE_DOCUMENTROOT=/var/www/${DOCROOT:-docroot}
+      - APACHE_FCGI_HOST_PORT=cli:9000
       - APACHE_BASIC_AUTH_USER
       - APACHE_BASIC_AUTH_PASS
     dns:

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -47,7 +47,7 @@ services:
   # DB: MySQL
   mysql:
     hostname: db
-    image: ${DB_IMAGE:-docksal/db:1.2-mysql-5.6}
+    image: ${DB_IMAGE:-docksal/mysql:5.6-1.4}
     ports:
       - "${MYSQL_PORT_MAPPING:-3306}"
     volumes:
@@ -65,6 +65,28 @@ services:
     dns:
       - ${DOCKSAL_DNS1}
       - ${DOCKSAL_DNS2}
+
+  # DB: MySQL
+  mariadb:
+    hostname: db
+    image: ${DB_IMAGE:-docksal/mariadb:10.3-1.0}
+    ports:
+    - "${MYSQL_PORT_MAPPING:-3306}"
+    volumes:
+    - project_root:/var/www:ro,nocopy  # Project root volume (read-only)
+    - db_data:/var/lib/mysql  # Database data volume
+    environment:
+    - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-root}
+    - MYSQL_USER=${MYSQL_USER:-user}
+    - MYSQL_PASSWORD=${MYSQL_PASSWORD:-user}
+    - MYSQL_DATABASE=${MYSQL_DATABASE:-default}
+    - MYSQL_ALLOW_EMPTY_PASSWORD
+    - MYSQL_RANDOM_ROOT_PASSWORD
+    - MYSQL_ONETIME_PASSWORD
+    - MYSQL_INITDB_SKIP_TZINFO
+    dns:
+    - ${DOCKSAL_DNS1}
+    - ${DOCKSAL_DNS2}
 
   # DB: PostgreSQL
   pgsql:

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -8,7 +8,7 @@ services:
   # Web: Apache
   apache:
     hostname: web
-    image: ${WEB_IMAGE:-docksal/web:2.1-apache2.4}
+    image: ${WEB_IMAGE:-docksal/apache:2.4-2.3}
     volumes:
       - project_root:/var/www:ro,nocopy  # Project root volume (read-only)
     labels:
@@ -28,7 +28,7 @@ services:
   # TODO: remove November 2019
   web:
     hostname: web
-    image: ${WEB_IMAGE:-docksal/web:2.1-apache2.4}
+    image: ${WEB_IMAGE:-docksal/web:2.2-apache2.4}
     volumes:
       - project_root:/var/www:ro,nocopy  # Project root volume (read-only)
     labels:

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -159,7 +159,7 @@ services:
   # Varnish
   varnish:
     hostname: varnish
-    image: ${VARNISH_IMAGE:-docksal/varnish:1.1-varnish5}
+    image: ${VARNISH_IMAGE:-docksal/varnish:6.1-2.0}
     volumes:
       - project_root:/var/www:ro,nocopy  # Project root volume (read-only)
     labels:

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -44,6 +44,27 @@ services:
       - ${DOCKSAL_DNS1}
       - ${DOCKSAL_DNS2}
 
+  # Web: Nginx
+  nginx:
+    hostname: web
+    image: ${WEB_IMAGE:-docksal/nginx:1.14-1.0}
+    volumes:
+    - project_root:/var/www:ro,nocopy  # Project root volume (read-only)
+    labels:
+    - io.docksal.virtual-host=${VIRTUAL_HOST},*.${VIRTUAL_HOST},${VIRTUAL_HOST}.*
+    - io.docksal.cert-name=${VIRTUAL_HOST_CERT_NAME:-none}
+    - io.docksal.project-root=${PROJECT_ROOT}
+    - io.docksal.permanent=${SANDBOX_PERMANENT:-false}
+    environment:
+    - NGINX_VHOST_PRESET=drupal
+    - NGINX_FCGI_HOST_PORT=cli:9000
+    - NGINX_SERVER_ROOT=/var/www/${DOCROOT}
+    - NGINX_BASIC_AUTH_USER
+    - NGINX_BASIC_AUTH_PASS
+    dns:
+    - ${DOCKSAL_DNS1}
+    - ${DOCKSAL_DNS2}
+
   # DB: MySQL
   mysql:
     hostname: db

--- a/stacks/stack-acquia.yml
+++ b/stacks/stack-acquia.yml
@@ -3,7 +3,7 @@
 # - Apache 2.4
 # - MySQL 5.6
 # - PHP 7.2
-# - Varnish 5
+# - Varnish 4.1
 # - Memcached 1.4
 # - ApacheSolr 4.5
 
@@ -34,7 +34,7 @@ services:
       file: ${HOME}/.docksal/stacks/services.yml
       service: varnish
     # Pin Varnish version
-    image: ${VARNISH_IMAGE:-docksal/varnish:1.1-varnish4}
+    image: ${VARNISH_IMAGE:-docksal/varnish:4.1-2.0}
     depends_on:
       - web
 

--- a/stacks/stack-acquia.yml
+++ b/stacks/stack-acquia.yml
@@ -2,15 +2,15 @@
 #
 # - Apache 2.4
 # - MySQL 5.6
-# - PHP 5.6 / PHP 7.1
+# - PHP 7.2
 # - Varnish 5
 # - Memcached 1.4
-# - ApacheSolr 4.x
+# - ApacheSolr 4.5
 
 version: "2.1"
 
 services:
-  # Web
+  # http(s)://VIRTUAL_HOST
   web:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml
@@ -18,34 +18,35 @@ services:
     depends_on:
       - cli
 
-  # DB
   db:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml
       service: mysql
 
-  # CLI
   cli:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml
       service: cli
 
-  # Varnish
+  # http(s)://varnish.VIRTUAL_HOST
   varnish:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml
       service: varnish
+    # Pin Varnish version
+    image: ${VARNISH_IMAGE:-docksal/varnish:1.1-varnish4}
     depends_on:
       - web
 
-  # Memcached
   memcached:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml
       service: memcached
 
-  # Solr
+  # http(s)://solr.VIRTUAL_HOST/solr
   solr:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml
       service: solr
+    # Pin Solr version
+    image: ${SOLR_IMAGE:-docksal/solr:1.0-solr4}

--- a/stacks/stack-default.yml
+++ b/stacks/stack-default.yml
@@ -1,9 +1,12 @@
 # Basic LAMP stack
+# - Apache 2.4
+# - MySQL 5.6
+# - PHP 7.2
 
 version: "2.1"
 
 services:
-  # Web
+  # http(s)://VIRTUAL_HOST
   web:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml
@@ -11,13 +14,11 @@ services:
     depends_on:
       - cli
 
-  # DB
   db:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml
       service: mysql
 
-  # CLI
   cli:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml

--- a/stacks/stack-pantheon.yml
+++ b/stacks/stack-pantheon.yml
@@ -38,7 +38,7 @@ services:
       file: ${HOME}/.docksal/stacks/services.yml
       service: varnish
     # Pin Varnish version
-    image: ${VARNISH_IMAGE:-docksal/varnish:1.1-varnish4}
+    image: ${VARNISH_IMAGE:-docksal/varnish:4.1-2.0}
     depends_on:
       - web
 

--- a/stacks/stack-pantheon.yml
+++ b/stacks/stack-pantheon.yml
@@ -1,0 +1,58 @@
+# Pantheon alike stack
+#
+# - Nginx 1.14
+# - MariaDB 10.1
+# - PHP 7.2
+# - Varnish 4.1
+# - Redis 4.0
+# - ApacheSolr 3.6
+
+version: "2.1"
+
+services:
+  # http(s)://VIRTUAL_HOST
+  web:
+    extends:
+      file: ${HOME}/.docksal/stacks/services.yml
+      service: nginx
+    # Pin nginx version
+    image: ${WEB_IMAGE:-docksal/nginx:1.14-edge}
+    depends_on:
+      - cli
+
+  db:
+    extends:
+      file: ${HOME}/.docksal/stacks/services.yml
+      service: mariadb
+    # Pin MariaDB version
+    image: ${DB_IMAGE:-docksal/mariadb:10.1-1.0}
+
+  cli:
+    extends:
+      file: ${HOME}/.docksal/stacks/services.yml
+      service: cli
+
+  # http(s)://varnish.VIRTUAL_HOST
+  varnish:
+    extends:
+      file: ${HOME}/.docksal/stacks/services.yml
+      service: varnish
+    # Pin Varnish version
+    image: ${VARNISH_IMAGE:-docksal/varnish:1.1-varnish4}
+    depends_on:
+      - web
+
+  redis:
+    extends:
+      file: ${HOME}/.docksal/stacks/services.yml
+      service: redis
+    # Pin Redis version
+    image: ${REDIS_IMAGE:-wodby/redis:4.0}
+
+  # http(s)://solr.VIRTUAL_HOST/solr
+  solr:
+    extends:
+      file: ${HOME}/.docksal/stacks/services.yml
+      service: solr
+    # Pin Solr version
+    image: ${SOLR_IMAGE:-docksal/solr:1.0-solr3}


### PR DESCRIPTION
- Apache
  - Switched `apache` service to `docksal/apache:2.4-2.3`
  - Switched `web` service (legacy) to `docksal/web:2.2-apache2.4`
- MySQL
  - Switched `mysql` service to  `docksal/mysql:5.6-1.4`
  - Added new `mariadb` service: `docksal/mariadb:10.3-1.0`
- Redis
  - Switched `redis` service to `wodby/redis:5.0`
- Nginx
  - Added `nginx` service: `docksal/nginx:1.14-1.0`
- Varnish
  - Switched `varnish` service to `docksal/varnish:6.1-2.0`
- Pinned `varnish` and `solr` versions in Acquia stack
- And... 🥁🥁🥁 Pantheon stack! 🎉 
