### PR TITLE
Updated documentation to for versions of CLI images

### DIFF
--- a/docs/content/service/cli/settings.md
+++ b/docs/content/service/cli/settings.md
@@ -37,11 +37,11 @@ When using the default stack (a custom project stack is not defined in `.docksal
 via the `CLI_IMAGE` variable in `.docksal/docksal.env`, e.g.:
 
 ```bash
-CLI_IMAGE='docksal/cli:2.5-php7.1'
+CLI_IMAGE='docksal/cli:2.6-php7.1'
 ```
 This can also be set with `fin config set`.
 ```bash
-fin config set CLI_IMAGE='docksal/cli:2.5-php7.1'
+fin config set CLI_IMAGE='docksal/cli:2.6-php7.1'
 ```
 
 Run `fin project reset cli` (`fin p reset cli`) to properly reset and update the `cli` service.
@@ -50,9 +50,9 @@ Available images:
 
 - PHP 5.6 - `docksal/cli:2.5-php5.6` (deprecated)
 - PHP 7.0 - `docksal/cli:2.5-php7.0` (deprecated)
-- PHP 7.1 - `docksal/cli:2.5-php7.1`
-- PHP 7.2 - `docksal/cli:2.5-php7.2` (default)
-- PHP 7.3 - `docksal/cli:2.5-php7.3`
+- PHP 7.1 - `docksal/cli:2.6-php7.1`
+- PHP 7.2 - `docksal/cli:2.6-php7.2` (default)
+- PHP 7.3 - `docksal/cli:2.6-php7.3`
 
 There are also "edge" versions available that contain code from ongoing updates, but may not be stable. Don't switch to an
 edge image unless directed to do so by the Docksal team for testing purposes only.

--- a/docs/content/stack/checking-configuration.md
+++ b/docs/content/stack/checking-configuration.md
@@ -41,7 +41,7 @@ networks: {}
 services:
   cli:
     hostname: cli
-    image: docksal/cli:2.5-php7.2
+    image: docksal/cli:2.6-php7.2
     volumes:
     - docksal_ssh_agent:/.ssh-agent:ro
     - project_root:/var/www:rw,nocopy

--- a/docs/content/stack/extend-images.md
+++ b/docs/content/stack/extend-images.md
@@ -49,7 +49,7 @@ Below is an example of extending the `cli` image with additional configs, apt, a
 
 ```Dockerfile
 # Use a stock Docksal image as the base
-FROM docksal/cli:php7.2
+FROM docksal/cli:2-php7.2
 
 # Install addtional apt packages
 RUN apt-get update && apt-get -y --no-install-recommends install \

--- a/docs/content/troubleshooting/_index.md
+++ b/docs/content/troubleshooting/_index.md
@@ -1,8 +1,8 @@
 ---
 title: "Troubleshooting"
 chapter: true
-weight: 8
-pre: "<b>8. </b>"
+weight: 7
+pre: "<b>7. </b>"
 ---
 
 # Troubleshooting

--- a/docs/content/use-cases/docker-image.md
+++ b/docs/content/use-cases/docker-image.md
@@ -10,7 +10,7 @@ the Docksal default. Here are the steps that can be taken to build an image:
 1. Create image project, test and verify it worked as expected
 
     ```
-    FROM docksal/cli:php7.2
+    FROM docksal/cli:2-php7.2
     
     RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     


### PR DESCRIPTION
Updated documentation to point to the incremented version of the cli version but to also change the extending stock images to `docksal/cli:2-phpX.X`

Solves https://github.com/docksal/service-cli/issues/60