### PR TITLE
WSL full support

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -3393,8 +3393,9 @@ configure_network ()
 {
 	local mode="${1:-on}"
 
-	# Set mode to off for Mac and Windows when not running in "native" mode
-	if ! is_docker_native && (is_mac || is_windows); then
+	# Always set mode to "off" when running on Mac/Windows/WSL in VirtualBox mode.
+	# Mode "on" is only applicable to Linux and Docker for Mac/Windows.
+	if ! is_docker_native && (is_mac || is_windows || is_wsl); then
 		mode="off"
 	fi
 

--- a/bin/fin
+++ b/bin/fin
@@ -711,9 +711,9 @@ is_docker_running ()
 	if ! is_linux && ! is_docker_native; then
 		if ! is_docker_machine_running; then return 255; fi
 	fi
-	# Check if docker is running via docker info.
+	# Check if docker is running via docker version.
 	# This operation is instant even if docker is not running (assuming a socket is used).
-	which docker >/dev/null 2>&1 && docker info >/dev/null || return 1
+	which docker >/dev/null 2>&1 && docker version >/dev/null || return 1
 }
 
 is_docksal_running ()

--- a/bin/fin
+++ b/bin/fin
@@ -3371,11 +3371,18 @@ configure_network_windows ()
 # Configure Docksal network settings on WSL
 configure_network_wsl ()
 {
-	# TODO: implement on/off modes
 	local mode="${1:-on}"
 
-	sudowin netsh.exe interface ip add address name=\"vEthernet \(DockerNAT\)\" address="${DOCKSAL_IP}" mask="255.255.255.0"
-	sudowin netsh.exe interface ip add address name=\"vEthernet \(DockerNAT\)\" address="${DOCKSAL_HOST_IP}" mask="255.255.255.0"
+	# Docker for Win
+	if [[ "$mode" == "on" ]]; then
+		# Add Docksal IP aliases on the DockerNAT adapter
+		sudowin netsh.exe interface ip add address name=\"vEthernet \(DockerNAT\)\" addr="${DOCKSAL_IP}" mask="255.255.255.0"
+		sudowin netsh.exe interface ip add address name=\"vEthernet \(DockerNAT\)\" addr="${DOCKSAL_HOST_IP}" mask="255.255.255.0"
+	elif [[ "$mode" == "off" ]]; then
+		# Remove Docksal IP aliases on the DockerNAT adapter
+		sudowin netsh.exe interface ip delete address name=\"vEthernet \(DockerNAT\)\" addr="${DOCKSAL_IP}"
+		sudowin netsh.exe interface ip delete address name=\"vEthernet \(DockerNAT\)\" addr="${DOCKSAL_HOST_IP}"
+	fi
 	# Wait 5s for network configuration to apply
 	sleep 5
 }

--- a/bin/fin
+++ b/bin/fin
@@ -1769,7 +1769,6 @@ show_help_vm ()
 	printh "ssh [command]" "Log into ssh or run a command via ssh"
 	printh "remove" "Remove Docksal machine and cleanup after it"
 	printh "ip" "Show the machine IP address"
-	# printh "ip [new ip]" "Set machine IP address (requires vm restart)"
 	printh "ls" "List all docker machines"
 	printh "env" "Display the commands to set up the shell for direct use of Docker client"
 	printh "mount" "Try remounting host filesystem (NFS on macOS, SMB on Windows)"
@@ -2195,28 +2194,6 @@ docker_machine_stop ()
 	docker-machine stop "$DOCKER_MACHINE_NAME"
 }
 
-docker_machine_change_ip ()
-{
-	echo "(docksal) Applying IP address $DOCKER_MACHINE_IP"
-	# extract first three parts of IP and append 255 to get broadcast mask
-	local BROADCAST_MASK=`expr "$DOCKER_MACHINE_IP" : '\([0-9][0-9]*[0-9]*\.[0-9][0-9]*[0-9]*\.[0-9][0-9]*[0-9]*\.\)'`'255';
-	docker-machine ssh "$DOCKER_MACHINE_NAME" "sudo cat /var/run/udhcpc.eth1.pid | xargs sudo kill" && \
-		docker-machine ssh "$DOCKER_MACHINE_NAME" "sudo ifconfig eth1 $DOCKER_MACHINE_IP netmask 255.255.255.0 broadcast $BROADCAST_MASK up" && \
-		sleep 2 && \
-		docker-machine regenerate-certs "$DOCKER_MACHINE_NAME" -f
-	sleep 2
-	local i=0
-	local _logs=""
-	for i in `seq 20`; do
-		_logs=$(docker-machine env "$DOCKER_MACHINE_NAME" 2>&1)
-		if [[ $? -eq 0 ]]; then return; fi
-		echo "IP validation (attempt #${i})..."
-		sleep 3
-	done
-	echo "$_logs"
-	return 1
-}
-
 docker_machine_start ()
 {
 	check_binary_found 'docker-machine'
@@ -2613,27 +2590,6 @@ vm ()
 	fi
 
 	case $1 in
-		create)
-			# usage: fin vm create <machine_name>
-			shift
-			# errors handling
-			[[ "$1" == "" ]] && echo "Please provide a name for a new vm." && return 1
-			is_docker_machine_exist "$1" && echo "Machine ${1} already exists." && return 1
-			# create
-			docker_machine_create "$1"
-			;;
-		active)
-			# Get/Set active vm
-			shift
-			if [[ "$1" == "" ]]; then
-				echo "$DOCKER_MACHINE_NAME"
-			else
-				[[ "$1" == "$DOCKER_MACHINE_NAME" ]] && echo "$1 is already active" && return 0
-				! is_docker_machine_exist "$1" && echo "No docker machine with name $1" && return 1
-				mkdir -p "$CONFIG_MACHINES" || return 1
-				echo "$1" | tee "$CONFIG_MACHINE_ACTIVE" >/dev/null && echo "$1 is set active"
-			fi
-			;;
 		start)
 			if is_docker_machine_running; then
 				echo "Machine \"$DOCKER_MACHINE_NAME\" is already running."
@@ -2656,7 +2612,7 @@ vm ()
 			;;
 		ssh)
 			shift
-			docker-machine ssh "$DOCKER_MACHINE_NAME" "$@"
+			docker-machine ssh ${DOCKER_MACHINE_NAME} "$@"
 			;;
 		stats)
 			vm-stats
@@ -2682,24 +2638,10 @@ vm ()
 			configure_mounts
 			;;
 		ip)
-			shift
-			local machine_name="${1:-$DOCKER_MACHINE_NAME}"
-			if [[ "$1" =~ [0-9][0-9]*[0-9]*.[0-9][0-9]*[0-9]*\.[0-9][0-9]*[0-9]*\.[0-9] ]]; then
-				# set ip
-				echo-green "Setting ip to $1..."
-#				echo "$1" > "$DOCKER_MACHINE_FOLDER/ip"
-#				echo-yellow "IP change will take effect on next machine start."
-				DOCKER_MACHINE_IP="$1"
-				docker_machine_change_ip
-			else
-				docker-machine ip "$machine_name"
-			fi
-
+			docker-machine ip ${DOCKER_MACHINE_NAME}
 			;;
 		env)
-			shift
-			DOCKER_MACHINE_NAME="${1:-$DOCKER_MACHINE_NAME}"
-			docker-machine env "$DOCKER_MACHINE_NAME"
+			docker-machine env ${DOCKER_MACHINE_NAME}
 			;;
 		ram)
 			shift
@@ -2713,7 +2655,7 @@ vm ()
 			show_help_vm
 			;;
 		regenerate-certs)
-			docker-machine regenerate-certs -f "$DOCKER_MACHINE_NAME"
+			docker-machine regenerate-certs -f ${DOCKER_MACHINE_NAME}
 			vm restart
 			;;
 		*)

--- a/bin/fin
+++ b/bin/fin
@@ -2677,7 +2677,7 @@ vm ()
 			docker-machine ip ${DOCKER_MACHINE_NAME}
 			;;
 		env)
-			docker-machine env ${DOCKER_MACHINE_NAME}
+			docker-machine env --shell=bash ${DOCKER_MACHINE_NAME}
 			;;
 		ram)
 			shift

--- a/bin/fin
+++ b/bin/fin
@@ -2529,7 +2529,7 @@ smb_share_mount()
 	command_mount="
 		(sudo umount $mount_point >/dev/null 2>&1 || true) && \
 		sudo mkdir -p $mount_point && \
-		sudo mount -t cifs -o username='${USERNAME}',pass='${password}',domain='${USERDOMAIN}',sec='${SMB_SEC}',vers=3,nobrl,mfsymlinks,noperm,actimeo=1,dir_mode=0777,file_mode=0777 //${DOCKSAL_HOST_IP}/$share_name $mount_point"
+		sudo mount -t cifs -o username='${USERNAME}',pass='${password}',domain='${USERDOMAIN}',sec='${SMB_SEC}',vers=3.02,nobrl,mfsymlinks,noperm,actimeo=1,dir_mode=0777,file_mode=0777 //${DOCKSAL_HOST_IP}/$share_name $mount_point"
 	docker-machine ssh ${DEFAULT_MACHINE_NAME} "$command_mount"
 
 	# Perform a second attenpt with sec=ntlm if the first one (with ntslssp or custom override via SMB_SEC=) failed.

--- a/bin/fin
+++ b/bin/fin
@@ -2195,7 +2195,12 @@ docker_machine_env ()
 	rm -f "$CONFIG_MACHINES_ENV" 2>/dev/null
 
 	# get the env
-	_env=$(docker-machine env --shell=bash "$DOCKER_MACHINE_NAME")
+	if is_wsl; then
+		# on wsl docker-machine is windows binary, but WSL does not understand windows paths
+		_env=$(docker-machine env --shell=bash docksal | sed "s/\\\\/\//g" | sed "s/C:/\/c/")
+	else
+		_env=$(docker-machine env --shell=bash "$DOCKER_MACHINE_NAME")
+	fi
 	res=$?
 
 	# apply the env
@@ -3727,7 +3732,7 @@ configure_resolver ()
 	elif [[ "$mode" == "off" ]]; then
 		echo-green "Disabling automatic *.$DOCKSAL_DNS_DOMAIN DNS resolver..."
 	fi
-return
+
 	is_mac && configure_resolver_mac "$mode" && return $?
 	is_linux && configure_resolver_alpine "$mode" && return $?
 	is_windows && configure_resolver_windows "$mode" && return $?
@@ -4083,19 +4088,15 @@ install_tools_generic_linux ()
 # Install WSL dependencies
 install_tools_wsl ()
 {
+	! is_docker_native && docker_machine_env
 	# Install Docker client
-	if ! is_docker_version; then
+	if ! is_docker_version || ! is_docker_server_version; then
 		echo-green "Installing Docker..."
-		# Install packages to allow apt to use a repository over HTTPS
-		sudo apt-get install apt-transport-https ca-certificates curl software-properties-common
-		# Add Docker's official GPG key
-		curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-		# Set up the repository
-		sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-		# Update source lists
-		sudo apt-get update
-		# Install Docker
-		sudo apt-get install docker-ce -y --allow-unauthenticated
+		# Pin docker version
+		curl -fsSL "${URL_DOCKER_NIX}" | VERSION=${REQUIREMENTS_DOCKER} sh
+		# Using $LOGNAME, not $(whoami). See http://stackoverflow.com/a/4598126/4550880.
+		sudo usermod -aG docker "$LOGNAME"
+		sudo docker version
 		if_failed "Docker installation/upgrade has failed."
 	fi
 

--- a/bin/fin
+++ b/bin/fin
@@ -529,7 +529,16 @@ get_container_id ()
 # Run command on Windows with elevated privileges
 winsudo ()
 {
-	cygstart --action=runas cmd /c "$@"
+	if is_wsl; then
+		# TODO: WIP
+		# Starting an elevated cmd.exe and passing command(s) to it.
+		# Make sure to enclose them in quotes like this:
+		# winsudo "'<command(s) to execute in elevated cmd.exe>'"
+		powershell.exe Start-Process -Wait -Verb RunAs cmd.exe -Args "'/C', '$@'"
+	else
+		# Backward compatibility wth Babun/Cygwin
+		cygstart --action=runas cmd /c "$@"
+	fi
 }
 
 # Run command on Windows and WSL with elevated privileges
@@ -2441,13 +2450,21 @@ docker_machine_mount_nfs ()
 # See http://serverfault.com/a/236393 for details.
 smb_windows_fix()
 {
-	! is_windows && return
+	(! is_windows || ! is_wsl) && return
 
 	echo-green "Going to optimize Windows network settings for file sharing..."
 	echo "You may see an elevated command prompt - click Yes."
 	sleep 2
 
-	local tmpfile="/tmp/fix-smb.reg"
+	if is_wsl; then
+		tmpfile="/mnt/c/Windows/temp/fix-smb.reg"
+		tmpfile_win=$(wsl_path -w ${tmpfile})
+	else
+		# Backward compatibility with Babun
+		tmpfile="/cygdrive/c/Windows/temp/fix-smb.reg"
+		tmpfile_win=$(cygpath -w ${tmpfile})
+	fi
+
 	cat <<EOF > $tmpfile
 Windows Registry Editor Version 5.00
 
@@ -2458,7 +2475,11 @@ Windows Registry Editor Version 5.00
 "Size"=dword:00000003
 EOF
 	# Update registry and restart Server and Computer Browser services.
-	winsudo "regedit /S $(cygpath -w ${tmpfile}) && net stop server /y && net start server && net start browser"
+	if is_wsl; then
+		winsudo "'regedit /S ${tmpfile_win} && net stop server /y && net start server && net start browser'"
+	else
+		winsudo "regedit /S $(cygpath -w ${tmpfile}) && net stop server /y && net start server && net start browser"
+	fi
 }
 
 # Method to create the user and SMB network share on Windows.

--- a/bin/fin
+++ b/bin/fin
@@ -2113,7 +2113,7 @@ docker_machine_create ()
 
 	local machine_name="${1:-$DEFAULT_MACHINE_NAME}"
 
-	if is_docker_machine_exist "$machine_name"; then
+	if is_docker_machine_exist; then
 		echo-error "Docker Machine '$machine_name' already exists"
 		return 1
 	fi
@@ -2144,22 +2144,17 @@ docker_machine_create ()
 	fi
 }
 
-# Param $1 machine name (defaults to $DOCKER_MACHINE_NAME)
-# Param $2 refresh machine status true|false (defaults to false)
+# Param $1 refresh machine status true|false (defaults to false)
 is_docker_machine_exist ()
 {
-	local refresh="${2:-false}"
-
 	! which 'docker-machine' >/dev/null 2>&1 && return 1
-	if [[ "$1" != "" ]] && [[ "$1" != "$DOCKER_MACHINE_NAME" ]]; then
-		docker-machine ls | grep "$1" >/dev/null 2>&1
-	else
-		if [[ "$refresh" == "true" ]]; then
-			# Refresh VM status in case it changed while the script was running.
-			DOCKER_MACHINE_STATUS=$(docker-machine status "$DOCKER_MACHINE_NAME" 2>&1 || echo '')
-		fi
-		[[ "$DOCKER_MACHINE_STATUS" == *"not exist"* ]] && return 1 || return 0
+
+	local refresh="${1:-false}"
+	if [[ "$refresh" == "true" ]]; then
+		# Refresh VM status in case it changed while the script was running.
+		DOCKER_MACHINE_STATUS=$(docker-machine status "$DOCKER_MACHINE_NAME" 2>&1 || echo '')
 	fi
+	[[ "$DOCKER_MACHINE_STATUS" == *"not exist"* ]] && return 1 || return 0
 }
 
 docker_machine_env ()
