### PR TITLE
Add Pantheon stack file to files_to_download list

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -279,6 +279,7 @@ STACKS_STACK_ACQUIA="stack-acquia.yml"
 STACKS_STACK_DEFAULT="stack-default.yml"
 STACKS_STACK_DEFAULT_NODB="stack-default-nodb.yml"
 STACKS_STACK_NODE="stack-node.yml"
+STACKS_STACK_PANTHEON="stack-pantheon.yml"
 STACKS_VOLUMES_BIND="volumes-bind.yml"
 STACKS_VOLUMES_NFS="volumes-nfs.yml"
 STACKS_VOLUMES_NONE="volumes-none.yml"
@@ -4541,6 +4542,7 @@ update_config_files ()
 			$STACKS_STACK_DEFAULT
 			$STACKS_STACK_DEFAULT_NODB
 			$STACKS_STACK_NODE
+			$STACKS_STACK_PANTHEON
 			$STACKS_VOLUMES_BIND
 			$STACKS_VOLUMES_NFS
 			$STACKS_VOLUMES_NONE


### PR DESCRIPTION
With fin 1.85.0 when doing a `fin update` it doesn't download the newly added Pantheon stack. So, I added the  `stack-pantheon.yml` to the `files_to_download` list in `update_config_files ()` function