### PR TITLE
Use unique home volumes for run-cli images

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -5266,7 +5266,11 @@ run_cli ()
 
 	# Set default image
 	local RUN_IMAGE="${image:-$IMAGE_RUN_CLI}"
-	local HOME_VOLUME_NAME="docksal_run_cli_home"
+
+	# Use unique home volumes for run-cli images
+	# Without this, switching images won't update tools installed in the home volume (like nodejs, etc.).
+	local HOME_VOLUME_NAME="docksal_run_cli_home_$(echo ${RUN_IMAGE} | sed -e 's/[^A-Za-z0-9_.]/-/g')"
+
 	# Escape spaces that are "spaces" and not parameter delimiters (i.e., param1 param2\ with\ spaces param3)
 	if [[ $2 != "" ]]; then
 		cmd="$cmd "$(printf " %q" "$@")

--- a/bin/fin
+++ b/bin/fin
@@ -5304,7 +5304,9 @@ run_cli ()
 
 	local MOUNT_HOME
 	if [[ "$RUN_CLEAN" != "1" ]]; then
-		docker volume create ${HOME_VOLUME_NAME} >/dev/null 2>&1
+		# Using "io.docksal" label on the volume ensures the cleanup of run-cli volumes.
+		# Volumes with the "io.docksal" label are dropped by "fin cleanup" (which also runs during updates).
+		docker volume create --label "io.docksal" ${HOME_VOLUME_NAME} >/dev/null 2>&1
 		# By default mount as a *persistent* named volume
 		MOUNT_HOME="dst=/home/docker,src=$HOME_VOLUME_NAME"
 	else


### PR DESCRIPTION
- Use unique home volumes for run-cli images
- Ensure run-cli volumes are cleaned up
  - Added `io.docksal` label to run-cli volume. `fin cleanup` already drops volumes with the `io.docksal` label set.

Fixes #1225