### PR TITLE
changes link of sample projects to the Docksal boilerplate list

### DIFF
--- a/docs/content/troubleshooting/common-issues.md
+++ b/docs/content/troubleshooting/common-issues.md
@@ -7,7 +7,7 @@ aliases:
 
 {{% notice warning %}}
 Quite often a problem may reside within the 3rd party tools, project code, local configuration, etc., and not the stack.
-To make sure that the Docksal stack works properly, try launching any of the [sample projects](/stack/config/#sample-projects).  
+To make sure that the Docksal stack works properly, try launching any of the [sample projects](https://github.com/docksal?q=boilerplate).  
 If you believe the issue is within the Docksal stack, then read on.
 {{% /notice %}}
 


### PR DESCRIPTION
close #1139

By linking to "boilerplate" github projects, all of these will be shown without having to maintain a list in the docs (which may have existed previously, but doesn't now).
