### PR TITLE
Adds SSH key forwarding support for cli

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -253,6 +253,15 @@ PATH="$CONFIG_BIN_DIR:$PATH"
 # Set global variable in case native Docker app is used/not-used
 DOCKER_NATIVE="${DOCKER_NATIVE:-0}"
 
+# SSH agent settings
+if ! is_ci; then
+	# Use the built-in agent in non-CI environments
+	DOCKSAL_SSH_AGENT_USE_HOST="${DOCKSAL_SSH_AGENT_USE_HOST:-0}"
+else
+	# Prefer the hosts' agent in CI environments
+	DOCKSAL_SSH_AGENT_USE_HOST="${DOCKSAL_SSH_AGENT_USE_HOST:-1}"
+fi
+
 #---------------------------- URL references --------------------------------
 GITHUB_API="https://api.github.com"
 URL_REPO="https://raw.githubusercontent.com/docksal/docksal"
@@ -7519,9 +7528,10 @@ else
 	export DOCKER_RUNNING="false"
 fi
 
-# Only allow SSH key forwarding in a CI/Linux environment, otherwise cli won't be able to start on Mac/Win,
-# since ssh-agent sockets there would be outside of the mounted/accessible projects directory.
-if ! is_ci || ! is_linux; then unset SSH_AUTH_SOCK; fi
+# Reusing host's ssh-agent socket (SSH_AUTH_SOCK) is only supported on Linux.
+# On Mac/Win, SSH_AUTH_SOCK would be outside of the mounted projects directory and thus inaccessible (cli will fail to start).
+# On Linux, we default to the built-in agent, unless DOCKSAL_SSH_AGENT_USE_HOST=1
+if ! is_linux || [[ "${DOCKSAL_SSH_AGENT_USE_HOST}" != "1" ]]; then unset SSH_AUTH_SOCK; fi
 
 # Handle Alias
 if [[ "$1" == "@"* ]]; then

--- a/bin/fin
+++ b/bin/fin
@@ -7519,6 +7519,10 @@ else
 	export DOCKER_RUNNING="false"
 fi
 
+# Only allow SSH key forwarding in a CI/Linux environment, otherwise cli won't be able to start on Mac/Win,
+# since ssh-agent sockets there would be outside of the mounted/accessible projects directory.
+if ! is_ci || ! is_linux; then unset SSH_AUTH_SOCK; fi
+
 # Handle Alias
 if [[ "$1" == "@"* ]]; then
 	USED_ALIAS=${1#@}

--- a/docs/content/stack/configuration-variables.md
+++ b/docs/content/stack/configuration-variables.md
@@ -30,6 +30,23 @@ Docker image to use as the VHOST Proxy. This forwards all requests to the approp
 
 Docker image to use for DNS Routing.
 
+### CI
+
+This is a global variable. Only use on Linux servers. 
+
+When set, enables CI mode:
+
+- Sets `DOCKSAL_VHOST_PROXY_IP="0.0.0.0"`, which opens vhost-proxy to the world.
+- Reports the instance as a CI instance (vs local), so our anonymous usage stats are not skewed.
+- Allows SSH agent forwarding from ci/dev to sandbox server to cli containers (only works on Linux servers). 
+- Enables usage of host's `SSH_AUTH_SOCK` in `cli` containers. Used in conjunction with [SSH agent forwarding](https://developer.github.com/v3/guides/using-ssh-agent-forwarding/).
+
+This should be used on sandbox servers (and in CI) at the time of Docksal installation like this:
+
+```
+curl -fsSL https://get.docksal.io | CI=1 bash
+```
+
 ### DOCKSAL_LOCK_UPDATES 
 
 When set, this will allow for Docksal to no longer accept updates. This is usually good in combination with `CI=true`.

--- a/docs/content/stack/configuration-variables.md
+++ b/docs/content/stack/configuration-variables.md
@@ -38,14 +38,22 @@ When set, enables CI mode:
 
 - Sets `DOCKSAL_VHOST_PROXY_IP="0.0.0.0"`, which opens vhost-proxy to the world.
 - Reports the instance as a CI instance (vs local), so our anonymous usage stats are not skewed.
-- Allows SSH agent forwarding from ci/dev to sandbox server to cli containers (only works on Linux servers). 
-- Enables usage of host's `SSH_AUTH_SOCK` in `cli` containers. Used in conjunction with [SSH agent forwarding](https://developer.github.com/v3/guides/using-ssh-agent-forwarding/).
+- Sets `DOCKSAL_SSH_AGENT_USE_HOST=1`, which enables reuse of the hosts `SSH_AUTH_SOCK` socket (Linux only).
 
 This should be used on sandbox servers (and in CI) at the time of Docksal installation like this:
 
 ```
 curl -fsSL https://get.docksal.io | CI=1 bash
 ```
+
+### DOCKSAL_SSH_AGENT_USE_HOST
+
+Defaults to `0` for non-CI environments and to `1` for CI environments.
+
+When set to `1`, project's stack will prefer the host's SSH agent (`SSH_AUTH_SOCK` socket) over the built-in docksal-ssh-agent.
+Can be used in conjunction with [SSH agent forwarding](https://developer.github.com/v3/guides/using-ssh-agent-forwarding/).
+
+Only applicable to Linux hosts.
 
 ### DOCKSAL_LOCK_UPDATES 
 

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -134,7 +134,7 @@ services:
     image: ${CLI_IMAGE:-docksal/cli:2.6-php7.2}
     volumes:
       - project_root:/var/www:rw,nocopy  # Project root volume
-      - docksal_ssh_agent:/.ssh-agent:ro  # Shared ssh-agent socket
+      - ${SSH_AUTH_SOCK:-docksal_ssh_agent}:${SSH_AUTH_SOCK:-/.ssh-agent}:ro  # Shared ssh-agent socket/SSH key forwarding support
       - cli_home:/home/docker  # Write-heavy directories should be in volumes. See https://github.com/docksal/docksal/issues/325
     environment:
       - GIT_USER_EMAIL
@@ -154,6 +154,7 @@ services:
       - SECRET_ACAPI_KEY
       - SECRET_PLATFORMSH_CLI_TOKEN
       - SECRET_TERMINUS_TOKEN
+      - SSH_AUTH_SOCK=${SSH_AUTH_SOCK:-/.ssh-agent/proxy-socket}  # SSH key forwarding support
     dns:
       - ${DOCKSAL_DNS1}
       - ${DOCKSAL_DNS2}


### PR DESCRIPTION
Fixes #1079

SSH key forwarding chain:

```
ci-agent (has keys loaded in ssh-gent) 
  => server (SSH_AUTH_SOCK) 
      => project cli container (mounted SSH_AUTH_SOCK from the host and overridden SSH_AUTH_SOCK variable)
```

This PR implements the last link of the chain.

SSH key(s) loaded in the ssh-agent on the client will be available on the server and in the target project's `cli` container only during the build time. Once the SSH connection from client drops, the ssh-agent socket becomes unavailable.