### PR TITLE
vm functions refactoring

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -774,7 +774,7 @@ check_docker_running ()
 
 	if [[ ${docker_status} -eq 255 ]] && (! is_docker_native && ! is_wsl); then
 		echo-yellow "It looks like '$DOCKER_MACHINE_NAME' docker machine is not running."
-		_confirm "Run 'fin vm start' to start it now?"
+		_confirm "Start it now?"
 		docker_machine_start
 		if_failed "Could not start Docksal docker machine properly"
 		# re-check status
@@ -2195,6 +2195,7 @@ docker_machine_stop ()
 {
 	check_binary_found 'docker-machine'
 	docker-machine stop "$DOCKER_MACHINE_NAME"
+	DOCKER_MACHINE_STATUS="Stopped"
 }
 
 docker_machine_start ()
@@ -2204,6 +2205,7 @@ docker_machine_start ()
 	if is_docker_machine_exist; then
 		docker-machine start "$DOCKER_MACHINE_NAME"
 		if_failed_error "Failed starting virtual machine"
+
 		DOCKER_MACHINE_STATUS='Running'
 		# Disable IP change for now
 		#docker_machine_change_ip &&
@@ -2211,8 +2213,6 @@ docker_machine_start ()
 		if_failed_error "Failed starting virtual machine" \
 			"In case you see certificates problem, reboot your local host." \
 			"Common issues: https://docs.docksal.io/troubleshooting/common-issues/"
-		configure_resolver
-		configure_mounts
 	else
 		# only auto-create default machine
 		if [[ "$DOCKER_MACHINE_NAME" != "$DEFAULT_MACHINE_NAME" ]]; then
@@ -2226,32 +2226,16 @@ docker_machine_start ()
 			# Disable IP change for now
 			#docker_machine_change_ip &&
 			docker_machine_env
-		[[ $? != 0 ]] && _docker_machine_start_exception
 
-		echo-green "Pulling Docksal system images..."
-		update_system_images
-		configure_mounts
-	fi
-
-	# Catch the return code from docker_machine_mounts
-	# TODO: figure out a more reliable implementation, as this may break if the code above gets reordered
-	local _err=$?
-	if [[ ${_err} -eq 0 ]]; then
-		echo-green "Importing ssh keys..."
-		ssh_key add
-	fi
-
-	return ${_err}
-}
-
-# Displays an error message and offers to remove the vm if something failed
-_docker_machine_start_exception ()
-{
-	echo-error "Proper creation of virtual machine has failed" \
+		# Displays an error message and offers to remove the vm if something failed
+		if [[ $? != 0 ]]; then
+			echo-error "Proper creation of virtual machine has failed" \
 				"For details please refer to the log above." \
 				"${yellow}It is recommended to remove malfunctioned virtual machine.${NC}"
-	docker_machine_remove
-	exit 1
+			docker_machine_remove
+			exit 1
+		fi
+	fi
 }
 
 # param $1 machine name (defaults to $DOCKER_MACHINE_NAME)
@@ -2588,30 +2572,27 @@ vm ()
 	check_binary_found 'docker-machine'
 
 	if ! is_docker_machine_exist && [[ "$1" != "" ]] && [[ "$1" != "start" ]] && [[ "$1" != "create" ]] && [[ "$1" != "ls" ]] && [[ "$1" != "remove" ]] && [[ "$1" != "rm" ]] && [[ "$1" != "active" ]] ; then
-		 echo-yellow "Docker machine $DOCKER_MACHINE_NAME does not exist. Use 'fin vm start' or 'fin up'."
+		 echo-yellow "Docker machine $DOCKER_MACHINE_NAME does not exist. Use 'fin system start'."
 		 return 1
 	fi
 
 	case $1 in
 		start)
-			if is_docker_machine_running; then
-				echo "Machine \"$DOCKER_MACHINE_NAME\" is already running."
-			else
-				docker_machine_start
-			fi
+			# Show a message and pause for input.
+			echo -e "Deprecated. Please use ${yellow}fin system start${NC} instead."; read -p "Press any key to continue..."
+			system_start
 			;;
 		restart)
-			docker_machine_stop; docker_machine_start
+			system_stop
+			system_start
 			;;
 		status)
-			shift
-			local machine_name="${1:-$DOCKER_MACHINE_NAME}"
-			docker-machine status "$machine_name"
+			docker-machine status ${DOCKER_MACHINE_NAME}
 			;;
 		stop)
