### PR TITLE
Allow help text for commands located in symlinked directories.

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -1536,7 +1536,7 @@ show_help_list_commands_in_help ()
 	local executable="-executable"
 	is_mac && executable="-perm +100"
 
-	local addons_list=$(find "$addons_path" -type f ${executable} 2>/dev/null | sort -n 2>/dev/null)
+	local addons_list=$(find -L "$addons_path" -maxdepth 2 -type f ${executable} 2>/dev/null | sort -n 2>/dev/null)
 	if [[ "$addons_list" != "" ]]; then
 		local scope
 		for cmd_name in ${addons_list}


### PR DESCRIPTION
This addresses the issue noted here https://github.com/docksal/docksal/issues/846#issuecomment-484269763. It does not completely resolve that, but at least allows help text to be printed.
