### PR TITLE
Make the is_tty function language independent

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -815,7 +815,7 @@ is_docksal_running ()
 # All other direct checks don't work well in and every environment and scripts.
 is_tty ()
 {
-	[[ "$(/usr/bin/tty || true)" != "not a tty" ]]
+	/usr/bin/env tty -s
 
 	# TODO: rewrite this check using [ -t ] test
 	# http://stackoverflow.com/questions/911168/how-to-detect-if-my-shell-script-is-running-through-a-pipe/911213#911213


### PR DESCRIPTION
As the check is currently, it only works in systems where the call to `/usr/bin/tty` returns an english text. This is not the case for some linux distributions like Ubuntu Bionic in brazilian portuguese which returns `não é um tty` instead of the expected `not a tty` message.

Getting the status from the call by using the `-s` flag should make the function more portable.
*Edit:* (And fix a bunch of "not a tty" errors on some developer machines i've tested custom docksal commands with background processes)

*Yet another edit:* This change was tested at Ubuntu Xenial and Bionic both in english and portuguese. I was hoping to see a result from Travis CI but... ¯\\_(ツ)\_/¯