### PR TITLE
macOS 10.15 Catalina compatibility (v2)

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -3806,9 +3806,11 @@ configure_mounts ()
 			fi
 
 			# Mount the share in VirtualBox
-			if ! is_docker_native; then
-				docker_machine_mount_nfs "${DOCKSAL_NFS_PATH}:${DOCKSAL_NFS_PATH}"
-			fi
+			# TODO: Disabled. To be removed.
+			# NFS mounts are now handled using NFS volumes - same approach as with Docker Desktop
+			#if ! is_docker_native; then
+			#	docker_machine_mount_nfs "${DOCKSAL_NFS_PATH}:${DOCKSAL_NFS_PATH}"
+			#fi
 		fi
 		# Create, then mount shares in VirtualBox
 		if (is_wsl || is_windows) && ! is_docker_native; then
@@ -5990,7 +5992,18 @@ alias_list ()
 load_global_configuration ()
 {
 	export DOCROOT=${DOCROOT:-docroot}
+	export DOCKSAL_PATH="$(get_project_path)"
 	export PROJECT_ROOT="$(get_project_path)"
+	is_windows && export PROJECT_ROOT_WIN="$(get_project_path_dc)"
+
+	# On macOS 10.15 Catalina special treatment
+	# See https://github.com/docksal/docksal/issues/1130
+	# The exported NFS path needs the "/System/Volumes/Data" prefix unless project is on an external drive (/Volumes/...)
+	if is_mac_catalina && ! [[ "${PROJECT_ROOT}" =~ "/Volumes" ]]; then
+		export PROJECT_ROOT_NFS="/System/Volumes/Data${PROJECT_ROOT}"
+	else
+		export PROJECT_ROOT_NFS=${PROJECT_ROOT}
+	fi
 }
 
 load_configuration ()
@@ -6056,7 +6069,13 @@ load_configuration ()
 		fi
 
 		# Include a volumes yml if requested. Use bind mount for volumes by default.
-		DOCKSAL_VOLUMES=${DOCKSAL_VOLUMES:-bind}
+		if is_mac; then
+			# Default to NFS volumes on Mac (both VirtualBox and Docker Desktop)
+			DOCKSAL_VOLUMES=${DOCKSAL_VOLUMES:-nfs}
+		else
+			# Bind mounted volumes on all other systems
+			DOCKSAL_VOLUMES=${DOCKSAL_VOLUMES:-bind}
+		fi
 		if [[ "$DOCKSAL_VOLUMES" != "disable" ]]; then
 			volumes_yml_file="$(get_config_dir_dc)/stacks/volumes-$DOCKSAL_VOLUMES.yml"
 			if [[ -f "$volumes_yml_file" ]]; then
@@ -6104,7 +6123,6 @@ load_configuration ()
 	else
 		export VIRTUAL_HOST=${VIRTUAL_HOST:-$COMPOSE_PROJECT_VHOST_NAME_SAFE.$DOCKSAL_DNS_DOMAIN}
 	fi
-	export DOCROOT=${DOCROOT:-docroot}
 
 	# Make VIRTUAL_HOST lowercase, replace '_' with '-', remove everything non-letter or digit,
 	# make sure it starts with letter or digit
@@ -6127,12 +6145,11 @@ load_configuration ()
 		fi
 	fi
 
-	# Make project root globally available
-	export DOCKSAL_PATH="$(get_project_path)"
-	export PROJECT_ROOT="$(get_project_path)"
-	is_windows && export PROJECT_ROOT_WIN="$(get_project_path_dc)"
 	# https://docs.docker.com/compose/reference/envvars/#compose_convert_windows_paths
 	export COMPOSE_CONVERT_WINDOWS_PATHS=1
+
+	# Loaded last to allow overrides from env files
+	load_global_configuration
 }
 
 # Default init command. Initializes default config and starts containers
@@ -6197,6 +6214,8 @@ config_show ()
 		echo -e "ENV_FILE:\n$(echo ${ENV_FILE} | tr ${SEPARATOR} '\n')"
 	echo
 	echo "PROJECT_ROOT: ${PROJECT_ROOT}"
+	is_mac &&
+		echo "PROJECT_ROOT_NFS: ${PROJECT_ROOT_NFS}"
 	echo "DOCROOT: ${DOCROOT}"
 	echo "VIRTUAL_HOST: ${VIRTUAL_HOST}"
 	echo "VIRTUAL_HOST_ALIASES: *.${VIRTUAL_HOST}"
@@ -7557,13 +7576,6 @@ if is_tty; then
 		read LINES COLUMNS < <(stty size)
 	fi
 	export LINES COLUMNS
-fi
-
-# Temporary hack for macOS 10.15 Catalina
-# Only switch dirs for the internal Mac drive (/System/Volumes/Data/...), skip external drives (/Volumes/...)
-# See https://github.com/docksal/docksal/issues/1130
-if is_mac_catalina && ! [[ "${PWD}" =~ "/System/Volumes/Data" ]] && ! [[ "${PWD}" =~ "/Volumes" ]]; then
-	cd "/System/Volumes/Data${PWD}"
 fi
 
 # Inherit hosts git user.email and user.name settings

--- a/bin/fin
+++ b/bin/fin
@@ -76,6 +76,12 @@ is_mac ()
 	[[ "$OS_TYPE" == "Darwin" ]]
 }
 
