### PR TITLE
Add ability to list containers that should use bash instead of sh.

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -322,7 +322,8 @@ IMAGE_DNS=${IMAGE_DNS:-docksal/dns:1.1}
 CLI_USER=${CLI_USER:-docker}
 
 # Shell to use for CLI commands
-FIN_SHELL=${FIN_SHELL:-sh}
+cli_containers="$CLI_CONTAINERS"
+IFS=' ' read -a bash_cli_containers <<< "$cli_containers"
 #---------------------------- Helper functions --------------------------------
 
 DOCKSAL_PATH='' #docksal path value will be cached here
@@ -687,6 +688,15 @@ empty_dir ()
 {
 	[[ "$2" == "-a" ]] && _all=" -A " || _all=""
 	[[ -z "$(ls ${_all} $1 2>/dev/null)" ]]
+}
+
+check_bash_container ()
+{
+  local match="$1"
+	read -a arr <<< "$CLI_CONTAINERS"
+  for e in ${arr[@]}; do [[ "$e" == "$match" ]] && echo 'bash' && return 0; done
+	echo 'sh'
+  return 1
 }
 
 #------------------------- Basics check functions -----------------------------
@@ -4970,8 +4980,14 @@ _bash ()
 
 	# Use sh by default
 	if [[ "$1" != "" ]]; then
-		# Pass container name to _exec
-		_exec --in="$1" sh -il
+		local use_bash=$(check_bash_container "$1")
+		if [[ $use_bash == "bash" ]]; then
+			# Pass container name to _exec using bash
+			_exec --in="$1" bash -il
+		else
+			# Pass container name to _exec using sh
+			_exec --in="$1" sh -il
+		fi
 	else
 		# Use bash when container is not specified, for it defaults to cli
 		_exec bash -il
@@ -5008,6 +5024,9 @@ _exec ()
 		container_name="cli"
 	fi
 
+
+	local use_bash=$(check_bash_container "$container_name")
+
 	container_id=$(get_project_container_id "$container_name")
 
 	# Use sh as default shell
@@ -5015,7 +5034,7 @@ _exec ()
 	local SHELL_NONINTERACTIVE="sh -lc"
 
 	# For cli and db use bash (complex SQL queries fail when fed from stdin to sh)
-	if [[ "$container_name" == "cli" ]] || [[ "$container_name" == "db" ]] || [[ "$FIN_SHELL" == "bash" ]]; then
+	if [[ "$container_name" == "cli" ]] || [[ "$container_name" == "db" ]] || [[ "$use_bash" == "bash" ]]; then
 		SHELL_INTERACTIVE="bash -ilc"
 		SHELL_NONINTERACTIVE="bash -lc"
 	fi
@@ -5055,7 +5074,7 @@ _exec ()
 		container_id="$container_name"
 	fi
 
-	if [[ "$container_name" == "cli" ]]; then
+	if [[ "$container_name" == "cli" ]] || [[ "$use_bash" == "bash" ]]; then
 		# Commands in cli should be run using the docker user, not root.
 		local container_user="-u $CLI_USER"
 	fi

--- a/bin/fin
+++ b/bin/fin
@@ -320,6 +320,9 @@ IMAGE_DNS=${IMAGE_DNS:-docksal/dns:1.1}
 
 # User to be passed to the CLI container when executing commands.
 CLI_USER=${CLI_USER:-docker}
+
+# Shell to use for CLI commands
+FIN_SHELL=${FIN_SHELL:-sh}
 #---------------------------- Helper functions --------------------------------
 
 DOCKSAL_PATH='' #docksal path value will be cached here
@@ -5012,7 +5015,7 @@ _exec ()
 	local SHELL_NONINTERACTIVE="sh -lc"
 
 	# For cli and db use bash (complex SQL queries fail when fed from stdin to sh)
-	if [[ "$container_name" == "cli" ]] || [[ "$container_name" == "db" ]]; then
+	if [[ "$container_name" == "cli" ]] || [[ "$container_name" == "db" ]] || [[ "$FIN_SHELL" == "bash" ]]; then
 		SHELL_INTERACTIVE="bash -ilc"
 		SHELL_NONINTERACTIVE="bash -lc"
 	fi


### PR DESCRIPTION
Fixes #1107 

Adds the ability for developers to choose which containers use bash and the docker user instead of limiting to `cli` for bash and -u docker and `db` for bash.

To use, add an environment variable to your docksal.env file `CLI_CONTAINERS`

This variable should create a string of container names, separated by a single space.  Within the `fin` script, this string is converted to an array and current container names are compared with the containers listed so that commands run will use the selected shell, bash or sh.

For example, with a container named `nodeapp` for a front-end of a decoupled drupal install the commands before to run NPM functions would be
`container_user="-u docker" fin exec --in=nodeapp npm -v`

or to use `fin bash nodeapp` you would have to get into the container, then run `bash` to change shells, and then `su docker` to change to the docker user to use these commands.  This also meant that to exit, you would have to type `exit` multiple times to get out of the container.

Now, with this PR, you can select which containers should be bash and docker by default with the environment variable `CLI_CONTAINERS`

For example:
`CLI_CONTAINERS="nodeapp otherservice"`

Run `fin p start` to reload the variables, and you can run `fin bash nodeapp` and be in the container as the docker user, or run `fin exec --in=nodeapp npm -v` and not get an error from sh.