-			# Disable resolver configuration before machine is turned off
-			configure_resolver off
-			docker_machine_stop
+			# Show a message and pause for input.
+			echo -e "Deprecated. Please use ${yellow}fin system stop${NC} instead."; read -p "Press any key to continue..."
+			system_stop
 			;;
 		ssh)
 			shift
@@ -2621,21 +2602,15 @@ vm ()
 			vm-stats
 			;;
 		kill)
-			# Disable resolver configuration before machine is turned off
-			configure_resolver off
-			shift
-			local machine_name="${1:-$DOCKER_MACHINE_NAME}"
-			docker-machine kill "$machine_name"
+			system_stop
+			docker-machine kill ${DOCKER_MACHINE_NAME}
 			;;
 		ls|list)
 			docker-machine ls
 			;;
 		remove|rm)
-			# Disable resolver configuration before machine is turned off
-			configure_resolver off
-			shift
-			local machine_name="${1:-$DOCKER_MACHINE_NAME}"
-			docker_machine_remove "$machine_name"
+			system_stop
+			docker_machine_remove ${DOCKER_MACHINE_NAME}
 			;;
 		mount)
 			configure_mounts
@@ -3098,35 +3073,41 @@ system_status ()
 }
 
 # Starts all Docksal related things
-# TODO: add projects, network, /etc/exports, etc. here for a complete shutdown of Docksal
 system_start ()
 {
 	if ! is_linux && ! is_docker_native && ! is_wsl; then
-		echo "Starting Docksal VM..."
-		vm start
-		system_reset
-	else
-		echo "Starting Docksal system services..."
-		system_reset
+		if is_docker_machine_running; then
+			echo "Machine ${DOCKER_MACHINE_NAME} is already running."
+		else
+			echo "Starting Docksal VM..."
+			docker_machine_start
+		fi
 	fi
+
+	echo "Starting Docksal system services..."
+	system_reset
 }
 
 # Stops/disables all Docksal things
 system_stop ()
 {
 	if ! is_linux && ! is_docker_native && ! is_wsl; then
-		echo-green "Stopping Docksal VM..."
-		# VM stop will perform configure_resolver off
-		vm stop
+		# Stop the docker-machine VM.
+		if is_docker_machine_running; then
+			echo-green "Stopping Docksal VM..."
+			docker_machine_stop
+		fi
 	else
+		# Stop all Docksal project and system containers.
 		# keep in a subshell so that exit during that command would not stop other command in system stop
 		(_stop_containers --all)
 		echo-green "Stopping Docksal system services..."
 		docker ps -q --filter "label=io.docksal.group=system" | xargs docker rm -vf >/dev/null
-		configure_resolver off
-		configure_mounts off
-		configure_network off
 	fi
+
+	configure_resolver off
+	configure_mounts off
+	configure_network off
 }
 
 # Helper function to run ssh-key inside the ssh-agent container
