### PR TITLE
Updated is_tty check

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -811,15 +811,10 @@ is_docksal_running ()
 
 # Check whether we have a working tty.
 # We assume the environment is interactive if there is a tty.
-# All other direct checks don't work well in and every environment and scripts.
+# See http://stackoverflow.com/questions/911168/how-to-detect-if-my-shell-script-is-running-through-a-pipe/911213#911213
 is_tty ()
 {
-	/usr/bin/env tty -s
-
-	# TODO: rewrite this check using [ -t ] test
-	# http://stackoverflow.com/questions/911168/how-to-detect-if-my-shell-script-is-running-through-a-pipe/911213#911213
-	# 0: stdin, 1: stdout, 2: stderr
-	# [ -t 0 -a -t 1 ]
+	[[ -t 0 ]]
 }
 
 # Checks whether fin is run under root privileges


### PR DESCRIPTION
Fixes the issue with the `is_tty()` on Alpine (one of the issues in https://github.com/docksal/docksal/issues/1233):

```
$ tty -s
tty: ignoring all arguments
/dev/pts/1
```

From `man tty` on macOS:

```
     -s      Do not write the terminal name; only the exit status is affected when this option is specified.  The -s option is deprecated
             in favor of the ``test -t 0'' command.
```

Tested on Mac Catalina 10.15.1, Ubuntu 18.04.1 LTS, WSL 17134 and PWD Alpine 3.10.3:

```
$ [[ -t 0 ]] && echo tty || echo 'not a tty'
tty
$ echo '[[ -t 0 ]] && echo tty || echo 'not a tty'' | bash
not a tty
```
