### PR TITLE
Fix/typo in stacks

### DIFF
--- a/docs/content/stack/zero-configuration.md
+++ b/docs/content/stack/zero-configuration.md
@@ -26,6 +26,6 @@ The following stacks are available:
 
 - `default` - web (Apache), db (MySQL), cli (assumed, when none specified)
 - `default-nodb` - web (Apache), cli
- - `acquia` - web (Apache), db (MySQL), cli, varnish, memcached, solr (used specifically for [Acquia](https://www.acquia.com/) hosted projects)
+- `acquia` - web (Apache), db (MySQL), cli, varnish, memcached, solr (used specifically for [Acquia](https://www.acquia.com/) hosted projects)
 - `pantheon` - web (Nginx), db (MariaDB), cli, varnish, redis, solr (used specifically for [Pantheon](https://www.pantheon.io/) hosted projects)
 - `node` - cli


### PR DESCRIPTION
Fixing a small typo in the stacks list that indents the acquia stack to make it look like a sub-stack of nodb