@@ -4106,7 +4087,7 @@ update_virtualbox () {
 	fi
 
 	# Stop VM
-	fin vm stop >/dev/null 2>&1
+	docker_machine_stop >/dev/null 2>&1
 
 	# Download and install Mac
 	is_mac && (
@@ -4276,17 +4257,17 @@ update ()
 			local res=$?
 			if [[ "$res" != "0" ]]; then
 				[[ "$res" == "2" ]] && echo-red "VirtualBox version should be $REQUIREMENTS_VBOX or higher"
-				(which 'docker-machine' >/dev/null 2>&1) && vm stop
+				(which 'docker-machine' >/dev/null 2>&1) && docker_machine_stop
 				DOCKER_MACHINE_STATUS="Stopped"
 				update_virtualbox
-				(which 'docker-machine' >/dev/null 2>&1) && vm start
+				(which 'docker-machine' >/dev/null 2>&1) && docker_machine_start
 			fi
 		fi
 
 		if ! is_linux && ! is_docker_native && ! is_wsl && which 'docker-machine' >/dev/null 2>&1; then
 			if is_docker_machine_exist && ! is_docker_machine_running; then
 				echo-error "Docker Machine '$DOCKER_MACHINE_NAME' should be running to perform update" \
-					"Start it with ${yellow}fin vm start${NC} or destroy it with ${yellow}fin vm remove${NC} if you want it re-created."
+					"Start it with ${yellow}fin system start${NC} or destroy it with ${yellow}fin vm kill${NC} if you want it re-created."
 				return 1
 			fi
 		fi

--- a/bin/fin
+++ b/bin/fin
@@ -1772,7 +1772,6 @@ show_help_vm ()
 	printh "ssh [command]" "Log into ssh or run a command via ssh"
 	printh "remove" "Remove Docksal machine and cleanup after it"
 	printh "ip" "Show the machine IP address"
-	# printh "ip [new ip]" "Set machine IP address (requires vm restart)"
 	printh "ls" "List all docker machines"
 	printh "env" "Display the commands to set up the shell for direct use of Docker client"
 	printh "mount" "Try remounting host filesystem (NFS on macOS, SMB on Windows)"
@@ -2198,28 +2197,6 @@ docker_machine_stop ()
 	docker-machine stop "$DOCKER_MACHINE_NAME"
 }
 
-docker_machine_change_ip ()
-{
-	echo "(docksal) Applying IP address $DOCKER_MACHINE_IP"
-	# extract first three parts of IP and append 255 to get broadcast mask
-	local BROADCAST_MASK=`expr "$DOCKER_MACHINE_IP" : '\([0-9][0-9]*[0-9]*\.[0-9][0-9]*[0-9]*\.[0-9][0-9]*[0-9]*\.\)'`'255';
-	docker-machine ssh "$DOCKER_MACHINE_NAME" "sudo cat /var/run/udhcpc.eth1.pid | xargs sudo kill" && \
-		docker-machine ssh "$DOCKER_MACHINE_NAME" "sudo ifconfig eth1 $DOCKER_MACHINE_IP netmask 255.255.255.0 broadcast $BROADCAST_MASK up" && \
-		sleep 2 && \
-		docker-machine regenerate-certs "$DOCKER_MACHINE_NAME" -f
-	sleep 2
-	local i=0
-	local _logs=""
-	for i in `seq 20`; do
-		_logs=$(docker-machine env "$DOCKER_MACHINE_NAME" 2>&1)
-		if [[ $? -eq 0 ]]; then return; fi
-		echo "IP validation (attempt #${i})..."
-		sleep 3
-	done
-	echo "$_logs"
-	return 1
-}
-
 docker_machine_start ()
 {
 	check_binary_found 'docker-machine'
@@ -2616,27 +2593,6 @@ vm ()
 	fi
 
 	case $1 in
-		create)
-			# usage: fin vm create <machine_name>
-			shift
-			# errors handling
-			[[ "$1" == "" ]] && echo "Please provide a name for a new vm." && return 1
-			is_docker_machine_exist "$1" && echo "Machine ${1} already exists." && return 1
-			# create
-			docker_machine_create "$1"
-			;;
-		active)
-			# Get/Set active vm
-			shift
-			if [[ "$1" == "" ]]; then
-				echo "$DOCKER_MACHINE_NAME"
-			else
-				[[ "$1" == "$DOCKER_MACHINE_NAME" ]] && echo "$1 is already active" && return 0
-				! is_docker_machine_exist "$1" && echo "No docker machine with name $1" && return 1
-				mkdir -p "$CONFIG_MACHINES" || return 1
-				echo "$1" | tee "$CONFIG_MACHINE_ACTIVE" >/dev/null && echo "$1 is set active"
-			fi
-			;;
 		start)
 			if is_docker_machine_running; then
 				echo "Machine \"$DOCKER_MACHINE_NAME\" is already running."
@@ -2659,7 +2615,7 @@ vm ()
 			;;
 		ssh)
 			shift
-			docker-machine ssh "$DOCKER_MACHINE_NAME" "$@"
+			docker-machine ssh ${DOCKER_MACHINE_NAME} "$@"
 			;;
 		stats)
 			vm-stats
@@ -2685,24 +2641,10 @@ vm ()
 			configure_mounts
 			;;
 		ip)
-			shift
-			local machine_name="${1:-$DOCKER_MACHINE_NAME}"
-			if [[ "$1" =~ [0-9][0-9]*[0-9]*.[0-9][0-9]*[0-9]*\.[0-9][0-9]*[0-9]*\.[0-9] ]]; then
-				# set ip
-				echo-green "Setting ip to $1..."
-#				echo "$1" > "$DOCKER_MACHINE_FOLDER/ip"
-#				echo-yellow "IP change will take effect on next machine start."
-				DOCKER_MACHINE_IP="$1"
-				docker_machine_change_ip
-			else
-				docker-machine ip "$machine_name"
-			fi
-
+			docker-machine ip ${DOCKER_MACHINE_NAME}
 			;;
 		env)
