### PR TITLE
Feature: Enable creation of default commands for command groups

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -528,7 +528,7 @@ get_command_script ()
 	# Then search global docksal commands directory for the command
 	[ ! -f "$command_script" ] && command_script="$HOME/$DOCKSAL_COMMANDS_PATH/$1"
 	# Then search for a default command in a global command group
-	[ ! -f "$command_script" ] && command_script="$HOME/$DOCKSAL_COMMANDS_PATH/$1/.default"
+	[ ! -f "$command_script" ] && command_script="$HOME/$DOCKSAL_COMMANDS_PATH/$1/$1"
 	# If command was found then return it
 	[ -f "$command_script" ] && echo "$command_script"
 }

--- a/bin/fin
+++ b/bin/fin
@@ -527,6 +527,8 @@ get_command_script ()
 	[ ! -f "$command_script" ] && command_script="$COMMANDS_ROOT/$1/.default"
 	# Then search global docksal commands directory for the command
 	[ ! -f "$command_script" ] && command_script="$HOME/$DOCKSAL_COMMANDS_PATH/$1"
+	# Then search for a default command in a global command group
+	[ ! -f "$command_script" ] && command_script="$HOME/$DOCKSAL_COMMANDS_PATH/$1/.default"
 	# If command was found then return it
 	[ -f "$command_script" ] && echo "$command_script"
 }

--- a/bin/fin
+++ b/bin/fin
@@ -524,7 +524,7 @@ get_command_script ()
 	# First search project commands folder for the command
 	command_script="$COMMANDS_ROOT/$1"
 	# Then search for a default command in a group
-	[ ! -f "$command_script" ] && command_script="$COMMANDS_ROOT/$1/.default"
+	[ ! -f "$command_script" ] && command_script="$COMMANDS_ROOT/$1/$1"
 	# Then search global docksal commands directory for the command
 	[ ! -f "$command_script" ] && command_script="$HOME/$DOCKSAL_COMMANDS_PATH/$1"
 	# Then search for a default command in a global command group

--- a/bin/fin
+++ b/bin/fin
@@ -1543,8 +1543,12 @@ show_help_list_commands_in_help ()
 			local g
 			[[ "$1" == 'global' ]] && g=' [g]'
                         cmd_name=${cmd_name/${addons_path}\//}
+			local cmd_path=${cmd_name}
+                        local cmd_short=${cmd_name##*/}
+                        local cmd_regex="${cmd_short}/${cmd_short}$"
+                        [[ ${cmd_name} =~ $cmd_regex ]] && cmd_name=${cmd_name/${cmd_short}\/${cmd_short}/${cmd_short}}
 			# command description is lines that start with ##
-			local filename="$addons_path/$cmd_name"
+			local filename="$addons_path/$cmd_path"
 			local cmd_desc
 			[[ ! -f "$filename" ]] && continue
 			cmd_desc=$(cat "$filename" | grep '^##' | sed "s/^##[ ]*//g" | head -1 --)

--- a/bin/fin
+++ b/bin/fin
@@ -523,6 +523,8 @@ get_command_script ()
 	COMMANDS_ROOT="$(get_project_path)/$DOCKSAL_COMMANDS_PATH"
 	# First search project commands folder for the command
 	command_script="$COMMANDS_ROOT/$1"
+	# Then search for a default command in a group
+	[ ! -f "$command_script" ] && command_script="$COMMANDS_ROOT/$1/.default"
 	# Then search global docksal commands directory for the command
 	[ ! -f "$command_script" ] && command_script="$HOME/$DOCKSAL_COMMANDS_PATH/$1"
 	# If command was found then return it

--- a/docs/content/fin/custom-commands.md
+++ b/docs/content/fin/custom-commands.md
@@ -176,12 +176,12 @@ services:
 
 ## Grouping Commands
 
-Docksal allows for commands to be grouped together within folders. This is particulary useful when creating a toolkit to share with other developers. Commands can be grouped within the Global Scope `~/.docksal/commands` and on a per project basis. Command groups can also have a `.default` command that runs when the group name is given. For example, a project's `.docksal/commands` folder might contain a `test` directory as a command group:
+Docksal allows for commands to be grouped together within folders. This is particulary useful when creating a toolkit to share with other developers. Commands can be grouped within the Global Scope `~/.docksal/commands` and on a per project basis. Command groups can also have a default command, with the same name as the folder, that runs when the group name is given. For example, a project's `.docksal/commands` folder might contain a `test` directory as a command group:
 
 | File          | Command           | What it does...                                       |
 | ------------- | ----------------- | ----------------------------------------------------- |
 | test/         | | |
-| test/.default | `fin test`        | (runs all the tests)                                  |
+| test/test     | `fin test`        | (runs all the tests)                                  |
 | test/behat    | `fin test/behat`  | `./vendor/bin/behat --config=behat-docksal.yml "$@"`  |
 | test/sniff    | `fin test/sniff`  | `./vendor/bin/phpcs -h`                               |
 

--- a/docs/content/fin/custom-commands.md
+++ b/docs/content/fin/custom-commands.md
@@ -176,7 +176,14 @@ services:
 
 ## Grouping Commands
 
-Docksal allows for commands to be grouped together within folders. This is particulary useful when creating a toolkit to share with other developers. Commands can be grouped within the Global Scope `~/.docksal/commands` and on a per project basis.
+Docksal allows for commands to be grouped together within folders. This is particulary useful when creating a toolkit to share with other developers. Commands can be grouped within the Global Scope `~/.docksal/commands` and on a per project basis. Command groups can also have a `.default` command that runs when the group name is given. For example, a project's `.docksal/commands` folder might contain a `test` directory as a command group:
+
+| File          | Command           | What it does...                                       |
+| ------------- | ----------------- | ----------------------------------------------------- |
+| test/         | | |
+| test/.default | `fin test`        | (runs all the tests)                                  |
+| test/behat    | `fin test/behat`  | `./vendor/bin/behat --config=behat-docksal.yml "$@"`  |
+| test/sniff    | `fin test/sniff`  | `./vendor/bin/phpcs -h`                               |
 
 To view commands, run `fin help` and there should be similar output. This will show the available commands and prefix them within the folder they are located in.
 


### PR DESCRIPTION
As a project manager / lead developer, I would like to give my dev team a group of commands related to behat, but still allow them to type `fin behat` as a basic command. In order to do this, I need to be able to create a default command that will be executed when the name of the folder is typed. For example, I might have the following commands:

| Command | Runs something like ... |
| --- | --- |
| `fin behat` | `vendor/bin/behat "$@"` |
| `fin behat/info` | `vendor/bin/behat -d i --no-colors > available-tests.txt` |

To do this, I would make a folder structure as follows:

```
.docksal
  commands
    behat
      .default
      info
```