### PR TITLE
Provide database argument when running `fin db cli`

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -5407,7 +5407,7 @@ _mysql ()
 			docker exec "$container_id" mysql -u${__dump_user} -p${__dump_password} ${__database} -e "${ARGV[*]}"
 		fi
 	else
-		${winpty} docker exec -it "$container_id" mysql -u${__dump_user} -p${__dump_password}
+		${winpty} docker exec -it "$container_id" mysql -u${__dump_user} -p${__dump_password} ${__database}
 	fi
 }
 


### PR DESCRIPTION
When running `fin db cli`, the default MySQL database is not selected. This only happens when extra arguments are provided.

This PR changes this behavior by always starting `mysql` with the database argument set to whatever `$db` or `$MYSQL_DATABASE` contains.

Note that this is MySQL/MariaDB-specific, but currently `fin db` only deals with those types of databases.