### PR TITLE
Export CLI user to a configurable variable

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -306,6 +306,8 @@ IMAGE_SSH_AGENT=${IMAGE_SSH_AGENT:-docksal/ssh-agent:1.2}
 IMAGE_VHOST_PROXY=${IMAGE_VHOST_PROXY:-docksal/vhost-proxy:1.5}
 IMAGE_DNS=${IMAGE_DNS:-docksal/dns:1.1}
 
+# User to be passed to the CLI container when executing commands.
+CLI_USER=${CLI_USER:-docker}
 #---------------------------- Helper functions --------------------------------
 
 DOCKSAL_PATH='' #docksal path value will be cached here
@@ -4996,7 +4998,7 @@ _exec ()
 
 	if [[ "$container_name" == "cli" ]]; then
 		# Commands in cli should be run using the docker user, not root.
-		local container_user='-u docker'
+		local container_user="-u $CLI_USER"
 	fi
 
 	# Enter project containers

--- a/docs/content/stack/configuration-variables.md
+++ b/docs/content/stack/configuration-variables.md
@@ -209,6 +209,12 @@ Acquia Cloud API Key. See [Acquia Drush Commands](/tools/acquia-drush/).
 
 Token used for logging in to Pantheon's CLI Tool [Terminus](/tools/terminus/).
 
+### CLI_USER
+
+`Default:  docker`
+
+User to be used for `fin exec`.
+
 ## Image Variables
 
 The following variables are used to set images to a specified version. Using them will prevent the images from being udpated


### PR DESCRIPTION
Currently the user used to execute command on the `cli` container is hard coded to `docker`. This works well for the "official" docksal `cli` container provided in the stacks but may not be true for custom `cli` container.

This changes exports the `cli` user to a `CLI_USER` variable that can be set via the various docksal environments overrides.