+is_mac_catalina ()
+{
+	[[ "$OS_TYPE" == "Darwin" ]] &&
+		[[ "$OS_VERSION" =~ "10.15" ]]
+}
+
 # CI
 is_ci ()
 {
@@ -198,7 +204,13 @@ CONFIG_DOCKER_MACHINE_ENV="$CONFIG_DOCKER_MACHINE_DIR/machine.env"
 CONFIG_CERTS=${CONFIG_CERTS:-$CONFIG_DIR/certs}
 
 # Host path to make accessible to the VM (Mac only)
-DOCKSAL_NFS_PATH="${DOCKSAL_NFS_PATH:-/Users}"
+# macOS Catalina required special treatment
+# See https://github.com/docksal/docksal/issues/1130
+if is_mac_catalina; then
+	DOCKSAL_NFS_PATH="${DOCKSAL_NFS_PATH:-/System/Volumes/Data/Users}"
+else
+	DOCKSAL_NFS_PATH="${DOCKSAL_NFS_PATH:-/Users}"
+fi
 
 # Where custom commands live (relative path)
 DOCKSAL_COMMANDS_PATH=".docksal/commands"
@@ -472,7 +484,7 @@ upfind ()
 # Get path to .docksal folder using upfind
 get_project_path ()
 {
-	if [ -z "$DOCKSAL_PATH" ]; then
+	if [[ "$DOCKSAL_PATH" == "" ]]; then
 		DOCKSAL_PATH=$(upfind ".docksal")
 	fi
 	# If we reached $HOME, then we did not find the project root.
@@ -7545,6 +7557,13 @@ if is_tty; then
 		read LINES COLUMNS < <(stty size)
 	fi
 	export LINES COLUMNS
+fi
+
+# Temporary hack for macOS 10.15 Catalina
+# Only switch dirs for the internal Mac drive (/System/Volumes/Data/...), skip external drives (/Volumes/...)
+# See https://github.com/docksal/docksal/issues/1130
+if is_mac_catalina && ! [[ "${PWD}" =~ "/System/Volumes/Data" ]] && ! [[ "${PWD}" =~ "/Volumes" ]]; then
+	cd "/System/Volumes/Data${PWD}"
 fi
 
 # Inherit hosts git user.email and user.name settings

--- a/bin/fin
+++ b/bin/fin
@@ -7584,6 +7584,14 @@ if is_tty; then
 	export LINES COLUMNS
 fi
 
+# On macOS 10.15 Catalina, ensure we are NOT inside /System/Volumes/Data
+# See https://github.com/docksal/docksal/issues/1130
+# This eliminates the need for checks for this path prefix down the road in multiple places
+if is_mac_catalina && [[ "${PWD}" =~ "/System/Volumes/Data" ]]; then
+	# Remove the prefix from path and switch directories
+	cd $(echo ${PWD} | sed "s|/System/Volumes/Data||")
+fi
+
 # Inherit hosts git user.email and user.name settings
 # This happens before the environment variable overrides are sources, thus can be overridden via docksal.env files.
 # On macOS there is a git wrapper even when git is not installed, so we have to check for git differently on mac

--- a/bin/fin
+++ b/bin/fin
@@ -207,7 +207,13 @@ CONFIG_CERTS=${CONFIG_CERTS:-$CONFIG_DIR/certs}
 # macOS Catalina required special treatment
 # See https://github.com/docksal/docksal/issues/1130
 if is_mac_catalina; then
-	DOCKSAL_NFS_PATH="${DOCKSAL_NFS_PATH:-/System/Volumes/Data/Users}"
+	if [[ "${DOCKSAL_NFS_PATH}" != "" ]] && ! [[ "${DOCKSAL_NFS_PATH}" =~ "/System/Volumes/Data" ]] && ! [[ "${DOCKSAL_NFS_PATH}" =~ "/Volumes" ]]; then
+		# Prefix user provided path with "/System/Volumes/Data" unless the prefix is already there AND the path is NOT on an external drive (/Volumes/...)
+		DOCKSAL_NFS_PATH="/System/Volumes/Data${DOCKSAL_NFS_PATH}"
+	else
+		# Either the default value or the value provided by user
+		DOCKSAL_NFS_PATH="${DOCKSAL_NFS_PATH:-/System/Volumes/Data/Users}"
+	fi
 else
 	DOCKSAL_NFS_PATH="${DOCKSAL_NFS_PATH:-/Users}"
 fi

--- a/stacks/volumes-nfs.yml
+++ b/stacks/volumes-nfs.yml
@@ -11,7 +11,7 @@ volumes:
     driver: local
     driver_opts:
       type: nfs
-      device: :${PROJECT_ROOT}
+      device: :${PROJECT_ROOT_NFS}
       o: addr=${DOCKSAL_HOST_IP},vers=3,nolock,noacl,nocto,noatime,nodiratime,actimeo=1
   db_data:  # Database data volume (bind)
   docksal_ssh_agent:  # Shared ssh-agent volume


### PR DESCRIPTION
Workarounds for macOS 10.15 Catalina:

- Override the default for NFS path
- Added `PROJECT_ROOT_NFS` variable, which is overridden on Catalina
- Made NFS volumes the default options on Macs
- Disabled NFS mounting in boot2docker VM
- Added `PROJECT_ROOT_NFS` in the output of "fin config"

Existing projects will have to be reset due to the changes in the `project_root` volume configuration.

ToDo:

- [x] Implement fix
- [x] Confirm tests pass in Travis
- [ ] Confirm tests pass in macOS 10.14 High Sierra (manual run)
- [ ] Confirm tests pass in macOS 10.15 Catalina (manual run)

Fixes #1130. Resolves #1025