### PR TITLE
Add proxy variables to run cli

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -5345,6 +5345,9 @@ run_cli ()
 			-e GIT_USER_NAME \
 			-e HOST_UID \
 			-e HOST_GID \
+			-e NO_PROXY \
+			-e HTTP_PROXY \
+			-e HTTPS_PROXY \
 			-e COLUMNS \
 			-e LINES \
 			-e DEBUG \
@@ -5366,6 +5369,9 @@ run_cli ()
 			-e GIT_USER_NAME \
 			-e HOST_UID \
 			-e HOST_GID \
+			-e NO_PROXY \
+			-e HTTP_PROXY \
+			-e HTTPS_PROXY \
 			-e COLUMNS \
 			-e LINES \
 			-e DEBUG \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docksal/docksal/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Write a short summary that describes the changes in this pull request:
-->

Add http proxy variables to run_cli
fixes #1251
