### PR TITLE
Added ability to run an alias in a custom command

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -6323,6 +6323,7 @@ addon_execute ()
 		# Run the command
 		CONTAINER_NAME="$_exec_target" _exec "$cmd"
 	else
+		export ADDON_SCRIPT=true
 		exec "$addon" "$@"
 	fi
 }
@@ -7211,6 +7212,15 @@ if [[ "$1" == "@"* ]]; then
 	fi
 	[[ "$1" == "" ]] && echo "$_alias_cd" && exit
 	cd "$_alias_cd" 2>/dev/null
+
+	# If ran within a script
+	if [[ -n $ADDON_SCRIPT ]]; then
+		unset COMPOSE_PROJECT_NAME
+		unset COMPOSE_PROJECT_NAME_SAFE
+		unset COMPOSE_PROJECT_VHOST_NAME_SAFE
+		unset VIRTUAL_HOST
+	fi
+
 	if_failed_error "Could not navigate to directory linked by $1 alias"
 fi
 


### PR DESCRIPTION
When running commands in custom commands with aliases there is an issue where the VIRTUAL_HOST and the PROJECT_SAFE_NAME

To reproduce:

* create two projects (project1 and project2)
* start both projects
* in project2 create a custom command in project2
```bash
#!/usr/bin/env bash

fin @project1 project status
```
* in project2 run `fin test`
* Should get a similar response

```
 ERROR:  Another project is already using the name 'project2'
         Change the name of the current project by renaming the project folder (folder name defines the project name and has to be unique)
         or remove the other project's stack by running fin project remove in /Users/sean.dietrich/Desktop/docksal_test/project2
```

Solves https://github.com/docksal/docksal/issues/974