### PR TITLE
Use NFS volumes on Mac by default

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -5288,6 +5288,16 @@ run_cli ()
 		docker volume rm -f ${HOME_VOLUME_NAME} >/dev/null 2>&1
 	fi
 
+	local MOUNT_PWD
+	if [[ "${DOCKSAL_VOLUMES}" == "nfs" ]]; then
+		# Mounts options here should match those in volumes-nfs.yml
+		# Also, see https://docs.docker.com/storage/volumes/#choose-the--v-or---mount-flag
+		# and "Escape values from outer CSV parser" section on that page
+		MOUNT_PWD="type=volume,dst=/var/www,volume-driver=local,volume-opt=type=nfs,volume-opt=device=:$(pwd),\"volume-opt=o=addr=${DOCKSAL_HOST_IP},vers=3,nolock,noacl,nocto,noatime,nodiratime,actimeo=1\""
+	else
+		MOUNT_PWD="type=bind,src=$(pwd),dst=/var/www"
+	fi
+
 	local MOUNT_HOME
 	if [[ "$RUN_CLEAN" != "1" ]]; then
 		docker volume create ${HOME_VOLUME_NAME} >/dev/null 2>&1
@@ -5308,7 +5318,7 @@ run_cli ()
 		# (exit \$?) is a hack to return correct exit codes when docker exec is run with tty (-t).
 		# COLUMNS and LINES have to be passed to workaround a bug in Docker. See https://github.com/moby/moby/issues/35407#issuecomment-355753176
 		${winpty} docker run --rm -it \
-			--mount type=bind,src=$(pwd),dst=/var/www \
+			--mount ${MOUNT_PWD} \
 			--mount ${MOUNT_HOME} \
 			--mount type=volume,src=docksal_ssh_agent,dst=/.ssh-agent,readonly \
 			-e BLACKFIRE_CLIENT_ID \
@@ -5329,7 +5339,7 @@ run_cli ()
 	else
 		# non-interactive
 		docker run --rm \
-			--mount type=bind,src=$(pwd),dst=/var/www \
+			--mount ${MOUNT_PWD} \
 			--mount ${MOUNT_HOME} \
 			--mount type=volume,src=docksal_ssh_agent,dst=/.ssh-agent,readonly \
 			-e BLACKFIRE_CLIENT_ID \

--- a/bin/fin
+++ b/bin/fin
@@ -3811,11 +3811,11 @@ configure_mounts ()
 			fi
 
 			# Mount the share in VirtualBox
-			# TODO: Disabled. To be removed.
-			# NFS mounts are now handled using NFS volumes - same approach as with Docker Desktop
-			#if ! is_docker_native; then
-			#	docker_machine_mount_nfs "${DOCKSAL_NFS_PATH}:${DOCKSAL_NFS_PATH}"
-			#fi
+			# TODO: Drop this default NFS mount? (v2.0)
+			# NFS mounts are now handled using NFS volumes at the project level - same approach as with Docker Desktop.
+			if ! is_docker_native; then
+				docker_machine_mount_nfs "${DOCKSAL_NFS_PATH}:${DOCKSAL_NFS_PATH}"
+			fi
 		fi
 		# Create, then mount shares in VirtualBox
 		if (is_wsl || is_windows) && ! is_docker_native; then

--- a/bin/fin
+++ b/bin/fin
@@ -3811,9 +3811,11 @@ configure_mounts ()
 			fi
 
 			# Mount the share in VirtualBox
-			if ! is_docker_native; then
-				docker_machine_mount_nfs "${DOCKSAL_NFS_PATH}:${DOCKSAL_NFS_PATH}"
-			fi
+			# TODO: Disabled. To be removed.
+			# NFS mounts are now handled using NFS volumes - same approach as with Docker Desktop
+			#if ! is_docker_native; then
+			#	docker_machine_mount_nfs "${DOCKSAL_NFS_PATH}:${DOCKSAL_NFS_PATH}"
+			#fi
 		fi
 		# Create, then mount shares in VirtualBox
 		if (is_wsl || is_windows) && ! is_docker_native; then
@@ -6062,7 +6064,13 @@ load_configuration ()
 		fi
 
 		# Include a volumes yml if requested. Use bind mount for volumes by default.
-		DOCKSAL_VOLUMES=${DOCKSAL_VOLUMES:-bind}
+		if is_mac; then
+			# Default to NFS volumes on Mac (both VirtualBox and Docker Desktop)
+			DOCKSAL_VOLUMES=${DOCKSAL_VOLUMES:-nfs}
+		else
+			# Bind mounted volumes on all other systems
+			DOCKSAL_VOLUMES=${DOCKSAL_VOLUMES:-bind}
+		fi
 		if [[ "$DOCKSAL_VOLUMES" != "disable" ]]; then
 			volumes_yml_file="$(get_config_dir_dc)/stacks/volumes-$DOCKSAL_VOLUMES.yml"
 			if [[ -f "$volumes_yml_file" ]]; then

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -37,7 +37,6 @@ teardown() {
 
 	run fin config env
 	[[ $status == 0 ]]
-	[[ $output =~ "volumes-bind.yml" ]]
 	[[ $output =~ "stack-default.yml" ]]
 	# fin will automatically create docksal.yml and docksal.env if they do not exist
 	[[ $output =~ "docksal.yml" ]]
@@ -53,7 +52,6 @@ teardown() {
 
 	run fin config env
 	[[ $status == 0 ]]
-	[[ $output =~ "volumes-bind.yml" ]]
 	[[ $output =~ "stack-acquia.yml" ]]
 	# fin will automatically create docksal.yml and docksal.env if they do not exist
 	[[ $output =~ "docksal.yml" ]]
@@ -77,7 +75,6 @@ services:
 
 	run fin config
 	[[ $status == 0 ]]
-	[[ $output =~ "volumes-bind.yml" ]]
 	[[ $output =~ "stack-acquia.yml" ]]
 	# fin will automatically create docksal.yml and docksal.env if they do not exist
 	[[ $output =~ "docksal.yml" ]]
@@ -107,7 +104,6 @@ services:
 
 	run fin config
 	[[ $status == 0 ]]
-	[[ $output =~ "volumes-bind.yml" ]]
 	[[ ! $output =~ "stack-default.yml" ]]
 	# fin will automatically create docksal.yml and docksal.env if they do not exist
 	[[ $output =~ "docksal.yml" ]]
@@ -185,7 +181,6 @@ services:
 
 	run fin config
 	[[ $status == 0 ]]
-	[[ $output =~ "volumes-bind.yml" ]]
 	[[ $output =~ "stack-default.yml" ]]
 	# fin will automatically create docksal.yml and docksal.env if they do not exist
 	[[ $output =~ "docksal.yml" ]]
@@ -200,7 +195,6 @@ services:
 
 	run fin config
 	[[ $status == 0 ]]
-	[[ $output =~ "volumes-bind.yml" ]]
 	[[ $output =~ "stack-default.yml" ]]
 	# fin will automatically create docksal.yml and docksal.env if they do not exist
 	[[ $output =~ "docksal.yml" ]]


### PR DESCRIPTION
- Setting `DOCKSAL_VOLUMES=nfs` on Mac (applies to Docker Desktop and VBox)
- Disabled the default NFS mount triggered at VM start for VBox
- Added switching between nfs volume and bind mount in `run_cli`

Closes #1025 

- [x] Tests pass on Docker Desktop
- [x] Tests pass on VirtualBox