### PR TITLE
Fix environment variables for `fin exec` running scripts

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -8034,7 +8034,8 @@ case "$1" in
 			else
 				script_to_run="$1"
 			fi
-			_exec "PROJECT_ROOT=/var/www DOCROOT=$DOCROOT VIRTUAL_HOST=$VIRTUAL_HOST /bin/bash -c $script_to_run" "$@"
+			shift
+			_exec "$script_to_run" "$@"
 		else
 			_exec "$@"
 		fi


### PR DESCRIPTION
I discovered some issues with `fin exec` when executing scripts. There is a different flow when the first argument to `fin exec` is an existing file which has two issues:

1. The `$1` argument is duplicated to `$script_to_run` but no `shift` is executed, resulting in the `$1` argument being duplicated as part of `$@`
2. There are environment variables passed to `_exec` which result in garbled variables since the entire string is pulled through `printf`. I see no reason to define these variables again since they are also configured as environment variables in the Docker container itself. 

In the end, this makes things a bit simpler and fixes the usage of the `$PROJECT_ROOT` variable when executing scripts with `fin exec`.