### PR TITLE
Update for Elasticsearch 7 compatibility

### DIFF
--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -245,7 +245,7 @@ services:
   # Elastic Search
   elasticsearch:
     hostname: elasticsearch
-    image: elasticsearch:6.5.3
+    image: ${ELASTICSEARCH_IMAGE:-elasticsearch:6.5.3}
     ports:
       - "${ELASTICSEARCH_PORT_MAPPING:-9200}"
     dns:
@@ -253,6 +253,7 @@ services:
       - ${DOCKSAL_DNS2}
     environment:
       - bootstrap.memory_lock=true
+      - discovery.type=single-node
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ulimits:
       memlock:


### PR DESCRIPTION
I needed to use Elasticsearch 7 for one of my projects and could not get it to start by default 
Found that I needed to use the following in my override Yaml file:
```yaml
elasticsearch:
    extends:
      file: ${HOME}/.docksal/stacks/services.yml
      service: elasticsearch
    image: elasticsearch:7.1.1
    environment:
      - bootstrap.memory_lock=true
      - discovery.type=single-node
      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
```
Whereas it should be easier to use 
```bash
ELASTICSEARCH_IMAGE=elasticsearch:7.1.1
```
in my env file

Single node addon was also needed in order to allow the node to start 
