### PR TITLE
Instruct docker to clean up exited docksal/empty container

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -964,7 +964,7 @@ is_docker_path ()
 {
 	local _path="${1}"
 	[[ "$_path" == "" ]] && return 1
-	(cd "$_path" 2>/dev/null && docker run -v "$_path":"$_path" docksal/empty 2>/dev/null)
+	(cd "$_path" 2>/dev/null && docker run --rm -v "$_path":"$_path" docksal/empty 2>/dev/null)
 }
 
 # Check VirtualBox version


### PR DESCRIPTION
Added docker run flag that will cause docker to remove the docksal/empty container after it exits. 