@@ -2243,15 +2238,13 @@ docker_machine_remove ()
 	# Store host-only interface name before removing the VM.
 	local vboxifname=$("$vboxmanage" showvminfo "$machine_name" 2>/dev/null | grep "Host-only" | sed "s/.*Host-only.*'\(.*\)'.*/\1/g")
 	docker-machine rm -f "$machine_name"
-	if ! is_docker_machine_exist "$machine_name" "true"; then
+	if ! is_docker_machine_exist "true"; then
 		# If the VM was removed, remove the DHCP server associated with its network interface.
 		# This ensures that we always get the lower bound IP address from the DHCP address pool (i.e., ".100").
 		"$vboxmanage" dhcpserver remove --netname "HostInterfaceNetworking-${vboxifname}" >/dev/null 2>&1
 		# Killing the network interface also helps to avoid issues when VM is recreated.
 		"$vboxmanage" hostonlyif remove "$vboxifname" >/dev/null 2>&1
 	fi
-
-	configure_mounts off
 }
 
 # Create a NFS export

--- a/bin/fin
+++ b/bin/fin
@@ -3432,7 +3432,7 @@ configure_mounts ()
 			fi
 		fi
 		# Create, then mount shares in VirtualBox
-		if [[ is_wsl || is_windows ]] && ! is_docker_native; then
+		if is_wsl || is_windows && ! is_docker_native; then
 			echo-green "Configuring SMB shares..."
 			docker_machine_mount_smb
 		fi
@@ -3441,7 +3441,7 @@ configure_mounts ()
 			echo-green "Removing NFS exports..."
 			nfs_share_remove
 		fi
-		if [[ is_wsl || is_windows ]] && ! is_docker_native; then
+		if is_wsl || is_windows && ! is_docker_native; then
 			echo-green "Removing SMB shares..."
 			smb_share_remove
 		fi

--- a/bin/fin
+++ b/bin/fin
@@ -532,7 +532,7 @@ winsudo ()
 	cygstart --action=runas cmd /c "$@"
 }
 
