### PR TITLE
Allow disabling checking for updates

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -247,8 +247,8 @@ DOCKSAL_STATS_TID='UA-93724315-1'
 DOCKSAL_STATS_URL='http://www.google-analytics.com/collect'
 DOCKSAL_STATS_OPTOUT=${DOCKSAL_STATS_OPTOUT:-0}
 
-# Whether to disable the automatic check for Docksal updates
-DOCKSAL_DISABLE_UPDATES="${DOCKSAL_DISABLE_UPDATES:-0}"
+# Whether to prevent (checking for) updates for Docksal
+DOCKSAL_LOCK_UPDATES="${DOCKSAL_LOCK_UPDATES:-0}"
 
 # Override PATH to use our utilities
 PATH="$CONFIG_BIN_DIR:$PATH"
@@ -4863,7 +4863,7 @@ check_for_updates ()
 		echo "$timestamp" > "$CONFIG_LAST_PING"
 	fi
 
-	[[ "$DOCKSAL_DISABLE_UPDATES" == "1" ]] && return # Do not check for updates if disabled
+	[[ "$DOCKSAL_LOCK_UPDATES" == "1" ]] && return # Do not check for updates if disabled
 
 	if wants_rc_version; then
 		# Check once a day if DOCKSAL_USE_RC is set
@@ -7771,7 +7771,7 @@ case "$1" in
 		vm "$@"
 		;;
 	update)
-		if [[ "$DOCKSAL_LOCK_UPDATES" != "" ]]; then
+		if [[ "$DOCKSAL_LOCK_UPDATES" == "1" ]]; then
 			echo-error "Updates locked in this environment"
 			exit 1
 		fi

--- a/bin/fin
+++ b/bin/fin
@@ -4842,10 +4842,6 @@ get_fin_url ()
 
 check_for_updates ()
 {
-	if [ "${DOCKSAL_CHECK_FOR_UPDATES}" != 'true' ]; then
-		return
-	fi
-
 	# Never trigger in scripts
 	if ! is_tty; then return; fi
 	local UPDATE_AVAILABLE=0
@@ -4866,6 +4862,8 @@ check_for_updates ()
 		stats_ping
 		echo "$timestamp" > "$CONFIG_LAST_PING"
 	fi
+
+	[[ "$DOCKSAL_CHECK_FOR_UPDATES" != "true" ]] && return # Do not check for updates if disabled
 
 	if wants_rc_version; then
 		# Check once a day if DOCKSAL_USE_RC is set

--- a/bin/fin
+++ b/bin/fin
@@ -247,6 +247,9 @@ DOCKSAL_STATS_TID='UA-93724315-1'
 DOCKSAL_STATS_URL='http://www.google-analytics.com/collect'
 DOCKSAL_STATS_OPTOUT=${DOCKSAL_STATS_OPTOUT:-0}
 
+# Whether to automatically check for Docksal updates
+DOCKSAL_CHECK_FOR_UPDATES="${DOCKSAL_CHECK_FOR_UPDATES:-true}"
+
 # Override PATH to use our utilities
 PATH="$CONFIG_BIN_DIR:$PATH"
 
@@ -4839,6 +4842,10 @@ get_fin_url ()
 
 check_for_updates ()
 {
+	if [ "${DOCKSAL_CHECK_FOR_UPDATES}" != 'true' ]; then
+		return
+	fi
+
 	# Never trigger in scripts
 	if ! is_tty; then return; fi
 	local UPDATE_AVAILABLE=0

--- a/bin/fin
+++ b/bin/fin
@@ -247,8 +247,8 @@ DOCKSAL_STATS_TID='UA-93724315-1'
 DOCKSAL_STATS_URL='http://www.google-analytics.com/collect'
 DOCKSAL_STATS_OPTOUT=${DOCKSAL_STATS_OPTOUT:-0}
 
-# Whether to automatically check for Docksal updates
-DOCKSAL_CHECK_FOR_UPDATES="${DOCKSAL_CHECK_FOR_UPDATES:-true}"
+# Whether to disable the automatic check for Docksal updates
+DOCKSAL_DISABLE_UPDATES="${DOCKSAL_DISABLE_UPDATES:-0}"
 
 # Override PATH to use our utilities
 PATH="$CONFIG_BIN_DIR:$PATH"
@@ -4863,7 +4863,7 @@ check_for_updates ()
 		echo "$timestamp" > "$CONFIG_LAST_PING"
 	fi
 
-	[[ "$DOCKSAL_CHECK_FOR_UPDATES" != "true" ]] && return # Do not check for updates if disabled
+	[[ "$DOCKSAL_DISABLE_UPDATES" == "1" ]] && return # Do not check for updates if disabled
 
 	if wants_rc_version; then
 		# Check once a day if DOCKSAL_USE_RC is set

--- a/docs/content/stack/configuration-variables.md
+++ b/docs/content/stack/configuration-variables.md
@@ -32,7 +32,9 @@ Docker image to use for DNS Routing.
 
 ### DOCKSAL_LOCK_UPDATES 
 
-When set, this will allow for Docksal to no longer accept updates. This is usually good in combination with `CI=true`.
+`Default: 0`
+
+When set to `1`, this will prevent Docksal from installing and checking for updates. This is usually good in combination with `CI=true`.
 
 ### DOCKER_VERSION_ALERT_SUPPRESS
 
@@ -65,12 +67,6 @@ Allows for overriding the Docksal version used for checking for updates.
 `Default: 0` 
 
 Allow for collecting of statistical usage of docksal. When set to `1` this will no longer send statistics.
-
-### DOCKSAL_DISABLE_UPDATES
-
-`Default: 0`
-
-When set to `1`, Docksal will not perform automatic checks for available updates.
 
 ### DOCKER_NATIVE
 

--- a/docs/content/stack/configuration-variables.md
+++ b/docs/content/stack/configuration-variables.md
@@ -54,11 +54,23 @@ on a build/sandbox server via `fin config set --global DOCKSAL_ENVIRONMENT=ci`. 
 
 Note: `DOCKSAL_ENVIRONMENT` should not be set and will not work in the project's `docksal.env` file (this is by design).
 
+### DOCKSAL_VERSION
+
+`Default: master`
+
+Allows for overriding the Docksal version used for checking for updates.
+
 ### DOCKSAL_STATS_OPTOUT 
 
 `Default: 0` 
 
 Allow for collecting of statistical usage of docksal. When set to `1` this will no longer send statistics.
+
+### DOCKSAL_DISABLE_UPDATES
+
+`Default: 0`
+
+When set to `1`, Docksal will not perform automatic checks for available updates.
 
 ### DOCKER_NATIVE
 


### PR DESCRIPTION
This change adds a new environment variable `DOCKSAL_CHECK_FOR_UPDATES` which allows disabling automatically checking for updates. The default value is `true` but can be overridden by setting an environment variable or setting a value in `docksal.env`.

Rationale: we automatically deploy Docksal for development purposes and test new versions before releasing them across the board. If Docksal always automatically checks for new updates, users will be encouraged to run `fin update` instead of running on the fixed version we deploy. Using this new configuration value, we can disable the automatic update checks preventing the "fin update" message.