### PR TITLE
Make health check timeout configurable

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -271,6 +271,9 @@ else
 	DOCKSAL_SSH_AGENT_USE_HOST="${DOCKSAL_SSH_AGENT_USE_HOST:-0}"
 fi
 
+# Healthcheck timeout
+DOCKSAL_HEALTHCHECK_TIMEOUT=${DOCKSAL_HEALTHCHECK_TIMEOUT:60}
+
 #---------------------------- URL references --------------------------------
 GITHUB_API="https://api.github.com"
 URL_REPO="https://raw.githubusercontent.com/docksal/docksal"
@@ -1426,11 +1429,10 @@ _vhost_proxy_connect ()
 # Waits for containers to become healthy
 # For reasoning why we are not using  `depends_on` `condition` see here:
 # https://github.com/docksal/docksal/issues/225#issuecomment-306604063
-# TODO: make this universal. Currently hardcoded for cli only.
 _healthcheck_wait ()
 {
 	local delay=5
-	local timeout=60
+	local timeout=$DOCKSAL_HEALTHCHECK_TIMEOUT
 	local elapsed=0
 	local status=""
 	local FILTER="label=com.docker.compose.project=$COMPOSE_PROJECT_NAME"

--- a/bin/fin
+++ b/bin/fin
@@ -272,7 +272,7 @@ else
 fi
 
 # Healthcheck timeout
-DOCKSAL_HEALTHCHECK_TIMEOUT=${DOCKSAL_HEALTHCHECK_TIMEOUT:60}
+DOCKSAL_HEALTHCHECK_TIMEOUT=${DOCKSAL_HEALTHCHECK_TIMEOUT:-60}
 
 #---------------------------- URL references --------------------------------
 GITHUB_API="https://api.github.com"

--- a/docs/content/stack/configuration-variables.md
+++ b/docs/content/stack/configuration-variables.md
@@ -132,7 +132,7 @@ Allow disabling the DNS resolver configuration (in case there are issues with it
 
 `Default: 60`
 
-How many seconds to give project containers before `fin project start` stops waiting for them to reach healthy state. (Should divide by 5)
+How many seconds to give project containers to reach `healthy` state before `fin` considers the stack startup as failed. (Should be a multiple of 5)
 
 ### MYSQL_ROOT_PASSWORD
 

--- a/docs/content/stack/configuration-variables.md
+++ b/docs/content/stack/configuration-variables.md
@@ -128,6 +128,12 @@ This is the domain to use which is tacked on to the end of the projects url.
 
 Allow disabling the DNS resolver configuration (in case there are issues with it). Set to `true` to activate.
 
+### DOCKSAL_HEALTHCHECK_TIMEOUT
+
+`Default: 60`
+
+How many seconds to give project containers before `fin project start` stops waiting for them to reach healthy state. (Should divide by 5)
+
 ### MYSQL_ROOT_PASSWORD
 
 `Default: root`


### PR DESCRIPTION
In certain cases project containers would not start within 60 seconds. Despite usually you better investigate what exactly takes so long, sometimes it takes time for good reasons, that cannot or should not be worked around. 
This allows increasing the timeout.

Closes #1157