-# Run command on Windows and WSL with elevated provileges
+# Run command on Windows and WSL with elevated privileges
 sudowin ()
 {
 	local command="$1"
@@ -3525,7 +3525,7 @@ detect_dns ()
 		fi
 
 		# If previous detection failed, try another one. Lists all DNS addresses. Uses first non-localhost
-		# Not an ideal check as it might pick the wrong one is there are several, but better than nothing 
+		# Not an ideal check as it might pick the wrong one if there are several, but better than nothing 
 		if [[ "$DOCKSAL_DNS_UPSTREAM" == "" ]]; then
 			dns_addresses=""
 			IFS=$'\n'

--- a/bin/fin
+++ b/bin/fin
@@ -701,7 +701,7 @@ check_winpty_found ()
 
 is_docker_running ()
 {
-	if ! is_linux && ! is_docker_native && ! is_wsl; then
+	if ! is_linux && ! is_docker_native; then
 		if ! is_docker_machine_running; then return 255; fi
 	fi
 	# Check if docker is running via docker info.
@@ -801,7 +801,7 @@ check_docker_running ()
 	# Last chance to return non-error code
 	[[ ${docker_status} -eq 0 ]] && return
 
-	if [[ ${docker_status} -eq 255 ]] && (! is_docker_native && ! is_wsl); then
+	if [[ ${docker_status} -eq 255 ]] && ! is_docker_native; then
 		echo-yellow "It looks like '$DOCKER_MACHINE_NAME' docker machine is not running."
 		_confirm "Start it now?"
 		docker_machine_start
@@ -3112,7 +3112,7 @@ system_status ()
 # Starts all Docksal related things
 system_start ()
 {
-	if ! is_linux && ! is_docker_native && ! is_wsl; then
+	if ! is_linux && ! is_docker_native; then
 		if is_docker_machine_running; then
 			echo "Machine ${DOCKER_MACHINE_NAME} is already running."
 		else
@@ -3128,7 +3128,7 @@ system_start ()
 # Stops/disables all Docksal things
 system_stop ()
 {
-	if ! is_linux && ! is_docker_native && ! is_wsl; then
+	if ! is_linux && ! is_docker_native; then
 		# Stop the docker-machine VM.
 		if is_docker_machine_running; then
 			echo-green "Stopping Docksal VM..."

--- a/bin/fin
+++ b/bin/fin
@@ -3058,13 +3058,13 @@ system_reset ()
 	if [[ "$1" == "" ]] ; then
 		configure_network
 		configure_mounts
-		echo-green 'Resetting Docksal services...'
-		echo ' ➔ proxy'
+		echo-green 'Resetting Docksal system services...'
+		echo ' * proxy'
 		install_proxy_service
-		echo ' ➔ dns'
+		echo ' * dns'
 		install_dns_service
 		configure_resolver
-		echo ' ➔ ssh-agent'
+		echo ' * ssh-agent'
 		install_sshagent_service
 		return
 	fi
@@ -3119,7 +3119,6 @@ system_start ()
 		fi
 	fi
 
-	echo "Starting Docksal system services..."
 	system_reset
 }
 

--- a/bin/fin
+++ b/bin/fin
@@ -148,6 +148,7 @@ DOCKER_MACHINE_BIN="$CONFIG_BIN_DIR/docker-machine"
 WINPTY_BIN="$CONFIG_BIN_DIR/winpty"
 vboxmanage="VBoxManage"
 is_windows && vboxmanage="/cygdrive/c/Program Files/Oracle/VirtualBox/VBoxManage.exe"
+is_wsl && vboxmanage="/mnt/c/Program Files/Oracle/VirtualBox/VBoxManage.exe"
 # Stacks folder
 CONFIG_STACKS_DIR="$HOME/.docksal/stacks"
 mkdir -p "$CONFIG_STACKS_DIR" >/dev/null 2>&1
@@ -386,7 +387,7 @@ wsl_get_environment_var ()
 # Unfortunately wslpath output contains \r that has to be cleaned 
 wsl_path ()
 {
-	echo $(wslpath "$1" | tr -d '[:cntrl:]')
+	echo $(wslpath "$@" | tr -d '[:cntrl:]')
 }
 
 # Search for a file/directory in a directory tree upwards. Return its path.
@@ -4137,7 +4138,7 @@ install_tools_wsl ()
 	# Install windows docker-machine to location where Windows can access it
 	# Create symlink for WSL
 	if ! is_docker_machine_version; then
-		local USERPROFILE=$(wsl_path $(wsl_get_environment_var "USERPROFILE"))
+		local USERPROFILE=$(wsl_path -u $(wsl_get_environment_var "USERPROFILE"))
 		local DMDIR="$USERPROFILE/bin"
 		local DMBIN="$DMDIR/docker-machine.exe"
 
@@ -4160,6 +4161,12 @@ update_virtualbox () {
 	if is_windows; then
  		url="$URL_VBOX_WIN"
 		vbox_pkg=$(cygpath -u "$USERPROFILE/Downloads")/$(basename "$url")
+	fi
+
+	if is_wsl; then
+		url="$URL_VBOX_WIN"
+		local USERPROFILE=$(wsl_path -u $(wsl_get_environment_var "USERPROFILE"))
+		vbox_pkg="$USERPROFILE/Downloads"/$(basename "$url")
 	fi
 
 	if is_mac; then
@@ -4199,7 +4206,7 @@ update_virtualbox () {
 	)
 
 	# Download and install Win
-	is_windows && (
+	(is_windows || is_wsl) && (
 		chmod +x "$vbox_pkg"
 		"$vbox_pkg"
 	)
@@ -4350,7 +4357,7 @@ update ()
 	# Pre-update check #1: check if there is existing but stopped Docksal machine
 	# We need it running to know Docker server version
 	if (${FULL_UPDATE}); then
-		if ! is_linux && ! is_docker_native && ! is_wsl; then
+		if ! is_linux && ! is_docker_native; then
 			# Check VirtualBox
 			is_vbox_version
 			local res=$?
@@ -4363,7 +4370,7 @@ update ()
 			fi
 		fi
 
-		if ! is_linux && ! is_docker_native && ! is_wsl && which 'docker-machine' >/dev/null 2>&1; then
+		if ! is_linux && ! is_docker_native && which 'docker-machine' >/dev/null 2>&1; then
 			if is_docker_machine_exist && ! is_docker_machine_running; then
 				echo-error "Docker Machine '$DOCKER_MACHINE_NAME' should be running to perform update" \
 					"Start it with ${yellow}fin system start${NC} or destroy it with ${yellow}fin vm kill${NC} if you want it re-created."

--- a/bin/fin
+++ b/bin/fin
@@ -245,6 +245,7 @@ STACKS_VOLUMES_UNISON="volumes-unison.yml"
 
 URL_DOCKER_MAC="https://download.docker.com/mac/static/stable/x86_64/docker-${REQUIREMENTS_DOCKER}.tgz"
 URL_DOCKER_NIX="https://get.docker.com/"
+URL_DOCKER_LINUX="https://download.docker.com/linux/static/stable/x86_64/docker-${REQUIREMENTS_DOCKER}.tgz"
 # Until there is an official standalone docker.exe binary available, use the one pulled from Docker for Windows
 # See https://github.com/docker/for-win/issues/1460#issuecomment-390045959
 #URL_DOCKER_WIN="https://download.docker.com/win/static/stable/x86_64/docker-${REQUIREMENTS_DOCKER}.zip"
@@ -4088,18 +4089,47 @@ install_tools_generic_linux ()
 # Install WSL dependencies
 install_tools_wsl ()
 {
-	! is_docker_native && docker_machine_env
-	# Install Docker client
-	if ! is_docker_version || ! is_docker_server_version; then
-		echo-green "Installing Docker..."
-		# Pin docker version
-		curl -fsSL "${URL_DOCKER_NIX}" | VERSION=${REQUIREMENTS_DOCKER} sh
-		# Using $LOGNAME, not $(whoami). See http://stackoverflow.com/a/4598126/4550880.
-		sudo usermod -aG docker "$LOGNAME"
-		sudo docker version
-		if_failed "Docker installation/upgrade has failed."
+	mkdir -p "$CONFIG_DOWNLOADS_DIR" 2>/dev/null
+	if_failed "Could not create $CONFIG_DOWNLOADS_DIR"
+
+	# Install Linux Docker client
+	if ! is_docker_version; then
+		local docker_pkg=$(basename "$URL_DOCKER_LINUX")
+		echo-green "Installing docker client v${REQUIREMENTS_DOCKER}..."
+		if [[ ! -f "$docker_pkg" ]]; then
+			echo-green "Downloading ${docker_pkg}..."
+			curl -fL# "$URL_DOCKER_LINUX" -o "$CONFIG_DOWNLOADS_DIR/$docker_pkg"
+			if_failed "Check internet connection."
+		# Use a local/portable copy if available
+		else
+			echo "Found a local copy of ${docker_pkg}. Using it..."
+			cp -f "$docker_pkg" "$CONFIG_DOWNLOADS_DIR"
+			if_failed "Check file permissions."
+		fi
+
+		# Run in sub-shell so we don't have to cd back
+		(
+			cd "$CONFIG_DOWNLOADS_DIR" && \
+			tar zxf "$docker_pkg" && \
+			mv -f "docker/docker" "$CONFIG_BIN_DIR/" && \
+			chmod +x "$DOCKER_BIN"
+		)
+		if_failed "Check file permissions."
 	fi
 
+	# Install Linux Docker Compose
+	if ! is_docker_compose_version; then
+		echo-green "Installing Docker Compose..."
+		sudo curl -fL# "$URL_DOCKER_COMPOSE_NIX" -o "$DOCKER_COMPOSE_BIN_NIX" && \
+			sudo chmod +x "$DOCKER_COMPOSE_BIN_NIX" && \
+			docker-compose --version
+		if_failed "Docker Compose installation/upgrade has failed."
+	fi
+
+	# Cleanup
+	rm -rf "$CONFIG_DOWNLOADS_DIR" >/dev/null 2>&1
+
+	! is_docker_native && docker_machine_env
 	# Install windows docker-machine to location where Windows can access it
 	# Create symlink for WSL
 	if ! is_docker_machine_version; then
@@ -4116,17 +4146,6 @@ install_tools_wsl ()
 			sudo ln -s "$DMBIN" "$DOCKER_MACHINE_BIN_NIX"
 		if_failed "Check file permissions and internet connection."
 	fi
-
-	# Install Linux Docker Compose
-	if ! is_docker_compose_version; then
-		echo-green "Installing Docker Compose..."
-		sudo curl -fL# "$URL_DOCKER_COMPOSE_NIX" -o "$DOCKER_COMPOSE_BIN_NIX" && \
-			sudo chmod +x "$DOCKER_COMPOSE_BIN_NIX" && \
-			docker-compose --version
-		if_failed "Docker Compose installation/upgrade has failed."
-	fi
-
-	system_reset
 }
 
 update_virtualbox () {

--- a/bin/fin
+++ b/bin/fin
@@ -4371,7 +4371,7 @@ update ()
 			if_failed_error "Docker for Windows is not running" "Start Docker for Windows, wait for Docker to start and run update again."
 
 			# Check for administrative privileges if needed
-			if ! (ipconfig.exe | grep "$DOCKSAL_IP") || ! (ipconfig.exe | grep "$DOCKSAL_HOST_IP"); then
+			if ! (ipconfig.exe | grep "$DOCKSAL_IP" &>/dev/null) || ! (ipconfig.exe | grep "$DOCKSAL_HOST_IP" &>/dev/null); then
 				cd "/mnt/c"
 				touch "file.tmp" &>/dev/null
 				if [[ "$?" != "0" ]]; then

--- a/bin/fin
+++ b/bin/fin
@@ -5497,7 +5497,7 @@ sysinfo ()
 	elif is_mac; then
 		df -h # mac native
 	else
-		wmic logicaldisk get size,freespace,caption # win native
+		wmic.exe logicaldisk get size,freespace,caption # win native
 	fi
 
 	if [[ "$all" == "all" ]]; then

--- a/bin/fin
+++ b/bin/fin
@@ -808,10 +808,11 @@ check_docker_running ()
 	# Last chance to return non-error code
 	[[ ${docker_status} == 0 ]] && return
 
-	if [[ ${docker_status} -eq 255 ]] && ! is_docker_native; then
+	if [[ ${docker_status} == 255 ]] && ! is_docker_native; then
 		echo-yellow "It looks like '$DEFAULT_MACHINE_NAME' docker machine is not running."
 		_confirm "Start it now?"
-		system_start && return $?
+		system_start
+		return $?
 	fi
 
 	# TODO: Should the checks below be moved to system_start?
@@ -2617,7 +2618,8 @@ vm ()
 	case $1 in
 		start)
 			# Show a message and pause for input.
-			echo -e "Deprecated. Please use ${yellow}fin system start${NC} instead."; read -p "Press any key to continue..."
+			echo -e "Deprecated. Please use ${yellow}fin system start${NC} instead."
+			read -p "Press any key to continue..."
 			system_start
 			;;
 		restart)
@@ -3550,7 +3552,7 @@ detect_dns ()
 		fi
 	fi
 
-	# If localhost address or empty was detected as upstream, fall back to the default
+	# If detected upstream points to localhost or is empty, then fall back to the default
 	if [[ "$DOCKSAL_DNS_UPSTREAM" =~ "127.0."* || "$DOCKSAL_DNS_UPSTREAM" == "" ]]; then
 		DOCKSAL_DNS_UPSTREAM="$DOCKSAL_DEFAULT_DNS"
 	fi
@@ -4389,7 +4391,7 @@ update ()
 		if ! is_linux && ! is_docker_native && which 'docker-machine' >/dev/null 2>&1; then
 			if is_docker_machine_exist && ! is_docker_machine_running; then
 				echo-error "Docker Machine '$DEFAULT_MACHINE_NAME' should be running to perform update" \
-					"Start it with ${yellow}fin system start${NC} or destroy it with ${yellow}fin vm kill${NC} if you want it re-created."
+					"Start it with ${yellow}fin system start${NC} or destroy it with ${yellow}fin vm remove${NC} if you want it re-created."
 				return 1
 			fi
 		fi

--- a/bin/fin
+++ b/bin/fin
@@ -3113,6 +3113,7 @@ system_start ()
 		else
 			echo "Starting Docksal VM..."
 			docker_machine_start
+			# docker_machine_start will quit here if something fails.
 		fi
 	fi
 

--- a/bin/fin
+++ b/bin/fin
@@ -4371,7 +4371,7 @@ update ()
 			fi
 		fi
 
-		if is_wsl; then
+		if is_wsl && is_docker_native; then
 			# Check Docker for Win running
 			IFS=':' read nc_host nc_port <<< "$DOCKER_HOST"
 			nc -w 1 ${nc_host} ${nc_port}

--- a/bin/fin
+++ b/bin/fin
@@ -546,9 +546,9 @@ sudowin ()
 		shift
 	done
 	if [[ "$arguments" != "" ]]; then
-		powershell.exe Start-Process -Wait -Verb runAs -FilePath "$command" -Args "$arguments"
+		(powershell.exe Start-Process -Wait -Verb runAs -FilePath "$command" -Args "$arguments")
 	else
-		powershell.exe Start-Process -Wait -Verb runAs -FilePath "$command"
+		(powershell.exe Start-Process -Wait -Verb runAs -FilePath "$command")
 	fi
 }
 

--- a/bin/fin
+++ b/bin/fin
@@ -3876,11 +3876,13 @@ install_tools_windows ()
 		fi
 
 		# Run in sub-shell so we don't have to cd back
+		# docker client binary downloaded from MS (e.g. docker-18-09-2.zip) is dynamically linked and needs DLLs from
+		# the archive. So unpacking everything below, not just docker.exe
 		(
 			cd "$CONFIG_DOWNLOADS_DIR" && \
-			unzip ${docker_pkg} && \
-			mv -f "docker/docker.exe" "$DOCKER_BIN.exe" && \
-			chmod +x "$DOCKER_BIN"
+			unzip -qq ${docker_pkg} && \
+			mv -f ./docker/* ${CONFIG_BIN_DIR}/ && \
+			chmod +x ${DOCKER_BIN}.exe
 		)
 		if_failed "Check file permissions."
 	fi

--- a/bin/fin
+++ b/bin/fin
@@ -381,7 +381,7 @@ cygpath_abs_unix ()
 # @param $1 var name
 wsl_get_environment_var () 
 {
-	$(cmd.exe /c "echo %$1%")
+	echo $(cmd.exe /c "echo %$1%" | tr -d '[:cntrl:]')
 }
 
 # Unfortunately wslpath output contains \r that has to be cleaned 
@@ -546,8 +546,12 @@ sudowin ()
 		fi
 		shift
 	done
+	if [[ "$arguments" != "" ]]; then
+		powershell.exe Start-Process -Wait -Verb runAs -FilePath "$command" -Args "$arguments"		
+	else
+		powershell.exe Start-Process -Wait -Verb runAs -FilePath "$command"
+	fi
 
-	powershell.exe Start-Process -Wait -Verb runAs -FilePath "$command" -Args "$arguments"
 }
 
 # Universal Bash parameter parsing
@@ -2460,12 +2464,18 @@ smb_share_add()
 	local share_name=$1
 	local share_path=$2
 
+	is_wsl && USERNAME="$(wsl_get_environment_var USERNAME)"
+
 	# Add SMB share if it does not exist.
-	if [[ "$(net share)" != *"${share_name}"*"Docksal ${share_path} drive"* ]];
+	if [[ "$(net.exe share)" != *"${share_name}"*"Docksal ${share_path} drive"* ]];
 	then
-		command_share="net share ${share_name}=${share_path} /grant:${USERNAME},FULL /REMARK:\"Docksal ${share_path} drive\""
+		command_share="net.exe share ${share_name}=${share_path} /grant:${USERNAME},FULL /REMARK:\"Docksal ${share_path} drive\""
 		echo-green "Adding docker SMB share..."
-		winsudo "$command_share"
+		if is_wsl; then
+			sudowin net.exe share "${share_name}=${share_path}" "/grant:${USERNAME},FULL" "/REMARK:Docksal-drive"
+		else
+			winsudo "$command_share"
+		fi
 
 		if [[ $? != 0 ]]; then
 			echo-error "SMB share creation failed." \
@@ -2498,6 +2508,8 @@ smb_share_mount()
 	local password=$3
 	# single quotes are banned from being used in password
 	password=${password//\'/}
+	is_wsl && USERNAME="$(wsl_get_environment_var USERNAME)"
+	is_wsl && USERDOMAIN="$(wsl_get_environment_var USERDOMAIN)"
 
 	# User ntlmssp by default. For some Windows machines ntlm should be used instead
 	# Also see https://unix.stackexchange.com/questions/124342/mount-error-13-permission-denied/124352#124352
@@ -2535,7 +2547,7 @@ docker_machine_mount_smb ()
 	# use his password for mount -t cifs ...
 
 	# Get a list of logical drives (type 3 = Local disk).
-	local drives=$(wmic logicaldisk get drivetype,name | grep 3 | awk '{print $2}' | sed 's/\r//g')
+	local drives=$(wmic.exe logicaldisk get drivetype,name | grep 3 | awk '{print $2}' | sed 's/\r//g')
 	read -s -p "Enter your Windows account password: " password
 	echo # Add a new line after user input.
 
@@ -2547,15 +2559,22 @@ docker_machine_mount_smb ()
 	fi
 
 	for drive in ${drives}; do
-		local mount_point=$(cygpath -u "$drive" | sed 's/^\/cygdrive\///')
+		# Mount point is lowercase drive letter with no slash
+		local mount_point
+		if is_wsl; then
+			mount_point=$(wslpath "$drive\\" | sed 's/\///g')
+		else
+			mount_point=$(cygpath -u "$drive" | sed 's/^\/cygdrive\///')
+		fi
 		# Avoid conflicts with existing drive shares buy using a unique share name
 		local share_name="docksal-$mount_point"
+		# echo smb_share_add "$share_name" "$drive"
 		smb_share_add "$share_name" "$drive" &&
 			smb_share_mount "$share_name" "/$mount_point" "$password"
 	done
 }
 
-# Creates bind mounts on WSL from /mnt/c to /c so that docker-compose pth would match path inside docker
+# Creates bind mounts on WSL from /mnt/c to /c so that docker-compose path would match path inside docker
 # See overridden pwd function too
 wsl_mount_drives ()
 {
@@ -3493,19 +3512,33 @@ detect_dns ()
 			# In case no name servers found, fall back to the default
 			DOCKSAL_DNS_UPSTREAM="$DOCKSAL_DEFAULT_DNS"
 		fi
-	elif is_windows; then
+	elif is_windows || is_wsl; then
 		# Look for Primary WINS server, it represents DNS whe WINS services is in use
-		local primary_wins=$(ipconfig /all | grep "Primary WINS")
+		local primary_wins=$(ipconfig.exe /all | grep "Primary WINS")
 		if [[ "$primary_wins" =~ ([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}) ]]; then
 			DOCKSAL_DNS_UPSTREAM=${BASH_REMATCH[0]}
-		else
-			# In case nothing was found, fall back to the default
-			DOCKSAL_DNS_UPSTREAM="$DOCKSAL_DEFAULT_DNS"
+		fi
+
+		# If previous detection failed, try another one. Lists all DNS addresses. Uses first non-localhost
+		# Not an ideal check as it might pick the wrong one is there are several, but better than nothing 
+		if [[ "$DOCKSAL_DNS_UPSTREAM" == "" ]]; then
+			dns_addresses=""
+			IFS=$'\n'
+			for dns_found in $(netsh.exe interface ip show config | grep DNS | grep -v None | grep -v $DOCKSAL_IP); do
+				dns_addresses=${dns_addresses}$(echo "$dns_found" | cut -d ":" -f 2 | tr -d '[:cntrl:]' | xargs)
+			done
+
+			for dns in $dns_addresses; do
+				if [[ ! "$dns" =~ "127.0."* ]]; then
+					DOCKSAL_DNS_UPSTREAM="${dns}"
+					break
+				fi
+			done
 		fi
 	fi
 
-	# If localhost address was detected as upstream, fall back to the default
-	if [[ "$DOCKSAL_DNS_UPSTREAM" =~ "127.0."* ]]; then
+	# If localhost address or empty was detected as upstream, fall back to the default
+	if [[ "$DOCKSAL_DNS_UPSTREAM" =~ "127.0."* || "$DOCKSAL_DNS_UPSTREAM" == "" ]]; then
 		DOCKSAL_DNS_UPSTREAM="$DOCKSAL_DEFAULT_DNS"
 	fi
 
@@ -3694,7 +3727,7 @@ configure_resolver ()
 	elif [[ "$mode" == "off" ]]; then
 		echo-green "Disabling automatic *.$DOCKSAL_DNS_DOMAIN DNS resolver..."
 	fi
-
+return
 	is_mac && configure_resolver_mac "$mode" && return $?
 	is_linux && configure_resolver_alpine "$mode" && return $?
 	is_windows && configure_resolver_windows "$mode" && return $?

--- a/bin/fin
+++ b/bin/fin
@@ -7078,6 +7078,9 @@ execute_hook ()
 
 #-------------------------- RUNTIME STARTS HERE ----------------------------
 
+# Debug mode: print all commands
+[[ ${FIN_DEBUG} == 1 ]] && set -x
+
 # Figure out COLUMNS and LINES (not set in scripts) have to be passed to workaround a bug in Docker.
 # See https://github.com/moby/moby/issues/35407#issuecomment-355753176
 if is_tty; then

--- a/bin/fin
+++ b/bin/fin
@@ -3674,8 +3674,11 @@ configure_resolver_wsl () {
 		# Use the default DockerNAT adapter
 		network_id="vEthernet (DockerNAT)"
 	else
-		# Figure out the name of the network (not the name of the adapter) the VM is using
-		network_id=$("$vboxmanage" showvminfo ${DEFAULT_MACHINE_NAME} --machinereadable | grep hostonlyadapter | cut -d'"' -f2 | sed 's/Ethernet Adapter/Network/')
+		# Need to check whether machine exists, otherwise we cannot get its info
+		if is_docker_machine_exist; then
+			# Figure out the name of the network (not the name of the adapter) the VM is using
+			network_id=$("$vboxmanage" showvminfo ${DEFAULT_MACHINE_NAME} --machinereadable | grep hostonlyadapter | cut -d'"' -f2 | sed 's/Ethernet Adapter/Network/')
+		fi
 	fi
 
 	if [[ "$network_id" == "" ]]; then

--- a/bin/fin
+++ b/bin/fin
@@ -2587,7 +2587,6 @@ wsl_mount_drives ()
 	# Create mnt point binds if they don't exist
 	for drive in $(ls /mnt); do
 		if ! (echo "$mounts" | grep " on /$drive " >/dev/null); then
-			echo "Applying necessary pre-flight WSL adjustments..."
 			echo "Creating bind mount /mnt/$drive -> /$drive"
 			sudo mkdir -p "/$drive"
 			sudo mount --bind "/mnt/$drive" "/$drive"

--- a/bin/fin
+++ b/bin/fin
@@ -144,7 +144,6 @@ CONFIG_BIN_DIR="$CONFIG_DIR/bin"
 CONFIG_DOWNLOADS_DIR="$CONFIG_BIN_DIR/downloads"
 DOCKER_BIN="$CONFIG_BIN_DIR/docker"
 DOCKER_COMPOSE_BIN="$CONFIG_BIN_DIR/docker-compose"
-DOCKER_COMPOSE_BIN_NIX="/usr/local/bin/docker-compose"
 DOCKER_MACHINE_BIN="$CONFIG_BIN_DIR/docker-machine"
 DOCKER_MACHINE_BIN_NIX="/usr/local/bin/docker-machine"
 WINPTY_BIN="$CONFIG_BIN_DIR/winpty"
@@ -4000,8 +3999,8 @@ install_tools_debian ()
 	# Install Docker Compose
 	if ! is_docker_compose_version; then
 		echo-green "Installing Docker Compose..."
-		sudo curl -fL# "$URL_DOCKER_COMPOSE_NIX" -o "$DOCKER_COMPOSE_BIN_NIX" && \
-			sudo chmod +x "$DOCKER_COMPOSE_BIN_NIX" && \
+		sudo curl -fL# "$URL_DOCKER_COMPOSE_NIX" -o "$DOCKER_COMPOSE_BIN" && \
+			sudo chmod +x "$DOCKER_COMPOSE_BIN" && \
 			docker-compose --version
 		if_failed "Docker Compose installation/upgrade has failed."
 	fi
@@ -4034,8 +4033,8 @@ install_tools_fedora ()
 	# Install Docker Compose
 	if ! is_docker_compose_version; then
 		echo-green "Installing Docker Compose..."
-		sudo curl -fL# "$URL_DOCKER_COMPOSE_NIX" -o "$DOCKER_COMPOSE_BIN_NIX" && \
-			sudo chmod +x "$DOCKER_COMPOSE_BIN_NIX" && \
+		sudo curl -fL# "$URL_DOCKER_COMPOSE_NIX" -o "$DOCKER_COMPOSE_BIN" && \
+			sudo chmod +x "$DOCKER_COMPOSE_BIN" && \
 			docker-compose --version
 		if_failed "Docker Compose installation/upgrade has failed."
 	fi
@@ -4079,8 +4078,8 @@ install_tools_generic_linux ()
 	# Install Docker Compose
 	if ! is_docker_compose_version; then
 		echo-green "Installing Docker Compose..."
-		sudo curl -fL# "$URL_DOCKER_COMPOSE_NIX" -o "$DOCKER_COMPOSE_BIN_NIX" && \
-			sudo chmod +x "$DOCKER_COMPOSE_BIN_NIX" && \
+		sudo curl -fL# "$URL_DOCKER_COMPOSE_NIX" -o "$DOCKER_COMPOSE_BIN" && \
+			sudo chmod +x "$DOCKER_COMPOSE_BIN" && \
 			docker-compose --version
 		if_failed "Docker Compose installation/upgrade has failed."
 	fi
@@ -4120,8 +4119,8 @@ install_tools_wsl ()
 	# Install Linux Docker Compose
 	if ! is_docker_compose_version; then
 		echo-green "Installing Docker Compose..."
-		sudo curl -fL# "$URL_DOCKER_COMPOSE_NIX" -o "$DOCKER_COMPOSE_BIN_NIX" && \
-			sudo chmod +x "$DOCKER_COMPOSE_BIN_NIX" && \
+		sudo curl -fL# "$URL_DOCKER_COMPOSE_NIX" -o "$DOCKER_COMPOSE_BIN" && \
+			sudo chmod +x "$DOCKER_COMPOSE_BIN" && \
 			docker-compose --version
 		if_failed "Docker Compose installation/upgrade has failed."
 	fi

--- a/bin/fin
+++ b/bin/fin
@@ -4122,33 +4122,51 @@ install_tools_wsl ()
 
 	# Install Linux Docker Compose
 	if ! is_docker_compose_version; then
-		echo-green "Installing Docker Compose..."
-		sudo curl -fL# "$URL_DOCKER_COMPOSE_NIX" -o "$DOCKER_COMPOSE_BIN" && \
-			sudo chmod +x "$DOCKER_COMPOSE_BIN" && \
-			docker-compose --version
-		if_failed "Docker Compose installation/upgrade has failed."
+		local dc_pkg=$(basename "$URL_DOCKER_COMPOSE_NIX")
+		echo-green "Installing docker-compose v${REQUIREMENTS_DOCKER_COMPOSE}..."
+		if [[ ! -f "$dc_pkg" ]]; then
+			echo-green "Downloading ${dc_pkg}..."
+			curl -fL# "$URL_DOCKER_COMPOSE_NIX" -o "$DOCKER_COMPOSE_BIN" && \
+				chmod +x "$DOCKER_COMPOSE_BIN"
+			if_failed "Check file permissions and internet connection."
+		# Use a local/portable copy if available
+		else
+			echo "Found a local copy of ${dc_pkg}. Using it..."
+			cp -f "$dc_pkg" "$DOCKER_COMPOSE_BIN" && \
+				chmod +x "$DOCKER_COMPOSE_BIN"
+			if_failed "Check file permissions."
+		fi
 	fi
+
+	# Install Windows Docker Machine client.
+	# The Linux one cannot correctly interact with the Windows VirtualBox cli, eventually resulting in something like:
+	# "Error creating machine: Error in driver during machine creation: write |1: broken pipe"
+	# The Windows binary has to be run from the Windows FS (e.g. from Windows user's profile).
+	local USERPROFILE=$(wsl_path -u $(wsl_env USERPROFILE))
+	local DOCKER_MACHINE_BIN_WSL="${USERPROFILE}/bin/docker-machine.exe"
+	mkdir -p "${USERPROFILE}/bin"
+	# Keeping the rest of the logic below very similar to other host environments.
+	if ! is_docker_machine_version; then
+		local dm_pkg=$(basename "$URL_DOCKER_MACHINE_WIN")
+		echo-green "Installing docker-machine v${REQUIREMENTS_DOCKER_MACHINE}..."
+		if [[ ! -f "$dm_pkg" ]]; then
+			echo-green "Downloading ${dm_pkg}..."
+			curl -fL# "$URL_DOCKER_MACHINE_WIN" -o "$DOCKER_MACHINE_BIN_WSL" && \
+				chmod +x "$DOCKER_MACHINE_BIN_WSL"
+			if_failed "Check file permissions and internet connection."
+		# Use a local/portable copy if available
+		else
+			echo "Found a local copy of ${dm_pkg}. Using it..."
+			cp -f "$dm_pkg" "$DOCKER_MACHINE_BIN_WSL" && \
+				chmod +x "$DOCKER_MACHINE_BIN_WSL"
+			if_failed "Check file permissions."
+		fi
+	fi
+	# Create a symlink to the Windows docker-machine binary inside the WSL FS.
+	ln -s "$DOCKER_MACHINE_BIN_WSL" "$DOCKER_MACHINE_BIN"
 
 	# Cleanup
 	rm -rf "$CONFIG_DOWNLOADS_DIR" >/dev/null 2>&1
-
-	! is_docker_native && docker_machine_env
-	# Install windows docker-machine to location where Windows can access it
-	# Create symlink for WSL
-	if ! is_docker_machine_version; then
-		local USERPROFILE=$(wsl_path -u $(wsl_get_environment_var "USERPROFILE"))
-		local DMDIR="$USERPROFILE/bin"
-		local DMBIN="$DMDIR/docker-machine.exe"
-
-		mkdir -p "$DMDIR"
-		if_failed "Could not create $DMDIR. Check your permissions."
-
-		echo-green "Downloading docker-machine..."
-		curl -fL# "$URL_DOCKER_MACHINE_WIN" -o "$DMBIN" &&
-			chmod +x "$DMBIN" &&
-			sudo ln -s "$DMBIN" "$DOCKER_MACHINE_BIN"
-		if_failed "Check file permissions and internet connection."
-	fi
 }
 
 update_virtualbox () {
@@ -4193,7 +4211,7 @@ update_virtualbox () {
 	# Stop VM
 	docker_machine_stop >/dev/null 2>&1
 
-	# Download and install Mac
+	# Install Mac
 	is_mac && (
 		echo "Attaching ${vbox_pkg}"
 		hdiutil detach "/Volumes/VirtualBox" >/dev/null 2>&1
@@ -4203,7 +4221,7 @@ update_virtualbox () {
 			open "/Volumes/VirtualBox/VirtualBox.pkg"
 	)
 
-	# Download and install Win
+	# Install Win/WSL
 	(is_windows || is_wsl) && (
 		chmod +x "$vbox_pkg"
 		"$vbox_pkg"

--- a/bin/fin
+++ b/bin/fin
@@ -5380,7 +5380,7 @@ sysinfo ()
 		echo "Linux Kernel"
 	elif is_docker_native; then
 		is_mac && echo "Docker for Mac"
-		is_windows && echo "Docker for Windows"
+		(is_windows || is_wsl) && echo "Docker for Windows"
 	else
 		echo "VirtualBox VM"
 	fi

--- a/bin/fin
+++ b/bin/fin
@@ -2584,11 +2584,12 @@ wsl_mount_drives ()
 	! is_wsl && return;
 	local mounts=$(mount)
 	# Create mnt point binds if they don't exist
-	for drive in $(ls "/mnt"); do
-		! (echo "$mounts" | grep "on /$drive" >/dev/null) && \
-			echo "Creating bind mount /mnt/$drive -> /$drive" && \
-			sudo mkdir -p "/$drive" && \
+	for drive in $(ls /mnt); do
+		if ! (echo "$mounts" | grep " on /$drive " >/dev/null); then
+			echo "Creating bind mount /mnt/$drive -> /$drive"
+			sudo mkdir -p "/$drive"
 			sudo mount --bind "/mnt/$drive" "/$drive"
+		fi
 	done
 }
 

--- a/bin/fin
+++ b/bin/fin
@@ -546,9 +546,9 @@ sudowin ()
 		shift
 	done
 	if [[ "$arguments" != "" ]]; then
-		(powershell.exe Start-Process -Wait -Verb runAs -FilePath "$command" -Args "$arguments")
+		powershell.exe Start-Process -Wait -Verb runAs -FilePath "$command" -Args "$arguments"
 	else
-		(powershell.exe Start-Process -Wait -Verb runAs -FilePath "$command")
+		powershell.exe Start-Process -Wait -Verb runAs -FilePath "$command"
 	fi
 }
 

--- a/bin/fin
+++ b/bin/fin
@@ -4374,7 +4374,7 @@ update ()
 			# Check for administrative privileges if needed
 			if ! (ipconfig.exe | grep "$DOCKSAL_IP") || ! (ipconfig.exe | grep "$DOCKSAL_HOST_IP"); then
 				cd "/mnt/c"
-				touch "file.tmp"
+				touch "file.tmp" &>/dev/null
 				if [[ "$?" != "0" ]]; then
 					echo-error "Docksal needs administrative privileges to set up network preferences." \
 						"--" \

--- a/bin/fin
+++ b/bin/fin
@@ -2494,7 +2494,7 @@ smb_share_add()
 smb_share_remove ()
 {
 	local drives
-	if is_wsl; then drives=$(ls /mnt); else drives=$(ls /cygpath); fi
+	if is_wsl; then drives=$(ls /mnt); else drives=$(ls /cygdrive); fi
 
 	for drive in ${drives}; do
 		# Avoid conflicts with existing drive shares by using a unique share name
@@ -2565,7 +2565,7 @@ docker_machine_mount_smb ()
 	fi
 
 	local drives
-	if is_wsl; then drives=$(ls /mnt); else drives=$(ls /cygpath); fi
+	if is_wsl; then drives=$(ls /mnt); else drives=$(ls /cygdrive); fi
 
 	for drive in ${drives}; do
 		# Mount point is lowercase drive letter with no slash

--- a/bin/fin
+++ b/bin/fin
@@ -546,11 +546,10 @@ sudowin ()
 		shift
 	done
 	if [[ "$arguments" != "" ]]; then
-		powershell.exe Start-Process -Wait -Verb runAs -FilePath "$command" -Args "$arguments"		
+		powershell.exe Start-Process -Wait -Verb runAs -FilePath "$command" -Args "$arguments"
 	else
 		powershell.exe Start-Process -Wait -Verb runAs -FilePath "$command"
 	fi
-
 }
 
 # Universal Bash parameter parsing
@@ -2195,7 +2194,7 @@ docker_machine_env ()
 
 	# get the env
 	if is_wsl; then
-		# on wsl docker-machine is windows binary, but WSL does not understand windows paths
+		# In WSL, docker-machine is a Windows binary, but WSL does not understand Windows paths
 		_env=$(docker-machine env --shell=bash docksal | sed "s/\\\\/\//g" | sed "s/C:/\/c/")
 	else
 		_env=$(docker-machine env --shell=bash "$DOCKER_MACHINE_NAME")

--- a/bin/fin
+++ b/bin/fin
@@ -245,11 +245,11 @@ STACKS_VOLUMES_UNISON="volumes-unison.yml"
 
 URL_DOCKER_COM="https://get.docker.com/"
 URL_DOCKER_MAC="https://download.docker.com/mac/static/stable/x86_64/docker-${REQUIREMENTS_DOCKER}.tgz"
-URL_DOCKER_LINUX="https://download.docker.com/linux/static/stable/x86_64/docker-${REQUIREMENTS_DOCKER}.tgz"
 # Until there is an official standalone docker.exe binary available, use the one pulled from Docker for Windows
 # See https://github.com/docker/for-win/issues/1460#issuecomment-390045959
 #URL_DOCKER_WIN="https://download.docker.com/win/static/stable/x86_64/docker-${REQUIREMENTS_DOCKER}.zip"
 URL_DOCKER_WIN="https://github.com/docksal/docksal/releases/download/v1.11.0/docker-${REQUIREMENTS_DOCKER}.zip"
+URL_DOCKER_NIX="https://download.docker.com/linux/static/stable/x86_64/docker-${REQUIREMENTS_DOCKER}.tgz"
 URL_DOCKER_COMPOSE_MAC="https://github.com/docker/compose/releases/download/${REQUIREMENTS_DOCKER_COMPOSE}/docker-compose-Darwin-x86_64"
 URL_DOCKER_COMPOSE_NIX="https://github.com/docker/compose/releases/download/${REQUIREMENTS_DOCKER_COMPOSE}/docker-compose-Linux-x86_64"
 URL_DOCKER_COMPOSE_WIN="https://github.com/docker/compose/releases/download/${REQUIREMENTS_DOCKER_COMPOSE}/docker-compose-Windows-x86_64.exe"
@@ -4094,11 +4094,11 @@ install_tools_wsl ()
 
 	# Install Linux Docker client
 	if ! is_docker_version; then
-		local docker_pkg=$(basename "$URL_DOCKER_LINUX")
+		local docker_pkg=$(basename "$URL_DOCKER_NIX")
 		echo-green "Installing docker client v${REQUIREMENTS_DOCKER}..."
 		if [[ ! -f "$docker_pkg" ]]; then
 			echo-green "Downloading ${docker_pkg}..."
-			curl -fL# "$URL_DOCKER_LINUX" -o "$CONFIG_DOWNLOADS_DIR/$docker_pkg"
+			curl -fL# "$URL_DOCKER_NIX" -o "$CONFIG_DOWNLOADS_DIR/$docker_pkg"
 			if_failed "Check internet connection."
 		# Use a local/portable copy if available
 		else

--- a/bin/fin
+++ b/bin/fin
@@ -377,6 +377,19 @@ cygpath_abs_unix ()
 	echo "/$(cygpath -m $1 | sed 's/^\/cygdrive//' | sed 's/\([A-Z]\)\:/\l\1/')"
 }
 
+# Returns the value of Windows environment var in WSL
+# @param $1 var name
+wsl_get_environment_var () 
+{
+	$(cmd.exe /c "echo %$1%")
+}
+
+# Unfortunately wslpath output contains \r that has to be cleaned 
+wsl_path ()
+{
+	echo $(wslpath "$1" | tr -d '[:cntrl:]')
+}
+
 # Search for a file/directory in a directory tree upwards. Return its path.
 # @param $1 filename
 upfind ()
@@ -4030,7 +4043,24 @@ install_tools_wsl ()
 		if_failed "Docker installation/upgrade has failed."
 	fi
 
-	# Install Docker Compose
+	# Install windows docker-machine to location where Windows can access it
+	# Create symlink for WSL
+	if ! is_docker_machine_version; then
+		local USERPROFILE=$(wsl_path $(wsl_get_environment_var "USERPROFILE"))
+		local DMDIR="$USERPROFILE/bin"
+		local DMBIN="$DMDIR/docker-machine.exe"
+
+		mkdir -p "$DMDIR"
+		if_failed "Could not create $DMDIR. Check your permissions."
+
+		echo-green "Downloading docker-machine..."
+		curl -fL# "$URL_DOCKER_MACHINE_WIN" -o "$DMBIN" &&
+			chmod +x "$DMBIN" &&
+			sudo ln -s "$DMBIN" "$DOCKER_MACHINE_BIN_NIX"
+		if_failed "Check file permissions and internet connection."
+	fi
+
+	# Install Linux Docker Compose
 	if ! is_docker_compose_version; then
 		echo-green "Installing Docker Compose..."
 		sudo curl -fL# "$URL_DOCKER_COMPOSE_NIX" -o "$DOCKER_COMPOSE_BIN_NIX" && \

--- a/bin/fin
+++ b/bin/fin
@@ -145,7 +145,6 @@ CONFIG_DOWNLOADS_DIR="$CONFIG_BIN_DIR/downloads"
 DOCKER_BIN="$CONFIG_BIN_DIR/docker"
 DOCKER_COMPOSE_BIN="$CONFIG_BIN_DIR/docker-compose"
 DOCKER_MACHINE_BIN="$CONFIG_BIN_DIR/docker-machine"
-DOCKER_MACHINE_BIN_NIX="/usr/local/bin/docker-machine"
 WINPTY_BIN="$CONFIG_BIN_DIR/winpty"
 vboxmanage="VBoxManage"
 is_windows && vboxmanage="/cygdrive/c/Program Files/Oracle/VirtualBox/VBoxManage.exe"
@@ -4142,7 +4141,7 @@ install_tools_wsl ()
 		echo-green "Downloading docker-machine..."
 		curl -fL# "$URL_DOCKER_MACHINE_WIN" -o "$DMBIN" &&
 			chmod +x "$DMBIN" &&
-			sudo ln -s "$DMBIN" "$DOCKER_MACHINE_BIN_NIX"
+			sudo ln -s "$DMBIN" "$DOCKER_MACHINE_BIN"
 		if_failed "Check file permissions and internet connection."
 	fi
 }

--- a/bin/fin
+++ b/bin/fin
@@ -136,10 +136,10 @@ CONFIG_ALIASES="$CONFIG_DIR/alias"
 CONFIG_LAST_CHECK="$CONFIG_DIR/.last_check"
 CONFIG_LAST_PING="$CONFIG_DIR/.last_ping"
 CONFIG_DOCKER_MACHINE_ENV="$CONFIG_DIR/docker-machine.env"
-mkdir -p "$CONFIG_PROJECTS" >/dev/null 2>&1
-# BIN folder
+# bin and bin/downloads folders
 CONFIG_BIN_DIR="$CONFIG_DIR/bin"
 CONFIG_DOWNLOADS_DIR="$CONFIG_BIN_DIR/downloads"
+mkdir -p "$CONFIG_DOWNLOADS_DIR" 2>/dev/null
 DOCKER_BIN="$CONFIG_BIN_DIR/docker"
 DOCKER_COMPOSE_BIN="$CONFIG_BIN_DIR/docker-compose"
 DOCKER_MACHINE_BIN="$CONFIG_BIN_DIR/docker-machine"
@@ -149,7 +149,7 @@ is_windows && vboxmanage="/cygdrive/c/Program Files/Oracle/VirtualBox/VBoxManage
 is_wsl && vboxmanage="/mnt/c/Program Files/Oracle/VirtualBox/VBoxManage.exe"
 # Stacks folder
 CONFIG_STACKS_DIR="$HOME/.docksal/stacks"
-mkdir -p "$CONFIG_STACKS_DIR" >/dev/null 2>&1
+mkdir -p "$CONFIG_STACKS_DIR" 2>/dev/null
 # Custom certs folder for vhost-proxy (overridable)
 CONFIG_CERTS=${CONFIG_CERTS:-$CONFIG_DIR/certs}
 
@@ -3761,9 +3761,6 @@ install_sshagent_service ()
 # Install Mac dependencies
 install_tools_mac ()
 {
-	mkdir -p "$CONFIG_DOWNLOADS_DIR" 2>/dev/null
-	if_failed "Could not create $CONFIG_DOWNLOADS_DIR"
-
 	# Install Docker client
 	if ! is_docker_version; then
 		local docker_pkg=$(basename "$URL_DOCKER_MAC")
@@ -3849,9 +3846,6 @@ install_tools_mac ()
 # Install Windows dependencies
 install_tools_windows ()
 {
-	mkdir -p "$CONFIG_DOWNLOADS_DIR" 2>/dev/null
-	if_failed "Could not create $CONFIG_DOWNLOADS_DIR"
-
 	# Remove old incorrect line
 	sed -i~ "s/^\\\\nexport.*$//" "$HOME/.babunrc"
 	# Disable Babun update checks as they often bring problems
@@ -4092,9 +4086,6 @@ install_tools_generic_linux ()
 # Install WSL dependencies
 install_tools_wsl ()
 {
-	mkdir -p "$CONFIG_DOWNLOADS_DIR" 2>/dev/null
-	if_failed "Could not create $CONFIG_DOWNLOADS_DIR"
-
 	# Install Linux Docker client
 	if ! is_docker_version; then
 		local docker_pkg=$(basename "$URL_DOCKER_NIX")

--- a/bin/fin
+++ b/bin/fin
@@ -2428,38 +2428,26 @@ docker_machine_mount_nfs ()
 
 # Fix/optimize Windows network settings for file sharing.
 # See http://serverfault.com/a/236393 for details.
-smb_windows_fix()
+# TODO: Deprecated and soon to be removed.
+# This was applicable to Windows 7. Most likely irrelevant at this point.
+smb_windows_fix ()
 {
-	(! is_windows || ! is_wsl) && return
+	! is_windows && return
 
 	echo-green "Going to optimize Windows network settings for file sharing..."
 	echo "You may see an elevated command prompt - click Yes."
 	sleep 2
 
-	if is_wsl; then
-		tmpfile="/mnt/c/Windows/temp/fix-smb.reg"
-		tmpfile_win=$(wsl_path -w ${tmpfile})
-	else
-		# Backward compatibility with Babun
-		tmpfile="/cygdrive/c/Windows/temp/fix-smb.reg"
-		tmpfile_win=$(cygpath -w ${tmpfile})
-	fi
-
+	local tmpfile="/tmp/fix-smb.reg"
 	cat <<EOF > $tmpfile
 Windows Registry Editor Version 5.00
-
 [HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management]
 "LargeSystemCache"=dword:00000001
-
 [HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\LanmanServer\Parameters]
 "Size"=dword:00000003
 EOF
 	# Update registry and restart Server and Computer Browser services.
-	if is_wsl; then
-		winsudo "'regedit /S ${tmpfile_win} && net stop server /y && net start server && net start browser'"
-	else
-		winsudo "regedit /S $(cygpath -w ${tmpfile}) && net stop server /y && net start server && net start browser"
-	fi
+	winsudo "regedit /S $(cygpath -w ${tmpfile}) && net stop server /y && net start server && net start browser"
 }
 
 # Method to create the user and SMB network share on Windows.

--- a/bin/fin
+++ b/bin/fin
@@ -775,7 +775,7 @@ check_docker_running ()
 
 	if [[ ${docker_status} -eq 255 ]] && (! is_docker_native && ! is_wsl); then
 		echo-yellow "It looks like '$DOCKER_MACHINE_NAME' docker machine is not running."
-		_confirm "Run 'fin vm start' to start it now?"
+		_confirm "Start it now?"
 		docker_machine_start
 		if_failed "Could not start Docksal docker machine properly"
 		# re-check status
@@ -2192,6 +2192,7 @@ docker_machine_stop ()
 {
 	check_binary_found 'docker-machine'
 	docker-machine stop "$DOCKER_MACHINE_NAME"
+	DOCKER_MACHINE_STATUS="Stopped"
 }
 
 docker_machine_start ()
@@ -2201,6 +2202,7 @@ docker_machine_start ()
 	if is_docker_machine_exist; then
 		docker-machine start "$DOCKER_MACHINE_NAME"
 		if_failed_error "Failed starting virtual machine"
+
 		DOCKER_MACHINE_STATUS='Running'
 		# Disable IP change for now
 		#docker_machine_change_ip &&
@@ -2208,8 +2210,6 @@ docker_machine_start ()
 		if_failed_error "Failed starting virtual machine" \
 			"In case you see certificates problem, reboot your local host." \
 			"Common issues: https://docs.docksal.io/troubleshooting/common-issues/"
-		configure_resolver
-		configure_mounts
 	else
 		# only auto-create default machine
 		if [[ "$DOCKER_MACHINE_NAME" != "$DEFAULT_MACHINE_NAME" ]]; then
@@ -2223,32 +2223,16 @@ docker_machine_start ()
 			# Disable IP change for now
 			#docker_machine_change_ip &&
 			docker_machine_env
-		[[ $? != 0 ]] && _docker_machine_start_exception
 
-		echo-green "Pulling Docksal system images..."
-		update_system_images
-		configure_mounts
-	fi
-
-	# Catch the return code from docker_machine_mounts
-	# TODO: figure out a more reliable implementation, as this may break if the code above gets reordered
-	local _err=$?
-	if [[ ${_err} -eq 0 ]]; then
-		echo-green "Importing ssh keys..."
-		ssh_key add
-	fi
-
-	return ${_err}
-}
-
-# Displays an error message and offers to remove the vm if something failed
-_docker_machine_start_exception ()
-{
-	echo-error "Proper creation of virtual machine has failed" \
+		# Displays an error message and offers to remove the vm if something failed
+		if [[ $? != 0 ]]; then
+			echo-error "Proper creation of virtual machine has failed" \
 				"For details please refer to the log above." \
 				"${yellow}It is recommended to remove malfunctioned virtual machine.${NC}"
-	docker_machine_remove
-	exit 1
+			docker_machine_remove
+			exit 1
+		fi
+	fi
 }
 
 # param $1 machine name (defaults to $DOCKER_MACHINE_NAME)
@@ -2585,30 +2569,27 @@ vm ()
 	check_binary_found 'docker-machine'
 
 	if ! is_docker_machine_exist && [[ "$1" != "" ]] && [[ "$1" != "start" ]] && [[ "$1" != "create" ]] && [[ "$1" != "ls" ]] && [[ "$1" != "remove" ]] && [[ "$1" != "rm" ]] && [[ "$1" != "active" ]] ; then
-		 echo-yellow "Docker machine $DOCKER_MACHINE_NAME does not exist. Use 'fin vm start' or 'fin up'."
+		 echo-yellow "Docker machine $DOCKER_MACHINE_NAME does not exist. Use 'fin system start'."
 		 return 1
 	fi
 
 	case $1 in
 		start)
-			if is_docker_machine_running; then
-				echo "Machine \"$DOCKER_MACHINE_NAME\" is already running."
-			else
-				docker_machine_start
-			fi
+			# Show a message and pause for input.
+			echo -e "Deprecated. Please use ${yellow}fin system start${NC} instead."; read -p "Press any key to continue..."
+			system_start
 			;;
 		restart)
-			docker_machine_stop; docker_machine_start
+			system_stop
+			system_start
 			;;
 		status)
-			shift
-			local machine_name="${1:-$DOCKER_MACHINE_NAME}"
-			docker-machine status "$machine_name"
+			docker-machine status ${DOCKER_MACHINE_NAME}
 			;;
 		stop)
-			# Disable resolver configuration before machine is turned off
-			configure_resolver off
-			docker_machine_stop
+			# Show a message and pause for input.
+			echo -e "Deprecated. Please use ${yellow}fin system stop${NC} instead."; read -p "Press any key to continue..."
+			system_stop
 			;;
 		ssh)
 			shift
@@ -2618,21 +2599,15 @@ vm ()
 			vm-stats
 			;;
 		kill)
-			# Disable resolver configuration before machine is turned off
-			configure_resolver off
-			shift
-			local machine_name="${1:-$DOCKER_MACHINE_NAME}"
-			docker-machine kill "$machine_name"
+			system_stop
+			docker-machine kill ${DOCKER_MACHINE_NAME}
 			;;
 		ls|list)
 			docker-machine ls
 			;;
 		remove|rm)
-			# Disable resolver configuration before machine is turned off
-			configure_resolver off
-			shift
-			local machine_name="${1:-$DOCKER_MACHINE_NAME}"
-			docker_machine_remove "$machine_name"
+			system_stop
+			docker_machine_remove ${DOCKER_MACHINE_NAME}
 			;;
 		mount)
 			configure_mounts
@@ -3095,35 +3070,41 @@ system_status ()
 }
 
 # Starts all Docksal related things
-# TODO: add projects, network, /etc/exports, etc. here for a complete shutdown of Docksal
 system_start ()
 {
 	if ! is_linux && ! is_docker_native && ! is_wsl; then
-		echo "Starting Docksal VM..."
-		vm start
-		system_reset
-	else
-		echo "Starting Docksal system services..."
-		system_reset
+		if is_docker_machine_running; then
+			echo "Machine ${DOCKER_MACHINE_NAME} is already running."
+		else
+			echo "Starting Docksal VM..."
+			docker_machine_start
+		fi
 	fi
+
+	echo "Starting Docksal system services..."
+	system_reset
 }
 
 # Stops/disables all Docksal things
 system_stop ()
 {
 	if ! is_linux && ! is_docker_native && ! is_wsl; then
-		echo-green "Stopping Docksal VM..."
-		# VM stop will perform configure_resolver off
-		vm stop
+		# Stop the docker-machine VM.
+		if is_docker_machine_running; then
+			echo-green "Stopping Docksal VM..."
+			docker_machine_stop
+		fi
 	else
+		# Stop all Docksal project and system containers.
 		# keep in a subshell so that exit during that command would not stop other command in system stop
 		(_stop_containers --all)
 		echo-green "Stopping Docksal system services..."
 		docker ps -q --filter "label=io.docksal.group=system" | xargs docker rm -vf >/dev/null
-		configure_resolver off
-		configure_mounts off
-		configure_network off
 	fi
+
+	configure_resolver off
+	configure_mounts off
+	configure_network off
 }
 
 # Helper function to run ssh-key inside the ssh-agent container
@@ -4103,7 +4084,7 @@ update_virtualbox () {
 	fi
 
 	# Stop VM
-	fin vm stop >/dev/null 2>&1
+	docker_machine_stop >/dev/null 2>&1
 
 	# Download and install Mac
 	is_mac && (
@@ -4273,17 +4254,17 @@ update ()
 			local res=$?
 			if [[ "$res" != "0" ]]; then
 				[[ "$res" == "2" ]] && echo-red "VirtualBox version should be $REQUIREMENTS_VBOX or higher"
-				(which 'docker-machine' >/dev/null 2>&1) && vm stop
+				(which 'docker-machine' >/dev/null 2>&1) && docker_machine_stop
 				DOCKER_MACHINE_STATUS="Stopped"
 				update_virtualbox
-				(which 'docker-machine' >/dev/null 2>&1) && vm start
+				(which 'docker-machine' >/dev/null 2>&1) && docker_machine_start
 			fi
 		fi
 
 		if ! is_linux && ! is_docker_native && ! is_wsl && which 'docker-machine' >/dev/null 2>&1; then
 			if is_docker_machine_exist && ! is_docker_machine_running; then
 				echo-error "Docker Machine '$DOCKER_MACHINE_NAME' should be running to perform update" \
-					"Start it with ${yellow}fin vm start${NC} or destroy it with ${yellow}fin vm remove${NC} if you want it re-created."
+					"Start it with ${yellow}fin system start${NC} or destroy it with ${yellow}fin vm kill${NC} if you want it re-created."
 				return 1
 			fi
 		fi

--- a/bin/fin
+++ b/bin/fin
@@ -4376,23 +4376,6 @@ update ()
 			IFS=':' read nc_host nc_port <<< "$DOCKER_HOST"
 			nc -w 1 ${nc_host} ${nc_port}
 			if_failed_error "Docker for Windows is not running" "Start Docker for Windows, wait for Docker to start and run update again."
-
-			# Check for administrative privileges if needed
-			if ! (ipconfig.exe | grep "$DOCKSAL_IP" &>/dev/null) || ! (ipconfig.exe | grep "$DOCKSAL_HOST_IP" &>/dev/null); then
-				cd "/mnt/c"
-				touch "file.tmp" &>/dev/null
-				if [[ "$?" != "0" ]]; then
-					echo-error "Docksal needs administrative privileges to set up network preferences." \
-						"--" \
-						"1. Close this bash window (you can't run elevated bash while this one is running)" \
-						"2. Run cmd.exe as an Administrator" \
-						"3. Start bash in that elevated cmd.exe session" \
-						"4. Run fin update in that elevated bash session"
-						# It is not allowed to start elevated and un-elevated bash simultaneously
-					exit 1
-				fi
-				rm -f "file.tmp"
-			fi
 		fi
 	fi
 

--- a/bin/fin
+++ b/bin/fin
@@ -2469,15 +2469,15 @@ smb_share_add()
 	local share_path=$2
 
 	is_wsl && USERNAME="$(wsl_get_environment_var USERNAME)"
+	is_wsl && USERDOMAIN="$(wsl_get_environment_var USERDOMAIN)"
 
 	# Add SMB share if it does not exist.
-	if [[ "$(net.exe share)" != *"${share_name}"*"Docksal ${share_path} drive"* ]];
-	then
-		command_share="net.exe share ${share_name}=${share_path} /grant:${USERNAME},FULL /REMARK:\"Docksal ${share_path} drive\""
-		echo-green "Adding docker SMB share..."
+	if [[ "$(net.exe share)" != *"${share_name}"* ]]; then
+		echo-green "Adding docker SMB share ${share_name}..."
 		if is_wsl; then
-			sudowin net.exe share "${share_name}=${share_path}" "/grant:${USERNAME},FULL" "/REMARK:Docksal-drive"
+			sudowin net.exe share "${share_name}=${share_path}" "/grant:${USERDOMAIN}\\${USERNAME},FULL" "/REMARK:Docksal"
 		else
+			command_share="net.exe share ${share_name}=${share_path} /grant:${USERDOMAIN}\\${USERNAME},FULL /REMARK:Docksal"
 			winsudo "$command_share"
 		fi
 
@@ -2493,13 +2493,18 @@ smb_share_add()
 # Removes Docksal SMB shares
 smb_share_remove ()
 {
-	local drives=$(wmic logicaldisk get drivetype,name | grep 3 | awk '{print $2}' | sed 's/\r//g')
+	local drives
+	if is_wsl; then drives=$(ls /mnt); else drives=$(ls /cygpath); fi
+
 	for drive in ${drives}; do
-		local mount_point=$(cygpath -u "$drive" | sed 's/^\/cygdrive\///')
-		# Avoid conflicts with existing drive shares buy using a unique share name
-		local share_name="docksal-$mount_point"
-		command_share="net share ${share_name} /DELETE"
-		winsudo "$command_share"
+		# Avoid conflicts with existing drive shares by using a unique share name
+		local share_name="docksal-$drive"
+		if is_wsl; then
+			sudowin net share ${share_name} /DELETE
+		else
+			command_share="net.exe share ${share_name} /DELETE"
+			winsudo "$command_share"
+		fi
 	done
 }
 
@@ -2549,9 +2554,6 @@ docker_machine_mount_smb ()
 	# add share \\hostname\c writable to current user
 	# ask user for his password
 	# use his password for mount -t cifs ...
-
-	# Get a list of logical drives (type 3 = Local disk).
-	local drives=$(wmic.exe logicaldisk get drivetype,name | grep 3 | awk '{print $2}' | sed 's/\r//g')
 	read -s -p "Enter your Windows account password: " password
 	echo # Add a new line after user input.
 
@@ -2562,19 +2564,16 @@ docker_machine_mount_smb ()
 		return 1
 	fi
 
+	local drives
+	if is_wsl; then drives=$(ls /mnt); else drives=$(ls /cygpath); fi
+
 	for drive in ${drives}; do
 		# Mount point is lowercase drive letter with no slash
-		local mount_point
-		if is_wsl; then
-			mount_point=$(wslpath "$drive\\" | sed 's/\///g')
-		else
-			mount_point=$(cygpath -u "$drive" | sed 's/^\/cygdrive\///')
-		fi
 		# Avoid conflicts with existing drive shares buy using a unique share name
-		local share_name="docksal-$mount_point"
+		local share_name="docksal-$drive"
 		# echo smb_share_add "$share_name" "$drive"
-		smb_share_add "$share_name" "$drive" &&
-			smb_share_mount "$share_name" "/$mount_point" "$password"
+		smb_share_add "$share_name" "$drive:" &&
+			smb_share_mount "$share_name" "/$drive" "$password"
 	done
 }
 

--- a/bin/fin
+++ b/bin/fin
@@ -3432,7 +3432,7 @@ configure_mounts ()
 			fi
 		fi
 		# Create, then mount shares in VirtualBox
-		if is_windows && ! is_docker_native; then
+		if [[ is_wsl || is_windows ]] && ! is_docker_native; then
 			echo-green "Configuring SMB shares..."
 			docker_machine_mount_smb
 		fi
@@ -3441,7 +3441,7 @@ configure_mounts ()
 			echo-green "Removing NFS exports..."
 			nfs_share_remove
 		fi
-		if is_windows && ! is_docker_native; then
+		if [[ is_wsl || is_windows ]] && ! is_docker_native; then
 			echo-green "Removing SMB shares..."
 			smb_share_remove
 		fi

--- a/bin/fin
+++ b/bin/fin
@@ -535,7 +535,7 @@ winsudo ()
 		powershell.exe Start-Process -Wait -Verb RunAs cmd.exe -Args "'/C', '$@'"
 	else
 		# Backward compatibility wth Babun/Cygwin
-		cygstart --action=runas cmd /c "$@"
+		cygstart --action=runas cmd.exe /C "$@"
 	fi
 }
 
@@ -901,7 +901,7 @@ is_vbox_version ()
 
 is_docker_version ()
 {
-	# Skip the check on Pplay-with-Docker and Katacoda
+	# Skip the check on Play-with-Docker and Katacoda
 	(is_pwd || is_katacoda) && return
 
 	! which docker >/dev/null 2>&1 && return 1
@@ -911,7 +911,7 @@ is_docker_version ()
 
 is_docker_server_version ()
 {
-	# Skip the check on Pplay-with-Docker and Katacoda
+	# Skip the check on Play-with-Docker and Katacoda
 	(is_pwd || is_katacoda) && return
 
 	! which docker >/dev/null 2>&1 && return 1
@@ -3359,12 +3359,12 @@ configure_network_windows ()
 		# Add Docksal IP aliases on the DockerNAT adapter
 		local command1="netsh interface ip add address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_IP} mask=255.255.255.0"
 		local command2="netsh interface ip add address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_HOST_IP} mask=255.255.255.0"
-		winsudo "$command1 && $command2"
+		winsudo "$command1 & $command2"
 	elif [[ "$mode" == "off" ]]; then
 		# Remove Docksal IP aliases on the DockerNAT adapter
 		local command1="netsh interface ip delete address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_IP}"
-		local command1="netsh interface ip delete address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_HOST_IP}"
-		winsudo "$command1 && $command2"
+		local command2="netsh interface ip delete address name=\"vEthernet (DockerNAT)\" addr=${DOCKSAL_HOST_IP}"
+		winsudo "$command1 & $command2"
 	fi
 	# Wait 5s for network configuration to apply
 	sleep 5
@@ -3533,7 +3533,7 @@ detect_dns ()
 		fi
 
 		# If previous detection failed, try another one. Lists all DNS addresses. Uses first non-localhost
-		# Not an ideal check as it might pick the wrong one if there are several, but better than nothing 
+		# Not an ideal check as it might pick the wrong one if there are several, but better than nothing
 		if [[ "$DOCKSAL_DNS_UPSTREAM" == "" ]]; then
 			dns_addresses=""
 			IFS=$'\n'
@@ -3656,7 +3656,7 @@ configure_resolver_windows () {
 	local command1="netsh interface ip set dnsservers \"${network_id}\" static ${dns_ip} none"
 	# Set the adapter metric (priority) to 10, so its DNS settings will take over other adapters
 	local command2="netsh interface ip set interface \"${network_id}\" metric=${metric}"
-	winsudo "$command1 && $command2"
+	winsudo "$command1 & $command2"
 
 	# Flush DNS cache
 	echo-green "Clearing DNS cache..."
@@ -5801,7 +5801,7 @@ config_generate ()
 		else
 			DOCROOT=docroot
 		fi
-		
+
 		if ! _confirm "DOCROOT has been detected as ${DOCROOT}. Is that correct?" --no-exit; then
 			DOCROOT=""
 			while [[ "$DOCROOT" == "" ]]; do

--- a/bin/fin
+++ b/bin/fin
@@ -3643,8 +3643,11 @@ configure_resolver_windows () {
 		# Use the default DockerNAT adapter
 		network_id="vEthernet (DockerNAT)"
 	else
-		# Figure out the name of the network (not the name of the adapter) the VM is using
-		network_id=$("$vboxmanage" showvminfo ${DEFAULT_MACHINE_NAME} --machinereadable | grep hostonlyadapter | cut -d'"' -f2 | sed 's/Ethernet Adapter/Network/')
+		# Need to check whether machine exists, otherwise we cannot get its info
+		if is_docker_machine_exist; then
+			# Figure out the name of the network (not the name of the adapter) the VM is using
+			network_id=$("$vboxmanage" showvminfo ${DEFAULT_MACHINE_NAME} --machinereadable | grep hostonlyadapter | cut -d'"' -f2 | sed 's/Ethernet Adapter/Network/')
+		fi
 	fi
 
 	if [[ "$network_id" == "" ]]; then

--- a/bin/fin
+++ b/bin/fin
@@ -377,7 +377,7 @@ cygpath_abs_unix ()
 
 # Returns the value of Windows environment var in WSL
 # @param $1 var name
-wsl_get_environment_var () 
+wsl_env () 
 {
 	echo $(cmd.exe /c "echo %$1%" | tr -d '[:cntrl:]')
 }
@@ -2466,8 +2466,8 @@ smb_share_add()
 	local share_name=$1
 	local share_path=$2
 
-	is_wsl && USERNAME="$(wsl_get_environment_var USERNAME)"
-	is_wsl && USERDOMAIN="$(wsl_get_environment_var USERDOMAIN)"
+	is_wsl && USERNAME="$(wsl_env USERNAME)"
+	is_wsl && USERDOMAIN="$(wsl_env USERDOMAIN)"
 
 	# Add SMB share if it does not exist.
 	if [[ "$(net.exe share)" != *"${share_name}"* ]]; then
@@ -2515,8 +2515,8 @@ smb_share_mount()
 	local password=$3
 	# single quotes are banned from being used in password
 	password=${password//\'/}
-	is_wsl && USERNAME="$(wsl_get_environment_var USERNAME)"
-	is_wsl && USERDOMAIN="$(wsl_get_environment_var USERDOMAIN)"
+	is_wsl && USERNAME="$(wsl_env USERNAME)"
+	is_wsl && USERDOMAIN="$(wsl_env USERDOMAIN)"
 
 	# User ntlmssp by default. For some Windows machines ntlm should be used instead
 	# Also see https://unix.stackexchange.com/questions/124342/mount-error-13-permission-denied/124352#124352
@@ -4163,7 +4163,7 @@ update_virtualbox () {
 
 	if is_wsl; then
 		url="$URL_VBOX_WIN"
-		local USERPROFILE=$(wsl_path -u $(wsl_get_environment_var "USERPROFILE"))
+		local USERPROFILE=$(wsl_path -u $(wsl_env "USERPROFILE"))
 		vbox_pkg="$USERPROFILE/Downloads"/$(basename "$url")
 	fi
 

--- a/bin/fin
+++ b/bin/fin
@@ -245,11 +245,11 @@ STACKS_VOLUMES_UNISON="volumes-unison.yml"
 
 URL_DOCKER_COM="https://get.docker.com/"
 URL_DOCKER_MAC="https://download.docker.com/mac/static/stable/x86_64/docker-${REQUIREMENTS_DOCKER}.tgz"
-# Until there is an official standalone docker.exe binary available, use the one pulled from Docker for Windows
-# See https://github.com/docker/for-win/issues/1460#issuecomment-390045959
-#URL_DOCKER_WIN="https://download.docker.com/win/static/stable/x86_64/docker-${REQUIREMENTS_DOCKER}.zip"
-URL_DOCKER_WIN="https://github.com/docksal/docksal/releases/download/v1.11.0/docker-${REQUIREMENTS_DOCKER}.zip"
 URL_DOCKER_NIX="https://download.docker.com/linux/static/stable/x86_64/docker-${REQUIREMENTS_DOCKER}.tgz"
+# Docker stopped publishing docker client binaries for Windows. They are now available from Microsoft.
+# See https://github.com/docker/for-win/issues/1460#issuecomment-442585850
+# MS uses a different naming convention, e.g. "docker-18-09-2.zip" instead of "docker-18.09.2.zip".
+URL_DOCKER_WIN="https://dockermsft.blob.core.windows.net/dockercontainer/docker-${REQUIREMENTS_DOCKER//./-}.zip"
 URL_DOCKER_COMPOSE_MAC="https://github.com/docker/compose/releases/download/${REQUIREMENTS_DOCKER_COMPOSE}/docker-compose-Darwin-x86_64"
 URL_DOCKER_COMPOSE_NIX="https://github.com/docker/compose/releases/download/${REQUIREMENTS_DOCKER_COMPOSE}/docker-compose-Linux-x86_64"
 URL_DOCKER_COMPOSE_WIN="https://github.com/docker/compose/releases/download/${REQUIREMENTS_DOCKER_COMPOSE}/docker-compose-Windows-x86_64.exe"

--- a/bin/fin
+++ b/bin/fin
@@ -135,9 +135,7 @@ CONFIG_ENV="$CONFIG_DIR/docksal.env"
 CONFIG_ALIASES="$CONFIG_DIR/alias"
 CONFIG_LAST_CHECK="$CONFIG_DIR/.last_check"
 CONFIG_LAST_PING="$CONFIG_DIR/.last_ping"
-CONFIG_MACHINES="$CONFIG_DIR/machines"
-CONFIG_MACHINES_ENV="$CONFIG_DIR/machines/.env"
-CONFIG_MACHINE_ACTIVE="$CONFIG_MACHINES/.active"
+CONFIG_DOCKER_MACHINE_ENV="$CONFIG_DIR/docker-machine.env"
 mkdir -p "$CONFIG_PROJECTS" >/dev/null 2>&1
 # BIN folder
 CONFIG_BIN_DIR="$CONFIG_DIR/bin"
@@ -811,12 +809,12 @@ check_docker_running ()
 	[[ ${docker_status} -eq 0 ]] && return
 
 	if [[ ${docker_status} -eq 255 ]] && ! is_docker_native; then
-		echo-yellow "It looks like '$DOCKER_MACHINE_NAME' docker machine is not running."
+		echo-yellow "It looks like '$DEFAULT_MACHINE_NAME' docker machine is not running."
 		_confirm "Start it now?"
 		docker_machine_start
 		if_failed "Could not start Docksal docker machine properly"
 		# re-check status
-		eval $(docker-machine env --shell=bash "$DOCKER_MACHINE_NAME")
+		eval $(docker-machine env --shell=bash "$DEFAULT_MACHINE_NAME")
 		docker info >/dev/null
 		docker_status=$?
 	fi
@@ -836,7 +834,7 @@ check_docker_running ()
 		fi
 	else # MacOS, Windows
 		# Check for certificates error
-		if (docker-machine env "$DOCKER_MACHINE_NAME" 2>&1 | grep "Error checking TLS connection" >/dev/null); then
+		if (docker-machine env --shell=bash "$DEFAULT_MACHINE_NAME" 2>&1 | grep "Error checking TLS connection" >/dev/null); then
 			echo-error "Error connecting to Docker due to certificates error" \
 				"WHAT TO DO?" \
 				"1. Try ${yellow}fin vm restart${NC}." \
@@ -2148,14 +2146,12 @@ docker_machine_create ()
 	check_vbox_version
 	check_binary_found 'docker-machine'
 
-	local machine_name="${1:-$DEFAULT_MACHINE_NAME}"
-
 	if is_docker_machine_exist; then
-		echo-error "Docker Machine '$machine_name' already exists"
+		echo-error "Docker Machine '$DEFAULT_MACHINE_NAME' already exists"
 		return 1
 	fi
 
-	echo-green "Creating docker machine '$machine_name'..."
+	echo-green "Creating docker machine '$DEFAULT_MACHINE_NAME'..."
 
 	# Use a local boot2docker.iso copy when available
 	ISO_FILE=${ISO_FILE:-boot2docker.iso}
@@ -2171,10 +2167,9 @@ docker_machine_create ()
 		--virtualbox-memory "$DEFAULT_MACHINE_VBOX_RAM" \
 		--virtualbox-hostonly-cidr "$DOCKSAL_SUBNET" \
 		--virtualbox-no-share \
-		"$machine_name"
+		"$DEFAULT_MACHINE_NAME"
 
 	if [[ $? -eq 0 ]]; then
-		DOCKER_MACHINE_NAME="$machine_name"
 		DOCKER_MACHINE_STATUS='Running'
 	else
 		return 1
@@ -2189,7 +2184,7 @@ is_docker_machine_exist ()
 	local refresh="${1:-false}"
 	if [[ "$refresh" == "true" ]]; then
 		# Refresh VM status in case it changed while the script was running.
-		DOCKER_MACHINE_STATUS=$(docker-machine status "$DOCKER_MACHINE_NAME" 2>&1 || echo '')
+		DOCKER_MACHINE_STATUS=$(docker-machine status "$DEFAULT_MACHINE_NAME" 2>&1 || echo '')
 	fi
 	[[ "$DOCKER_MACHINE_STATUS" == *"not exist"* ]] && return 1 || return 0
 }
@@ -2200,14 +2195,14 @@ docker_machine_env ()
 	local res
 
 	#remove cache
-	rm -f "$CONFIG_MACHINES_ENV" 2>/dev/null
+	rm -f "$CONFIG_DOCKER_MACHINE_ENV" 2>/dev/null
 
 	# get the env
 	if is_wsl; then
 		# In WSL, docker-machine is a Windows binary, but WSL does not understand Windows paths
 		_env=$(docker-machine env --shell=bash docksal | sed "s/\\\\/\//g" | sed "s/C:/\/c/")
 	else
-		_env=$(docker-machine env --shell=bash "$DOCKER_MACHINE_NAME")
+		_env=$(docker-machine env --shell=bash "$DEFAULT_MACHINE_NAME")
 	fi
 	res=$?
 
@@ -2220,14 +2215,14 @@ docker_machine_env ()
 	fi
 
 	# Save to file for reuse during subsequent fin runs to avoid running env which is expensive
-	echo "${_env}" | tee "$CONFIG_MACHINES_ENV" >/dev/null
+	echo "${_env}" | tee "$CONFIG_DOCKER_MACHINE_ENV" >/dev/null
 }
 
 # Stop docker machine
 docker_machine_stop ()
 {
 	check_binary_found 'docker-machine'
-	docker-machine stop "$DOCKER_MACHINE_NAME"
+	docker-machine stop "$DEFAULT_MACHINE_NAME"
 	DOCKER_MACHINE_STATUS="Stopped"
 }
 
@@ -2236,28 +2231,16 @@ docker_machine_start ()
 	check_binary_found 'docker-machine'
 
 	if is_docker_machine_exist; then
-		docker-machine start "$DOCKER_MACHINE_NAME"
+		docker-machine start "$DEFAULT_MACHINE_NAME"
 		if_failed_error "Failed starting virtual machine"
 
 		DOCKER_MACHINE_STATUS='Running'
-		# Disable IP change for now
-		#docker_machine_change_ip &&
 		docker_machine_env
 		if_failed_error "Failed starting virtual machine" \
 			"In case you see certificates problem, reboot your local host." \
 			"Common issues: https://docs.docksal.io/troubleshooting/common-issues/"
 	else
-		# only auto-create default machine
-		if [[ "$DOCKER_MACHINE_NAME" != "$DEFAULT_MACHINE_NAME" ]]; then
-			echo-error "Machine '$DOCKER_MACHINE_NAME' does not exist"
-			echo-yellow "Removing reference to non-existent machine... Run your command again."
-			rm -f "$CONFIG_MACHINE_ACTIVE"
-			exit 1
-		fi
-
 		docker_machine_create &&
-			# Disable IP change for now
-			#docker_machine_change_ip &&
 			docker_machine_env
 
 		# Displays an error message and offers to remove the vm if something failed
@@ -2271,15 +2254,12 @@ docker_machine_start ()
 	fi
 }
 
-# param $1 machine name (defaults to $DOCKER_MACHINE_NAME)
 docker_machine_remove ()
 {
-	local machine_name="${1:-$DOCKER_MACHINE_NAME}"
-
-	_confirm "Remove $machine_name?"
+	_confirm "Remove $DEFAULT_MACHINE_NAME?"
 	# Store host-only interface name before removing the VM.
-	local vboxifname=$("$vboxmanage" showvminfo "$machine_name" 2>/dev/null | grep "Host-only" | sed "s/.*Host-only.*'\(.*\)'.*/\1/g")
-	docker-machine rm -f "$machine_name"
+	local vboxifname=$("$vboxmanage" showvminfo "$DEFAULT_MACHINE_NAME" 2>/dev/null | grep "Host-only" | sed "s/.*Host-only.*'\(.*\)'.*/\1/g")
+	docker-machine rm -f "$DEFAULT_MACHINE_NAME"
 	if ! is_docker_machine_exist "true"; then
 		# If the VM was removed, remove the DHCP server associated with its network interface.
 		# This ensures that we always get the lower bound IP address from the DHCP address pool (i.e., ".100").
@@ -2295,11 +2275,10 @@ nfs_share_add ()
 {
 	[[ "$@" = "" ]] && return 1
 
-	local machine_name="${DOCKER_MACHINE_NAME:-docksal}"
 	eval $(parse_params "$@")
 
 	# Remove our own old exports
-	local exports_open="# <ds-nfs $machine_name"
+	local exports_open="# <ds-nfs $DEFAULT_MACHINE_NAME"
 	local exports_close="# ds-nfs>"
 	local exports=$(cat /etc/exports 2>/dev/null | \
 		tr "\n" "\r" | \
@@ -2376,9 +2355,8 @@ nfs_share_add ()
 # Removes all Docksal NFS exports
 nfs_share_remove ()
 {
-	local machine_name="${DOCKER_MACHINE_NAME:-docksal}"
 	# Remove our own old exports
-	local exports_open="# <ds-nfs $machine_name"
+	local exports_open="# <ds-nfs $DEFAULT_MACHINE_NAME"
 	local exports_close="# ds-nfs>"
 	local exports=$(cat /etc/exports 2>/dev/null)
 	local exports_new=$(cat /etc/exports 2>/dev/null | \
@@ -2414,14 +2392,13 @@ nfs_share_remove ()
 # Unnamed params - shares in format "$LOCAL_FOLDER:$MOUNT_POINT_NAME"
 docker_machine_mount_nfs ()
 {
-	local machine_name="$DOCKER_MACHINE_NAME"
 	local nfs_ip="$DOCKSAL_HOST_IP"
 	eval $(parse_params "$@")
 
 	# Mount exported folders
 	echo-green "Mounting NFS shares..."
 	# Start NFS client on docker-machine
-	docker-machine ssh "$machine_name" "sudo /usr/local/etc/init.d/nfs-client start"
+	docker-machine ssh "$DEFAULT_MACHINE_NAME" "sudo /usr/local/etc/init.d/nfs-client start"
 	for share in ${ARGV[@]}; do
 		local share_=(${share//:/ });
 		local share_export="${share_[0]}"
@@ -2430,14 +2407,14 @@ docker_machine_mount_nfs ()
 		# [!!] Think twice about performance before changing nfs settings
 		nfs_mount_command="sudo mount -t nfs -o vers=3,nolock,noacl,nocto,noatime,nodiratime,actimeo=1 $nfs_ip:$share_export $share_mount"
 		# Timeout will break mount command, that can freeze if connection to host is blocked by firewall
-		docker-machine ssh "$machine_name" \
+		docker-machine ssh "$DEFAULT_MACHINE_NAME" \
 			"sudo mkdir -p $share_mount;
 			timeout -t 5 sudo umount $share_mount 2>/dev/null;
 			timeout -t 20 $nfs_mount_command"
 		if [[ $? != 0 ]]; then
 			echo "Retrying mounting local $share_export to $share_mount"
 			sleep 5
-			docker-machine ssh "$machine_name" "timeout -t 20 $nfs_mount_command"
+			docker-machine ssh "$DEFAULT_MACHINE_NAME" "timeout -t 20 $nfs_mount_command"
 			if [[ $? != 0 ]]; then
 				echo-error "NFS share mount failed." "Try ${yellow}fin vm restart${NC}."
 				return 1
@@ -2550,14 +2527,14 @@ smb_share_mount()
 		(sudo umount $mount_point >/dev/null 2>&1 || true) && \
 		sudo mkdir -p $mount_point && \
 		sudo mount -t cifs -o username='${USERNAME}',pass='${password}',domain='${USERDOMAIN}',sec='${SMB_SEC}',vers=3,nobrl,mfsymlinks,noperm,actimeo=1,dir_mode=0777,file_mode=0777 //${DOCKSAL_HOST_IP}/$share_name $mount_point"
-	docker-machine ssh ${DOCKER_MACHINE_NAME} "$command_mount"
+	docker-machine ssh ${DEFAULT_MACHINE_NAME} "$command_mount"
 
 	# Perform a second attenpt with sec=ntlm if the first one (with ntslssp or custom override via SMB_SEC=) failed.
 	if [[ $? != 0 ]]; then
 		echo-yellow "Mount command failed... Trying an alternative method..."
 		# Switch sec to ntlm and try again
 		command_mount=$(echo $command_mount | sed 's/sec=.*,/sec=ntlm,/')
-		docker-machine ssh ${DOCKER_MACHINE_NAME} "$command_mount"
+		docker-machine ssh ${DEFAULT_MACHINE_NAME} "$command_mount"
 
 		if [[ $? == 0 ]]; then
 			echo-green 'Success!'
@@ -2630,7 +2607,7 @@ vm ()
 	check_binary_found 'docker-machine'
 
 	if ! is_docker_machine_exist && [[ "$1" != "" ]] && [[ "$1" != "start" ]] && [[ "$1" != "create" ]] && [[ "$1" != "ls" ]] && [[ "$1" != "remove" ]] && [[ "$1" != "rm" ]] && [[ "$1" != "active" ]] ; then
-		 echo-yellow "Docker machine $DOCKER_MACHINE_NAME does not exist. Use 'fin system start'."
+		 echo-yellow "Docker machine $DEFAULT_MACHINE_NAME does not exist. Use 'fin system start'."
 		 return 1
 	fi
 
@@ -2645,7 +2622,7 @@ vm ()
 			system_start
 			;;
 		status)
-			docker-machine status ${DOCKER_MACHINE_NAME}
+			docker-machine status ${DEFAULT_MACHINE_NAME}
 			;;
 		stop)
 			# Show a message and pause for input.
@@ -2654,30 +2631,30 @@ vm ()
 			;;
 		ssh)
 			shift
-			docker-machine ssh ${DOCKER_MACHINE_NAME} "$@"
+			docker-machine ssh ${DEFAULT_MACHINE_NAME} "$@"
 			;;
 		stats)
 			vm-stats
 			;;
 		kill)
 			system_stop
-			docker-machine kill ${DOCKER_MACHINE_NAME}
+			docker-machine kill ${DEFAULT_MACHINE_NAME}
 			;;
 		ls|list)
 			docker-machine ls
 			;;
 		remove|rm)
 			system_stop
-			docker_machine_remove ${DOCKER_MACHINE_NAME}
+			docker_machine_remove ${DEFAULT_MACHINE_NAME}
 			;;
 		mount)
 			configure_mounts
 			;;
 		ip)
-			docker-machine ip ${DOCKER_MACHINE_NAME}
+			docker-machine ip ${DEFAULT_MACHINE_NAME}
 			;;
 		env)
-			docker-machine env --shell=bash ${DOCKER_MACHINE_NAME}
+			docker-machine env --shell=bash ${DEFAULT_MACHINE_NAME}
 			;;
 		ram)
 			shift
