### PR TITLE
Increase custom command finding depth from 2 to 4

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -1590,7 +1590,7 @@ show_help_list_commands_in_help ()
 	local executable="-executable"
 	is_mac && executable="-perm +100"
 
-	local addons_list=$(find -L "$addons_path" -maxdepth 2 -type f ${executable} 2>/dev/null | sort -n 2>/dev/null)
+	local addons_list=$(find -L "$addons_path" -maxdepth 4 -type f ${executable} 2>/dev/null | sort -n 2>/dev/null)
 	if [[ "$addons_list" != "" ]]; then
 		local scope
 		for cmd_name in ${addons_list}


### PR DESCRIPTION
This commit limited the custom command finding depth to `2` to prevent infinite looping:
https://github.com/docksal/docksal/commit/9ea4932c8debe6df85a7a75635670f2d75820f51

A side effect of this was that our global custom commands were no longer listed, since we use a standardized format for our commands:

`{company}/{component}/{command}`

Since there is a lot of wiggle room between `2` and infinite, I suggest increasing the `maxdepth` to `4`. Note that commands still work regardless, it's just that they are not listed when running `fin`.