### PR TITLE
Fixed issue where date on cached db isn't checked properly

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -6845,11 +6845,11 @@ provider_pull_db ()
 	# Get the time from 24 hours ago.
 	local yesterday=$(_exec date --date='yesterday' "+%Y-%m-%d %H:%M:%S");
 
-	if [[ "${file_exists}" == "0" ]] || [[ -n "${file_time}" ]] || [[ "$force" == "force" ]]; then
-		echo -e "${acqua}Cached DB file needs updating${NC}"
-
+        # Check to see if doesn't exist or if file exists and is older or using force flag
+        if ( [[ "${file_exists}" == "0" ]] && [[ "${file_time}" == "" ]] ) || ( [[ "${file_exists}" > "0" ]] && [[ "${file_time}" != "" ]] ) || [[ "${force}" == "force" ]]; then
 		# Check to see if File Is Older than 1 hour
 		if [[ "$file_exists" > "0" ]] && [[ -z "${file_time}" ]] || [[ "$force" == "force" ]]; then
+                        echo -e "${acqua}Cached DB file needs updating${NC}"
 			echo -e "${acqua}Removing old database file${NC}"
 			_exec rm -f "${db_file}"
 		fi


### PR DESCRIPTION
Fixed logic for how DBs were used and pulled. Previously wasn't reading the cached db in the `/tmp` directory but should now fix that issue