### PR TITLE
`exec` refactoring

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -1463,11 +1463,13 @@ show_help_list_addons_in_help ()
 show_help_exec ()
 {
 	echo
-	echo "Execute command or file in \`cli\` service container."
+	echo "Execute commands or script in \`cli\` service container,"
+	echo "or execute commands in other containers when specified in params."
 	echo "fin exec will automatically cd into the same folder inside \`cli\`."
 
 	echo
 	echo "Usage: exec [-T] [--in=name] <command | file>"
+	echo "  [!] Parameters order matters."
 
 	echo
 	echo "Options:"

--- a/bin/fin
+++ b/bin/fin
@@ -4732,7 +4732,7 @@ _exec ()
 	local SHELL_NONINTERACTIVE="sh -lc"
 
 	# For cli use bash
-	if [[ "$CONTAINER_NAME" == "cli" ]]; then
+	if [[ "$container_name" == "cli" ]] || [[ "$container_name" == "db" ]]; then
 		SHELL_INTERACTIVE="bash -ilc"
 		SHELL_NONINTERACTIVE="bash -lc"
 	fi

--- a/bin/fin
+++ b/bin/fin
@@ -4733,7 +4733,7 @@ _exec ()
 	local SHELL_INTERACTIVE="sh -ilc"
 	local SHELL_NONINTERACTIVE="sh -lc"
 
-	# For cli use bash
+	# For cli and db use bash (complex SQL queries fail when fed from stdin to sh)
 	if [[ "$container_name" == "cli" ]] || [[ "$container_name" == "db" ]]; then
 		SHELL_INTERACTIVE="bash -ilc"
 		SHELL_NONINTERACTIVE="bash -lc"
@@ -4763,7 +4763,7 @@ _exec ()
 		cmd="$cmd"$(printf " %q" "$@")
 	# Do not escape spaces if there is only one parameter (e.g., fin run "ls -la | grep txt")
 	else
-		cmd="$cmd""$@"
+		cmd="${cmd}${@}"
 	fi
 	# ------------------------------------------------ #
 

--- a/bin/fin
+++ b/bin/fin
@@ -4679,20 +4679,26 @@ image_registry_list ()
 # @param $1 container name
 _bash ()
 {
-	check_docker_running
 	# Interactive shell requires a tty.
-	# On Windows we assume we run interactively via winpty.
 	if ! is_tty; then
-		echo "not a tty"
+		echo-error "tty is required to start an interactive shell"
 		return 1
 	fi
 
-	# Pass container name to _run
-	CONTAINER_NAME=$1 _exec bash -il
+	# Use sh by default
+	if [[ "$1" != "" ]]; then
+		# Pass container name to _exec
+		_exec --in="$1" sh -il
+	else
+		# Use bash when container is not specified, for it defaults to cli
+		_exec bash -il
+	fi
 }
 
 # Run a command in the cli container changing dir to the same folder
-# @param $* command with its params to run
+# @param [-T] Force no-tty
+# @param [--in=name] Specify container name
+# @param $@ commands to run
 _exec ()
 {
 	[[ $1 == "" ]] &&
@@ -4711,40 +4717,51 @@ _exec ()
 	fi
 
 	# Allow overriding container, where to run
+	local container_name
 	if [[ "$1" =~ "--in" ]]; then
-		CONTAINER_NAME=$(echo "$1" | cut -d "=" -f 2)
+		container_name=$(echo "$1" | cut -d "=" -f 2)
 		shift
+	else
+		container_name="cli"
 	fi
 
-	CONTAINER_NAME=${CONTAINER_NAME:-cli}
-	container_id=$(get_container_id "$CONTAINER_NAME")
+	container_id=$(get_container_id "$container_name")
+
+	# Use sh as default shell
+	local SHELL_INTERACTIVE="sh -ilc"
+	local SHELL_NONINTERACTIVE="sh -lc"
+
+	# For cli use bash
+	if [[ "$CONTAINER_NAME" == "cli" ]]; then
+		SHELL_INTERACTIVE="bash -ilc"
+		SHELL_NONINTERACTIVE="bash -lc"
+	fi
 
 	# ------------------------------------------------ #
 	# 1) cmd
-	local cmd
+	local cmd=""
 
-	local cdir
 	# Only chdir to the same dir in cli container
 	# RUN_NO_CDIR can be used to override this (used in mysql_import)
-	if [[ "$CONTAINER_NAME" == "cli" ]] && [[ "$RUN_NO_CDIR" != 1 ]]; then
+	if [[ "$container_name" == "cli" ]] && [[ "$RUN_NO_CDIR" != 1 ]]; then
 		local path=$(get_current_relative_path)
 		if [[ "$path" != "" ]] ; then
 			# We are deeper than project root and thus need to do a cd
-			cdir="cd $path &&"
+			cmd="cd $path &&"
 		fi
 	fi
-
-	cmd="$cdir"
 	# ------------------------------------------------ #
 
 	# ------------------------------------------------ #
 	# 2) convert array of parameters into escaped string
+	# Add space if cmd is not empty
+	[[ $cmd != "" ]] && cmd="$cmd "
 	# Escape spaces that are "spaces" and not parameter delimiters (i.e., param1 param2\ with\ spaces param3)
 	if [[ $2 != "" ]]; then
-		cmd="$cmd "$(printf " %q" "$@")
+		cmd="$cmd"$(printf " %q" "$@")
 	# Do not escape spaces if there is only one parameter (e.g., fin run "ls -la | grep txt")
 	else
-		cmd="$cmd $@"
+		cmd="$cmd""$@"
 	fi
 	# ------------------------------------------------ #
 
@@ -4752,40 +4769,23 @@ _exec ()
 	# 3) execute
 	# Allow entering arbitrary containers by name (e.g., system containers like vhost-proxy).
 	if [[ "$container_id" == "" ]]; then
-		${winpty} docker exec -it "$CONTAINER_NAME" sh -i
-		return
+		container_id="$container_name"
 	fi
 
-	if [[ "$CONTAINER_NAME" == "cli" ]]; then
+	if [[ "$container_name" == "cli" ]]; then
 		# Commands in cli should be run using the docker user, not root.
 		local container_user='-u docker'
 	fi
 
 	# Enter project containers
-	# Use the docker user in cli (-u docker) instead of root (default user).
-	# COLUMNS and LINES have to be passed to workaround a bug in Docker. See https://github.com/moby/moby/issues/35407#issuecomment-355753176
+	# COLUMNS and LINES have to be passed to workaround a race condition in Docker. See https://github.com/moby/moby/pull/37172#issuecomment-406844485
 	if is_tty && [[ "$no_tty" != true ]]; then
 		# interactive
 		# (exit \$?) is a hack to return correct exit codes when docker exec is run with tty (-t).
-		${winpty} docker exec -e COLUMNS -e LINES -it ${container_user} ${container_id} bash -ilc "$cmd; (exit \$?)"
+		${winpty} docker exec -e COLUMNS -e LINES -it ${container_user} ${container_id} ${SHELL_INTERACTIVE} "$cmd; (exit \$?)"
 	else
 		# non-interactive
-		docker exec -e COLUMNS -e LINES ${container_user} ${container_id} bash -lc "$cmd"
-	fi
-
-	res=$?
-
-	# Process a case when there is no bash in the container
-	if [[ $res == 126 ]]; then
-		if is_tty && [[ "$no_tty" != true ]]; then
-			# interactive
-			${winpty} docker exec -e COLUMNS -e LINES -it ${container_user} ${container_id} sh -ilc "$cmd"
-		else
-			# non-interactive
-			docker exec -e COLUMNS -e LINES ${container_user} ${container_id} sh -lc "$cmd"
-		fi
-	else
-		return $res
+		docker exec -e COLUMNS -e LINES ${container_user} ${container_id} ${SHELL_NONINTERACTIVE} "$cmd"
 	fi
 	# ------------------------------------------------ #
 }
@@ -4983,8 +4983,7 @@ mysql_list ()
 	local __dump_password="${dbpassword:-$MYSQL_ROOT_PASSWORD}"
 
 	# -N parameter suppresses columns header
-	_RUN_NO_CDIR=1 CONTAINER_NAME="db" \
-		_exec "echo 'SHOW DATABASES' | mysql -N -u ${__dump_user} -p${__dump_password}"
+	_exec --in="db" "echo 'SHOW DATABASES' | mysql -N -u ${__dump_user} -p${__dump_password}"
 }
 
 # Create a database