@@ -2691,7 +2668,7 @@ vm ()
 			show_help_vm
 			;;
 		regenerate-certs)
-			docker-machine regenerate-certs -f ${DOCKER_MACHINE_NAME}
+			docker-machine regenerate-certs -f ${DEFAULT_MACHINE_NAME}
 			vm restart
 			;;
 		*)
@@ -2707,19 +2684,19 @@ vm-stats ()
 	check_docker_running # should be running
 	check_vbox_version
 	metrics="CPU/Load/User,CPU/Load/Kernel,Net/Rate/Rx,Net/Rate/Tx"
-	"$vboxmanage" metrics setup --period 1 --samples 1 "$DOCKER_MACHINE_NAME"
+	"$vboxmanage" metrics setup --period 1 --samples 1 "$DEFAULT_MACHINE_NAME"
 	sleep 1
-	"$vboxmanage" metrics query "$DOCKER_MACHINE_NAME" "$metrics"
+	"$vboxmanage" metrics query "$DEFAULT_MACHINE_NAME" "$metrics"
 }
 
 vm-ram () {
-	echo "Total $("$vboxmanage" showvminfo "$DOCKER_MACHINE_NAME" | grep Memory)"
+	echo "Total $("$vboxmanage" showvminfo "$DEFAULT_MACHINE_NAME" | grep Memory)"
 	if [[ "$1" != "" ]]; then
 		local running
 		is_docker_machine_running && running=1
 		_confirm "Continue changing Memory size to ${1}MB?"
 		[[ ${running} == 1 ]] && docker_machine_stop
-		"$vboxmanage" modifyvm "$DOCKER_MACHINE_NAME" --memory "$1" && \
+		"$vboxmanage" modifyvm "$DEFAULT_MACHINE_NAME" --memory "$1" && \
 			echo "Memory size updated."
 		[[ ${running} == 1 ]] && docker_machine_start
 	else
@@ -2732,7 +2709,7 @@ vm-ram () {
 }
 
 vm-hdd () {
-	docker-machine ssh "$DOCKER_MACHINE_NAME" df -h /mnt/sda1
+	docker-machine ssh "$DEFAULT_MACHINE_NAME" df -h /mnt/sda1
 }
 
 #------------------------------- Other Commands -----------------------------------
@@ -3135,7 +3112,7 @@ system_start ()
 {
 	if ! is_linux && ! is_docker_native; then
 		if is_docker_machine_running; then
-			echo "Machine ${DOCKER_MACHINE_NAME} is already running."
+			echo "Machine ${DEFAULT_MACHINE_NAME} is already running."
 		else
 			echo "Starting Docksal VM..."
 			docker_machine_start
@@ -3664,7 +3641,7 @@ configure_resolver_windows () {
 		network_id="vEthernet (DockerNAT)"
 	else
 		# Figure out the name of the network (not the name of the adapter) the VM is using
-		network_id=$("$vboxmanage" showvminfo ${DOCKER_MACHINE_NAME} --machinereadable | grep hostonlyadapter | cut -d'"' -f2 | sed 's/Ethernet Adapter/Network/')
+		network_id=$("$vboxmanage" showvminfo ${DEFAULT_MACHINE_NAME} --machinereadable | grep hostonlyadapter | cut -d'"' -f2 | sed 's/Ethernet Adapter/Network/')
 	fi
 
 	if [[ "$network_id" == "" ]]; then
@@ -3703,7 +3680,7 @@ configure_resolver_wsl () {
 		network_id="vEthernet (DockerNAT)"
 	else
 		# Figure out the name of the network (not the name of the adapter) the VM is using
-		network_id=$("$vboxmanage" showvminfo ${DOCKER_MACHINE_NAME} --machinereadable | grep hostonlyadapter | cut -d'"' -f2 | sed 's/Ethernet Adapter/Network/')
+		network_id=$("$vboxmanage" showvminfo ${DEFAULT_MACHINE_NAME} --machinereadable | grep hostonlyadapter | cut -d'"' -f2 | sed 's/Ethernet Adapter/Network/')
 	fi
 
 	if [[ "$network_id" == "" ]]; then
@@ -3858,7 +3835,7 @@ install_tools_mac ()
 		echo-green "Preparing to update virtual machine..." && \
 		docker_machine_stop && \
 		echo "Downloading boot2docker.iso v${REQUIREMENTS_DOCKER}" && \
-		curl -fL# "$URL_BOOT2DOCKER" -o "$HOME/.docker/machine/machines/$DOCKER_MACHINE_NAME/boot2docker.iso" && \
+		curl -fL# "$URL_BOOT2DOCKER" -o "$HOME/.docker/machine/machines/$DEFAULT_MACHINE_NAME/boot2docker.iso" && \
 		docker_machine_start
 
 	if is_docker_native && [[ ${UPGRADE_IN_PROGRESS} == 1 ]]; then
@@ -3989,7 +3966,7 @@ install_tools_windows ()
 		echo-green "Preparing to update virtual machine..." && \
 		docker_machine_stop && \
 		echo "Downloading boot2docker.iso v${REQUIREMENTS_DOCKER}" && \
-		curl -fL# "$URL_BOOT2DOCKER" -o "$(cygpath $USERPROFILE)/.docker/machine/machines/$DOCKER_MACHINE_NAME/boot2docker.iso" && \
+		curl -fL# "$URL_BOOT2DOCKER" -o "$(cygpath $USERPROFILE)/.docker/machine/machines/$DEFAULT_MACHINE_NAME/boot2docker.iso" && \
 		docker_machine_start
 	fi
 
@@ -4394,7 +4371,7 @@ update ()
 
 		if ! is_linux && ! is_docker_native && which 'docker-machine' >/dev/null 2>&1; then
 			if is_docker_machine_exist && ! is_docker_machine_running; then
-				echo-error "Docker Machine '$DOCKER_MACHINE_NAME' should be running to perform update" \
+				echo-error "Docker Machine '$DEFAULT_MACHINE_NAME' should be running to perform update" \
 					"Start it with ${yellow}fin system start${NC} or destroy it with ${yellow}fin vm kill${NC} if you want it re-created."
 				return 1
 			fi
@@ -7189,31 +7166,17 @@ elif is_docker_native; then
 		export DOCKER_HOST=""
 	fi
 else
-	# get active machine and its status
-	__current_active_machine=$(cat "$CONFIG_MACHINE_ACTIVE" 2>/dev/null || echo '')
-	DOCKER_MACHINE_NAME="${__current_active_machine:-$DEFAULT_MACHINE_NAME}"
-	DOCKER_MACHINE_STATUS=$(docker-machine status "$DOCKER_MACHINE_NAME" 2>&1 || echo '')
+	DOCKER_MACHINE_STATUS=$(docker-machine status "$DEFAULT_MACHINE_NAME" 2>&1 || echo '')
 	if [[ "$DOCKER_MACHINE_STATUS" == 'Running' ]]; then
 		# Use cached environment variables if possible
-		if [[ -f "$CONFIG_MACHINES_ENV" ]]; then
-			eval $(cat "$CONFIG_MACHINES_ENV")
+		if [[ -f "$CONFIG_DOCKER_MACHINE_ENV" ]]; then
+			eval $(cat "$CONFIG_DOCKER_MACHINE_ENV")
 			# if DOCKER_HOST is still not set then get environment variables once again
 			if [[ DOCKER_HOST == "" ]]; then
 				docker_machine_env
 			fi
 		fi
 	fi
-
-	# current active machine folder
-	DOCKER_MACHINE_FOLDER="$CONFIG_MACHINES/$DOCKER_MACHINE_NAME"
-	mkdir -p "$DOCKER_MACHINE_FOLDER"
-
-	# TODO: revise or remove later. search for DOCKER_MACHINE_IP in the code
-	# get desired ip
-	# if [[ -f "$DOCKER_MACHINE_FOLDER/ip" ]]; then
-	#	DOCKER_MACHINE_IP=$(cat "$DOCKER_MACHINE_FOLDER/ip")
-	#fi
-	#DOCKER_MACHINE_IP=${DOCKER_MACHINE_IP:-$DOCKSAL_IP}
 fi
 
 if is_docker_running; then

--- a/bin/fin
+++ b/bin/fin
@@ -811,7 +811,7 @@ check_docker_running ()
 	if [[ ${docker_status} -eq 255 ]] && ! is_docker_native; then
 		echo-yellow "It looks like '$DEFAULT_MACHINE_NAME' docker machine is not running."
 		_confirm "Start it now?"
-		docker_machine_start
+		system_start
 		if_failed "Could not start Docksal docker machine properly"
 		# re-check status
 		eval $(docker-machine env --shell=bash "$DEFAULT_MACHINE_NAME")

--- a/bin/fin
+++ b/bin/fin
@@ -532,10 +532,22 @@ winsudo ()
 	cygstart --action=runas cmd /c "$@"
 }
 
+# Run command on Windows and WSL with elevated provileges
 sudowin ()
 {
-	# left for future use
-	powershell.exe Start-Process -Verb runAs -FilePath "cmd.exe" -Args '/c','dir','/?'
+	local command="$1"
+	local arguments=""
+	shift
+	while [[ "$1" != "" ]]; do
+		if [[ "$arguments" == "" ]]; then
+			arguments="'\"$1\"'"
+		else
+			arguments="$arguments,'\"$1\"'"
+		fi
+		shift
+	done
+
+	powershell.exe Start-Process -Wait -Verb runAs -FilePath "$command" -Args "$arguments"
 }
 
 # Universal Bash parameter parsing
@@ -3340,8 +3352,8 @@ configure_network_wsl ()
 	# TODO: implement on/off modes
 	local mode="${1:-on}"
 
-	cmd.exe /c netsh interface ip add address name=\"vEthernet \(DockerNAT\)\" address="${DOCKSAL_IP}" mask="255.255.255.0"
-	cmd.exe /c netsh interface ip add address name=\"vEthernet \(DockerNAT\)\" address="${DOCKSAL_HOST_IP}" mask="255.255.255.0"
+	sudowin netsh.exe interface ip add address name=\"vEthernet \(DockerNAT\)\" address="${DOCKSAL_IP}" mask="255.255.255.0"
+	sudowin netsh.exe interface ip add address name=\"vEthernet \(DockerNAT\)\" address="${DOCKSAL_HOST_IP}" mask="255.255.255.0"
 	# Wait 5s for network configuration to apply
 	sleep 5
 }
@@ -3620,12 +3632,23 @@ configure_resolver_wsl () {
 	fi
 
 	local network_id
-	network_id="vEthernet (DockerNAT)"
+	if is_docker_native; then
+		# Use the default DockerNAT adapter
+		network_id="vEthernet (DockerNAT)"
+	else
+		# Figure out the name of the network (not the name of the adapter) the VM is using
+		network_id=$("$vboxmanage" showvminfo ${DOCKER_MACHINE_NAME} --machinereadable | grep hostonlyadapter | cut -d'"' -f2 | sed 's/Ethernet Adapter/Network/')
+	fi
+
+	if [[ "$network_id" == "" ]]; then
+		echo-error "DNS resolver configuration failed"
+		return 1
+	fi
 
 	# Set DNS server to Docksal IP on the VM's VBox adapter
-	cmd.exe /c netsh interface ip set dnsservers "${network_id}" static ${dns_ip} none
+	sudowin netsh.exe interface ip set dnsservers "${network_id}" static ${dns_ip} none
 	# Set the adapter metric (priority) to 10, so its DNS settings will take over other adapters
-	cmd.exe /c netsh interface ip set interface "${network_id}" metric=${metric}
+	sudowin netsh.exe interface ip set interface "${network_id}" metric=${metric}
 
 	# Flush DNS cache
 	echo-green "Clearing DNS cache..."

--- a/bin/fin
+++ b/bin/fin
@@ -4003,8 +4003,8 @@ install_tools_debian ()
 	# Install Docker Compose
 	if ! is_docker_compose_version; then
 		echo-green "Installing Docker Compose..."
-		sudo curl -fL# "$URL_DOCKER_COMPOSE_NIX" -o "$DOCKER_COMPOSE_BIN" && \
-			sudo chmod +x "$DOCKER_COMPOSE_BIN" && \
+		curl -fL# "$URL_DOCKER_COMPOSE_NIX" -o "$DOCKER_COMPOSE_BIN" && \
+			chmod +x "$DOCKER_COMPOSE_BIN" && \
 			docker-compose --version
 		if_failed "Docker Compose installation/upgrade has failed."
 	fi
@@ -4037,8 +4037,8 @@ install_tools_fedora ()
 	# Install Docker Compose
 	if ! is_docker_compose_version; then
 		echo-green "Installing Docker Compose..."
-		sudo curl -fL# "$URL_DOCKER_COMPOSE_NIX" -o "$DOCKER_COMPOSE_BIN" && \
-			sudo chmod +x "$DOCKER_COMPOSE_BIN" && \
+		curl -fL# "$URL_DOCKER_COMPOSE_NIX" -o "$DOCKER_COMPOSE_BIN" && \
+			chmod +x "$DOCKER_COMPOSE_BIN" && \
 			docker-compose --version
 		if_failed "Docker Compose installation/upgrade has failed."
 	fi
@@ -4082,8 +4082,8 @@ install_tools_generic_linux ()
 	# Install Docker Compose
 	if ! is_docker_compose_version; then
 		echo-green "Installing Docker Compose..."
-		sudo curl -fL# "$URL_DOCKER_COMPOSE_NIX" -o "$DOCKER_COMPOSE_BIN" && \
-			sudo chmod +x "$DOCKER_COMPOSE_BIN" && \
+		curl -fL# "$URL_DOCKER_COMPOSE_NIX" -o "$DOCKER_COMPOSE_BIN" && \
+			chmod +x "$DOCKER_COMPOSE_BIN" && \
 			docker-compose --version
 		if_failed "Docker Compose installation/upgrade has failed."
 	fi

--- a/bin/fin
+++ b/bin/fin
@@ -2580,6 +2580,7 @@ wsl_mount_drives ()
 	# Create mnt point binds if they don't exist
 	for drive in $(ls /mnt); do
 		if ! (echo "$mounts" | grep " on /$drive " >/dev/null); then
+			echo "Applying necessary pre-flight WSL adjustments..."
 			echo "Creating bind mount /mnt/$drive -> /$drive"
 			sudo mkdir -p "/$drive"
 			sudo mount --bind "/mnt/$drive" "/$drive"

--- a/bin/fin
+++ b/bin/fin
@@ -2139,7 +2139,6 @@ docker_machine_create ()
 	if [[ $? -eq 0 ]]; then
 		DOCKER_MACHINE_NAME="$machine_name"
 		DOCKER_MACHINE_STATUS='Running'
-		vm active "$machine_name"
 	else
 		return 1
 	fi

--- a/bin/fin
+++ b/bin/fin
@@ -788,7 +788,7 @@ check_docker_running ()
 	[[ "$UPGRADE_IN_PROGRESS" == "1" ]] && return 0
 
 	# Check docker versions in this function
-	if ! is_docker_version && [[ -z $DOCKER_VERSION_ALERT_SUPPRESS ]]; then
+	if ! is_docker_version && [[ "$DOCKER_VERSION_ALERT_SUPPRESS" == "" ]]; then
 		echo-alert "Required Docker version is $REQUIREMENTS_DOCKER" \
 			"Run ${yellow}fin update${NC} to update to the required version." \ ""
 		DOCKER_VERSION_ALERT_SUPPRESS=1 # prevent multiple alerts
@@ -806,19 +806,15 @@ check_docker_running ()
 	is_docker_running
 	docker_status=$?
 	# Last chance to return non-error code
-	[[ ${docker_status} -eq 0 ]] && return
+	[[ ${docker_status} == 0 ]] && return
 
 	if [[ ${docker_status} -eq 255 ]] && ! is_docker_native; then
 		echo-yellow "It looks like '$DEFAULT_MACHINE_NAME' docker machine is not running."
 		_confirm "Start it now?"
-		system_start
-		if_failed "Could not start Docksal docker machine properly"
-		# re-check status
-		eval $(docker-machine env --shell=bash "$DEFAULT_MACHINE_NAME")
-		docker info >/dev/null
-		docker_status=$?
+		system_start && return $?
 	fi
 
+	# TODO: Should the checks below be moved to system_start?
 	if is_linux; then
 		# Remind the user about running 'newgrp docker' after install.
 		if ! (id -nG | grep docker >/dev/null 2>&1) && ! is_root ; then

--- a/bin/fin
+++ b/bin/fin
@@ -2524,7 +2524,7 @@ smb_share_mount()
 	command_mount="
 		(sudo umount $mount_point >/dev/null 2>&1 || true) && \
 		sudo mkdir -p $mount_point && \
-		sudo mount -t cifs -o username='${USERNAME}',pass='${password}',domain='${USERDOMAIN}',sec='${SMB_SEC}',vers=2.1,nobrl,mfsymlinks,noperm,actimeo=1,dir_mode=0777,file_mode=0777 //${DOCKSAL_HOST_IP}/$share_name $mount_point"
+		sudo mount -t cifs -o username='${USERNAME}',pass='${password}',domain='${USERDOMAIN}',sec='${SMB_SEC}',vers=3,nobrl,mfsymlinks,noperm,actimeo=1,dir_mode=0777,file_mode=0777 //${DOCKSAL_HOST_IP}/$share_name $mount_point"
 	docker-machine ssh ${DOCKER_MACHINE_NAME} "$command_mount"
 
 	# Perform a second attenpt with sec=ntlm if the first one (with ntslssp or custom override via SMB_SEC=) failed.

--- a/bin/fin
+++ b/bin/fin
@@ -901,6 +901,9 @@ is_vbox_version ()
 
 is_docker_version ()
 {
+	# Skip the check on Pplay-with-Docker and Katacoda
+	(is_pwd || is_katacoda) && return
+
 	! which docker >/dev/null 2>&1 && return 1
 	local version=$(docker version --format '{{.Client.Version}}' 2>/dev/null)
 	[[ $(ver_to_int "$REQUIREMENTS_DOCKER") -le $(ver_to_int "$version") ]]
@@ -908,6 +911,9 @@ is_docker_version ()
 
 is_docker_server_version ()
 {
+	# Skip the check on Pplay-with-Docker and Katacoda
+	(is_pwd || is_katacoda) && return
+
 	! which docker >/dev/null 2>&1 && return 1
 	local version=$(docker version --format '{{.Server.Version}}' 2>/dev/null)
 	[[ $(ver_to_int "$REQUIREMENTS_DOCKER") -le $(ver_to_int "$version") ]]

--- a/bin/fin
+++ b/bin/fin
@@ -243,8 +243,8 @@ STACKS_VOLUMES_NFS="volumes-nfs.yml"
 STACKS_VOLUMES_NONE="volumes-none.yml"
 STACKS_VOLUMES_UNISON="volumes-unison.yml"
 
+URL_DOCKER_COM="https://get.docker.com/"
 URL_DOCKER_MAC="https://download.docker.com/mac/static/stable/x86_64/docker-${REQUIREMENTS_DOCKER}.tgz"
-URL_DOCKER_NIX="https://get.docker.com/"
 URL_DOCKER_LINUX="https://download.docker.com/linux/static/stable/x86_64/docker-${REQUIREMENTS_DOCKER}.tgz"
 # Until there is an official standalone docker.exe binary available, use the one pulled from Docker for Windows
 # See https://github.com/docker/for-win/issues/1460#issuecomment-390045959
@@ -3989,7 +3989,7 @@ install_tools_debian ()
 		fi
 
 		# Pin docker version
-		curl -fsSL "${URL_DOCKER_NIX}" | VERSION=${REQUIREMENTS_DOCKER} sh
+		curl -fsSL "${URL_DOCKER_COM}" | VERSION=${REQUIREMENTS_DOCKER} sh
 		# Using $LOGNAME, not $(whoami). See http://stackoverflow.com/a/4598126/4550880.
 		sudo usermod -aG docker "$LOGNAME"
 		sudo service docker start 2>/dev/null
@@ -4021,7 +4021,7 @@ install_tools_fedora ()
 		fi
 
 		# Install stable Docker version
-		curl -fsSL "${URL_DOCKER_NIX}" | CHANNEL=stable sh
+		curl -fsSL "${URL_DOCKER_COM}" | CHANNEL=stable sh
 		if_failed "Docker installation/upgrade has failed."
 
 		# Have to create group here to add user to it


### PR DESCRIPTION
## Replaces #890

Full WSL support with both, Docker Desktop for Windows and VirtualBox modes.

Closes #851. Closes #865. Closes #973 (verify), Closes #936, Closes #749

## Replaces #960

- Dropped unused vm use cases
  - `vm create`
  - `vm active`
  - `vm ip <IP>`
- Deprecated `fin vm start/stop` in favor of `fin system start/stop`

Closes #949 (verify), 

---

Testing / regressions testing:

- [x] WSL + VirtualBox
- [x] WSL + Docker Desktop
- [x] Babun + VirtualBox
- [x] Babun + Docker Desktop
- [x] Mac + VirtualBox
- [x] Mac + Docker Desktop
- [x] Linux
- [x] Play with Docker