-			shift
-			DOCKER_MACHINE_NAME="${1:-$DOCKER_MACHINE_NAME}"
-			docker-machine env "$DOCKER_MACHINE_NAME"
+			docker-machine env ${DOCKER_MACHINE_NAME}
 			;;
 		ram)
 			shift
@@ -2716,7 +2658,7 @@ vm ()
 			show_help_vm
 			;;
 		regenerate-certs)
-			docker-machine regenerate-certs -f "$DOCKER_MACHINE_NAME"
+			docker-machine regenerate-certs -f ${DOCKER_MACHINE_NAME}
 			vm restart
 			;;
 		*)

--- a/bin/fin
+++ b/bin/fin
@@ -2116,7 +2116,7 @@ docker_machine_create ()
 
 	local machine_name="${1:-$DEFAULT_MACHINE_NAME}"
 
-	if is_docker_machine_exist "$machine_name"; then
+	if is_docker_machine_exist; then
 		echo-error "Docker Machine '$machine_name' already exists"
 		return 1
 	fi
@@ -2147,22 +2147,17 @@ docker_machine_create ()
 	fi
 }
 
-# Param $1 machine name (defaults to $DOCKER_MACHINE_NAME)
-# Param $2 refresh machine status true|false (defaults to false)
+# Param $1 refresh machine status true|false (defaults to false)
 is_docker_machine_exist ()
 {
-	local refresh="${2:-false}"
-
 	! which 'docker-machine' >/dev/null 2>&1 && return 1
-	if [[ "$1" != "" ]] && [[ "$1" != "$DOCKER_MACHINE_NAME" ]]; then
-		docker-machine ls | grep "$1" >/dev/null 2>&1
-	else
-		if [[ "$refresh" == "true" ]]; then
-			# Refresh VM status in case it changed while the script was running.
-			DOCKER_MACHINE_STATUS=$(docker-machine status "$DOCKER_MACHINE_NAME" 2>&1 || echo '')
-		fi
-		[[ "$DOCKER_MACHINE_STATUS" == *"not exist"* ]] && return 1 || return 0
+
+	local refresh="${1:-false}"
+	if [[ "$refresh" == "true" ]]; then
+		# Refresh VM status in case it changed while the script was running.
+		DOCKER_MACHINE_STATUS=$(docker-machine status "$DOCKER_MACHINE_NAME" 2>&1 || echo '')
 	fi
+	[[ "$DOCKER_MACHINE_STATUS" == *"not exist"* ]] && return 1 || return 0
 }
 
 docker_machine_env ()
@@ -2246,15 +2241,13 @@ docker_machine_remove ()
 	# Store host-only interface name before removing the VM.
 	local vboxifname=$("$vboxmanage" showvminfo "$machine_name" 2>/dev/null | grep "Host-only" | sed "s/.*Host-only.*'\(.*\)'.*/\1/g")
 	docker-machine rm -f "$machine_name"
-	if ! is_docker_machine_exist "$machine_name" "true"; then
+	if ! is_docker_machine_exist "true"; then
 		# If the VM was removed, remove the DHCP server associated with its network interface.
 		# This ensures that we always get the lower bound IP address from the DHCP address pool (i.e., ".100").
 		"$vboxmanage" dhcpserver remove --netname "HostInterfaceNetworking-${vboxifname}" >/dev/null 2>&1
 		# Killing the network interface also helps to avoid issues when VM is recreated.
 		"$vboxmanage" hostonlyif remove "$vboxifname" >/dev/null 2>&1
 	fi
-
-	configure_mounts off
 }
 
 # Create a NFS export

--- a/bin/fin
+++ b/bin/fin
@@ -2142,7 +2142,6 @@ docker_machine_create ()
 	if [[ $? -eq 0 ]]; then
 		DOCKER_MACHINE_NAME="$machine_name"
 		DOCKER_MACHINE_STATUS='Running'
-		vm active "$machine_name"
 	else
 		return 1
 	fi


### PR DESCRIPTION
- Dropped unused vm use cases
  - `vm create`
  - `vm active`
  - `vm ip <IP>`
- Deprecated `fin vm start/stop` in favor of `fin system start/stop`