### PR TITLE
Fix SSH_AUTH_SOCK being unset for custom commands

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -429,6 +429,13 @@ docker-compose ()
 		COMPOSE_FILE="${docksal_yml_file}${SEPARATOR}${COMPOSE_FILE}"
 	fi
 
+	# By default, we use the built-in SSH agent unless DOCKSAL_SSH_AGENT_USE_HOST=1
+	# On Linux, we can directly mount the SSH auth socket into the container.
+	# On Mac/Win, we proxy the Unix socket through TCP on Docksal's host IP.
+	if ! is_linux || [[ "$DOCKSAL_SSH_AGENT_USE_HOST" != "1" ]]; then
+		unset SSH_AUTH_SOCK
+	fi
+
 	# Call regular docker-compose.
 	# We can use `which` here, since it does not care about functions (but `type` does).
 	$(which docker-compose) "$@"
@@ -4145,13 +4152,13 @@ start_sshproxy_daemon ()
 			echo 'Run `apt-get install socat` to add this application.'
 		fi
 		exit 2
-	elif [[ -z "$DOCKSAL_SSH_AUTH_SOCK" ]]; then
+	elif [[ -z "$SSH_AUTH_SOCK" ]]; then
 		echo-error 'Environment variable SSH_AUTH_SOCK is not set.' \
 			'Is your local SSH agent running correctly?'
 		exit 3
 	fi
 
-	socat TCP-LISTEN:$DOCKSAL_SSH_PROXY_PORT,bind=$DOCKSAL_HOST_IP,reuseaddr,fork UNIX-CLIENT:$DOCKSAL_SSH_AUTH_SOCK &
+	socat TCP-LISTEN:$DOCKSAL_SSH_PROXY_PORT,bind=$DOCKSAL_HOST_IP,reuseaddr,fork UNIX-CLIENT:$SSH_AUTH_SOCK &
 	local pid=$!
 	if_failed_error "Failed starting the SSH proxy service."
 	echo "$pid" > "$CONFIG_SSHPROXY_PID"
@@ -7702,16 +7709,6 @@ if is_docker_running; then
 	export DOCKER_RUNNING="true"
 else
 	export DOCKER_RUNNING="false"
-fi
-
-# By default, we use the built-in SSH agent unless DOCKSAL_SSH_AGENT_USE_HOST=1
-# On Linux, we can directly mount the SSH auth socket into the container.
-# On Mac/Win, we proxy the Unix socket through TCP on Docksal's host IP.
-if [[ -n "$SSH_AUTH_SOCK" ]]; then
-	DOCKSAL_SSH_AUTH_SOCK="$SSH_AUTH_SOCK"
-fi
-if ! is_linux || [[ "$DOCKSAL_SSH_AGENT_USE_HOST" != "1" ]]; then
-	unset SSH_AUTH_SOCK
 fi
 
 # Default MySQL settings


### PR DESCRIPTION
When running Docksal with `DOCKSAL_SSH_AGENT_USE_HOST=1`, a side effect is that
the `SSH_AUTH_SOCK` env var is unset to prevent the default stack configuration
from picking this var up to mount a Unix socket inside the SSH agent container.

However, this happened too early and could break custom commands. For example:

  1. Run `fin custom1` with `DOCKSAL_SSH_AGENT_USE_HOST=1`
  2. Env var `SSH_AUTH_SOCK` is unset
  3. Custom command `custom1` executes `fin up` which in turn wants to start
     Docksal's system services
  4. Starting the SSH agent fails since `SSH_AUTH_SOCK` is unset (see 2)

To fix most occurrences of this issue, move unsetting the `SSH_AUTH_SOCK` var
to just before the `docker-compose` invocation.