@@ -5083,8 +5082,7 @@ mysql_db_truncate ()
 		DROP DATABASE \\\`${__database}\\\`;
 		EXECUTE DBCREATE;
 	EOF
-	_RUN_NO_CDIR=1 CONTAINER_NAME="db" \
-		_exec "echo -e \"$DBCREATE_COMMAND\"| mysql -u${__dump_user} -p${__dump_password} ${__database} "
+	_exec --in="db" "echo -e \"$DBCREATE_COMMAND\"| mysql -u${__dump_user} -p${__dump_password} ${__database} "
 }
 
 # Truncate db and import from sql dump
@@ -5145,8 +5143,7 @@ mysql_import ()
 			DROP DATABASE \\\`${__database}\\\`;
 			EXECUTE DBCREATE;
 		EOF
-		_RUN_NO_CDIR=1 CONTAINER_NAME="db" \
-			_exec "echo -e \"$DBCREATE_COMMAND\"| mysql -u${__dump_user} -p${__dump_password} ${__database} "
+		_exec --in="db" "echo -e \"$DBCREATE_COMMAND\"| mysql -u${__dump_user} -p${__dump_password} ${__database} "
 
 		if [[ ! $? -eq 0 ]] && (exit ${confirm}); then
 			_confirm "There were errors during truncation. Continue anyways?"
@@ -6369,7 +6366,7 @@ addon_execute ()
 			cmd="$container_addon_path"
 		fi
 		# Run the command
-		CONTAINER_NAME="$_exec_target" _exec "$cmd"
+		_exec --in="$_exec_target" "$cmd"
 	else
 		export ADDON_SCRIPT=true
 		exec "$addon" "$@"
@@ -7512,7 +7509,7 @@ case "$1" in
 		_bash "$@"
 		;;
 	exec|run)
-		DOCKER_VERSION_ALERT_SUPPRESS=1 # prevent version alert for exec
+		DOCKER_VERSION_ALERT_SUPPRESS=1 # prevent docker version alert for exec
 		load_configuration
 		shift
 		if [ -f "$1" ]; then

--- a/bin/fin
+++ b/bin/fin
@@ -4772,6 +4772,21 @@ _exec ()
 		# non-interactive
 		docker exec -e COLUMNS -e LINES ${container_user} ${container_id} bash -lc "$cmd"
 	fi
+
+	res=$?
+
+	# Process a case when there is no bash in the container
+	if [[ $res == 126 ]]; then
+		if is_tty && [[ "$no_tty" != true ]]; then
+			# interactive
+			${winpty} docker exec -e COLUMNS -e LINES -it ${container_user} ${container_id} sh -ilc "$cmd"
+		else
+			# non-interactive
+			docker exec -e COLUMNS -e LINES ${container_user} ${container_id} sh -lc "$cmd"
+		fi
+	else
+		return $res
+	fi
 	# ------------------------------------------------ #
 }
 

--- a/docs/content/fin/fin-help.md
+++ b/docs/content/fin/fin-help.md
@@ -1,5 +1,5 @@
 ---
-title: "All commands reference"
+title: "fin help"
 weight: 2
 aliases:
   - /en/master/fin/fin-help/
@@ -8,7 +8,7 @@ aliases:
 ## fin {#fin}
 
 	
-	Docksal command line utility v1.81.0
+	Docksal command line utility v1.82.1
 	
 	Usage: fin <command>
 	
@@ -152,11 +152,11 @@ aliases:
 	  --sync-git-branch        	The GIT Branch to pull from. (Defaults to current branch)
 	
 	Extra Options for DB
-	  --db-user=<user>          	Specify the DB User (Defaults to root)
-	  --db-pass=<pass>          	Specify the DB Password (Defaults to root)
-	  --db-name=<dbname>        	Specify the DB Name to import into. (Defaults to default)
+	  --db-user=<user>         	Specify the DB User (Defaults to root)
+	  --db-pass=<pass>         	Specify the DB Password (Defaults to root)
+	  --db-name=<dbname>       	Specify the DB Name to import into. (Defaults to default)
 	  --force                  	Generate and pull a new db dump, rather than using locally cached in /tmp
-	  --remote-db=<remote_db>  	Specify the remote DB name to pull. (Used with Acquia)
+	  --remote-db=<remotedb>   	Specify the remote DB name to pull. (Used with Acquia)
 	
 	Extra Options for Files
 	  --rsync-options=<options>	Rsync Options to append.
@@ -262,6 +262,29 @@ aliases:
 	Examples:
 	  fin addon install solr   	Install solr addon to the current project
 	  fin addon remove solr    	Uninstall solr addon from the current project
+
+## exec {#exec}
+
+	
+	Execute commands or script in `cli` service container,
+	or execute commands in other containers when specified in params.
+	fin exec will automatically cd into the same folder inside `cli`.
+	
+	Usage: exec [-T] [--in=name] <command | file>
+	  [!] Parameters order matters.
+	
+	Options:
+	  -T                       	Disable pseudo-tty allocation.
+	                           	Useful for non-interactive commands when output is saved into a variable for further comparison.
+	                           	In a TTY mode the output may contain unexpected invisible control symbols.
+	  --in=name                	Name of the service to execute the command in.
+	
+	Examples:
+	  fin exec ls -la          			Current directory listing
+	  fin exec "ls -la > /tmp/list"			Execute advanced shell command with pipes or stdout redirects happening inside `cli`
+	  res=$(fin exec -T drush st)			Use -T switch when using exec output
+	  fin exec .docksal/script.sh			Execute a whole file inside `cli` container
+	  fin exec --in=db mysql -uroot -p		Execute command in `db` container (will NOT cd into the same folder)
 
 ## run-cli {#run-cli}
 

--- a/scripts/fin-help-generate.sh
+++ b/scripts/fin-help-generate.sh
@@ -73,6 +73,10 @@ echo " - addon"
 headergen "addon"
 helpgen addon
 
+echo " - exec"
+headergen "exec"
+helpgen exec
+
 echo " - run-cli"
 headergen "run-cli"
 helpgen run-cli


### PR DESCRIPTION
`exec` and `bash` will use sh by default and only use bash for `cli` and `db` (complex db functions input requires `bash` as well).

Closes #942 
Relates to #924