### PR TITLE
NFS update safeguard for Mac users

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -278,6 +278,7 @@ DOCKSAL_HEALTHCHECK_TIMEOUT=${DOCKSAL_HEALTHCHECK_TIMEOUT:-60}
 GITHUB_API="https://api.github.com"
 URL_REPO="https://raw.githubusercontent.com/docksal/docksal"
 URL_REPO_UI="https://github.com/docksal/docksal"
+URL_RELEASE_NOTES="https://docksal.io/updates"
 URL_REPO_DRUPAL7="https://github.com/docksal/boilerplate-drupal7.git"
 URL_REPO_DRUPAL8="https://github.com/docksal/boilerplate-drupal8.git"
 URL_REPO_DRUPAL8COMPOSER="https://github.com/docksal/boilerplate-drupal8-composer.git"
@@ -4864,6 +4865,14 @@ is_update ()
 # Update Docksal
 update ()
 {
+	if is_mac; then
+		echo-warning "Please take a few minutes to review the release notes:" \
+			"${URL_RELEASE_NOTES}"
+		open "${URL_RELEASE_NOTES}"
+	fi
+	exit
+
+
 	# Suppress alerts until the very end of the update
 	export DOCKER_VERSION_ALERT_SUPPRESS=1
 
@@ -4943,6 +4952,14 @@ update ()
 	echo-green "Update finished"
 
 	# [STEP - POST UPDATE]
+	# Show release notes URL after update
+	if is_update; then
+		echo-warning "Please take a moment to read about what's new in this release:" "${URL_RELEASE_NOTES}"
+		# Open release notes in the browser
+		# TODO: add support for Linux and Windows/WSL
+		is_mac && open "${URL_RELEASE_NOTES}"
+	fi
+
 	# Cleanup
 	rm -f "$CONFIG_DOWNLOADS_DIR/*" &>/dev/null
 

--- a/bin/fin
+++ b/bin/fin
@@ -4946,6 +4946,16 @@ update ()
 	# Cleanup
 	rm -f "$CONFIG_DOWNLOADS_DIR/*" &>/dev/null
 
+	# Set DOCKSAL_VOLUMES globally for existing and new users on Macs (VirtualBox and Docker Desktop)
+	# Existing users get "bind" to match the previous default behavior.
+	# This ensures we do not break existing project stacks by switching to nfs volumes as the default (1.13.0 release)
+	# New users get "nfs" - the new default
+	if is_update && is_mac && [[ $(config_get --global DOCKSAL_VOLUMES) == "" ]]; then
+		config_set --global DOCKSAL_VOLUMES=bind
+	else
+		config_set --global DOCKSAL_VOLUMES=nfs
+	fi
+
 	# Rerun docker access/version checks here to inform the users of any issues
 	echo-green "Running post update checks..."
 	# Disabling alert suppression here, since it was likely enabled during earlier calls to check_docker_running

--- a/bin/fin
+++ b/bin/fin
@@ -4865,14 +4865,6 @@ is_update ()
 # Update Docksal
 update ()
 {
-	if is_mac; then
-		echo-warning "Please take a few minutes to review the release notes:" \
-			"${URL_RELEASE_NOTES}"
-		open "${URL_RELEASE_NOTES}"
-	fi
-	exit
-
-
 	# Suppress alerts until the very end of the update
 	export DOCKER_VERSION_ALERT_SUPPRESS=1
 
@@ -4963,14 +4955,14 @@ update ()
 	# Cleanup
 	rm -f "$CONFIG_DOWNLOADS_DIR/*" &>/dev/null
 
-	# Set DOCKSAL_VOLUMES globally for existing and new users on Macs (VirtualBox and Docker Desktop)
-	# Existing users get "bind" to match the previous default behavior.
-	# This ensures we do not break existing project stacks by switching to nfs volumes as the default (1.13.0 release)
-	# New users get "nfs" - the new default
+	# Set DOCKSAL_VOLUMES=bind globally for existing Macs (VirtualBox and Docker Desktop)
+	# This ensures we do not break existing project stacks by switching to nfs volumes as the default (Docksal 1.13.0 / fin 1.92.x)
 	if is_update && is_mac && [[ $(config_get --global DOCKSAL_VOLUMES) == "" ]]; then
-		config_set --global DOCKSAL_VOLUMES=bind
-	else
-		config_set --global DOCKSAL_VOLUMES=nfs
+		# Until the update process is completed, the old fin binary is still in place, so we can access it
+		# "fin -v" returns the version of the old fin here
+		if [[ $(ver_to_int "$(fin -v)") < $(ver_to_int "1.92.0") ]]; then
+			config_set --global DOCKSAL_VOLUMES=bind
+		fi
 	fi
 
 	# Rerun docker access/version checks here to inform the users of any issues


### PR DESCRIPTION
- Set `DOCKSAL_VOLUMES=bind` for existing Mac users (VirtualBox and Docker Desktop)
  - This ensures we do not break existing project stacks by switching to nfs volumes as the default
- Show release notes URL after update
  - Open release notes URL on Mac after update

TODOs:
- [x] Manual testing on Mac