### PR TITLE
Use docker instead of docker-compose for get_project_container_id()

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -583,8 +583,14 @@ get_mysql_connect ()
 # @return docker container id
 get_project_container_id ()
 {
+	local service=$1
+	local project=$COMPOSE_PROJECT_NAME
+
 	# Trim \r from output (necessary on Windows)
-	echo $(docker-compose ps -q $1 2>/dev/null | tr -d '\r')
+	echo $(docker ps -q --no-trunc \
+		--filter="label=com.docker.compose.project=${project}" \
+		--filter="label=com.docker.compose.service=${service}" \
+		--filter="status=running" 2>/dev/null | tr -d '\r')
 }
 
 # Run command on Windows with elevated privileges

--- a/bin/fin
+++ b/bin/fin
@@ -583,8 +583,8 @@ get_mysql_connect ()
 # @return docker container id
 get_project_container_id ()
 {
+	local project=$COMPOSE_PROJECT_NAME_SAFE
 	local service=$1
-	local project=$COMPOSE_PROJECT_NAME
 
 	# Trim \r from output (necessary on Windows)
 	echo $(docker ps -q --no-trunc \


### PR DESCRIPTION
Running docker-compose incurs a pretty big start-up penalty which is especially
visible when running many `fin exec` statements sequentially, which might
happen when you e.g. write local development environment setup scripts for your
project.

Performance comparison:

  docker-compose: 3.24s
  docker:         1.41s

Command: `for i in {1..10}; do time fin exec echo test; done`
Averaged over 10 runs after removing the smallest and largest results.

Run on MacOS Catalina 10.15.2, Docker Desktop 2.1.0.5, Docker 19.03.5, Docker
Compose 1.24.1.

An obvious downside to this is that we're bypassing `docker-compose` and directly talking to `docker` to get the right container. However, we also do this for executing the command (running`docker exec` instead of `docker-compose exec`) so I figured this might be worth the trouble.
