### PR TITLE
updates hugo config for docs site

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -4,7 +4,7 @@ theme = "learn"
 
 [params]
   description = "Official Docksal documentation website"
-  editURL = "https://github.com/docksal/docksal/edit/develop/docs/"
+  editURL = "https://github.com/docksal/docksal/edit/develop/docs/content/"
 
   # Custom CSS => statis/css/theme-docksal.css
   themeVariant = "docksal"

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -11,12 +11,32 @@ theme = "learn"
 
   google_tag_manager = "GTM-58ST6XD"
 
-  version = "v1.11.1"
+  version = "v1.12.3"
+
+  [[params.versions]]
+  version = "v1.12.3"
+  branch = "v1.12.3"
+  url = "https://docs.docksal.io"
+
+  [[params.versions]]
+  version = "v1.12.2"
+  branch = "v1.12.2"
+  url = "https://v1-12-2.docs.docksal.io"
+
+  [[params.versions]]
+  version = "v1.12.1"
+  branch = "v1.12.1"
+  url = "https://v1-12-1.docs.docksal.io"
   
+  [[params.versions]]
+  version = "v1.12.0"
+  branch = "v1.12.0"
+  url = "https://v1-12-0.docs.docksal.io"
+
   [[params.versions]]
   version = "v1.11.1"
   branch = "v1.11.1"
-  url = "https://docs.docksal.io"
+  url = "https://v1-11-1.docs.docksal.io"
 
   [[params.versions]]
   version = "v1.11.0"

--- a/docs/layouts/shortcodes/versions.html
+++ b/docs/layouts/shortcodes/versions.html
@@ -1,6 +1,6 @@
 {{ $versions := .Page.Param "versions" }}
 <ul>
     {{ range $versions }}
-    <li><a href="{{ .url }}">{{ .version }}</a></li>
+    <li><a href="{{ .url }}" rel="nofollow">{{ .version }}</a></li>
     {{ end }}
 </ul>


### PR DESCRIPTION
fixes #1147 

Adds Docksal release versions to Hugo config. Fixes path for edit link.