### PR TITLE
Reset system after docker machine started

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -2424,6 +2424,9 @@ docker_machine_start ()
 			exit 1
 		fi
 	fi
+
+	# After docker machine is restarted, we should reset the system to make sure everything is in a sane state.
+	system_reset
 }
 
 docker_machine_remove ()


### PR DESCRIPTION
I saw on a developers laptop that when he ran `fin up` after a reboot, the resolver for *.docksal was not added and the NFS mounts weren't properly setup. I noticed that when he was doing this docksal was saying that the docker-machine wasn't started and offering to start it for him, however it said nothing about NFS mounts and resolvers being added, whereas `fin project restart` did, and fixed the issue.

This PR adds the missing step to the `docker_machine_start` routine. I'm not convinced this is the correct place to put it yet as `check_docker_running` (and therefore possibly `docker_machine_start`) is called by `system_reset` which feels wrong. However, it shouldn't cause any loops as by the time `docker_machine_start` calls `system_reset` the docker machine should be started and therefore the `docker_machine_start` code is never called. I'm open to suggestions on where this would be better placed :)