### PR TITLE
Updates VM cert error docs, ngrok config example.

### DIFF
--- a/docs/content/tools/ngrok.md
+++ b/docs/content/tools/ngrok.md
@@ -86,3 +86,40 @@ Note: It is also possible to add/override these values via `.docksal/etc/ngrok/n
 {{% notice note %}}
 If you use the config file, all command line flags will be disregarded.
 {{% /notice %}}
+
+### Tunneling to multiple project sites
+
+1. Add the following to `.docksal/etc/ngrok/ngrok-local.yml` to setup tunnels to multiple sites running in the same project:
+
+	```yaml
+	authtoken: scrubbed
+	tunnels:
+	  site1:
+	    addr: project_web_1.project_default:80
+	    proto: http
+	    host_header: site1.projecthost.docksal
+	    hostname: site1.ngrok.customdomain.com
+	  site2:
+	    addr: project_web_1.project_default:80
+	    proto: http
+	    host_header: site2.projecthost.docksal
+	    hostname: site2.ngrok.customdomain.com
+	  site3:
+	    addr: project_web_1.project_default:80
+	    proto: http
+	    host_header: site3.projecthost.docksal
+	    hostname: site3.ngrok.customdomain.com
+	  site4:
+	    addr: project_web_1.project_default:80
+	    proto: http
+	    host_header: site4.projecthost.docksal
+	    hostname: site4.ngrok.customdomain.com
+	```
+
+2. Run `fin share` to start ngrok and open the tunnels. It will automatically use the configuration file above.
+
+In the above example a wildcard domain is used. In this example that is `*.ngrok.customdomain.com`. Add this as a CNAME DNS entry pointed to the designated ngrok endpoint assigned to it in your dashboard. Additional documentation about adding a wildcard domain to your account can be found at https://ngrok.com/docs#wildcard.
+
+{{% notice info %}}
+The above example leverages a Business account plan with ngrok, which allows for wildcard domains, multiple open tunnels and custom hostname/subdomains. See plans and pricing at https://ngrok.com/pricing.
+{{% /notice %}}

--- a/docs/content/tools/ngrok.md
+++ b/docs/content/tools/ngrok.md
@@ -91,34 +91,34 @@ If you use the config file, all command line flags will be disregarded.
 
 1. Add the following to `.docksal/etc/ngrok/ngrok-local.yml` to setup tunnels to multiple sites running in the same project:
 
-	```yaml
-	authtoken: scrubbed
-	tunnels:
-	  site1:
-	    addr: project_web_1.project_default:80
-	    proto: http
-	    host_header: site1.projecthost.docksal
-	    hostname: site1.ngrok.customdomain.com
-	  site2:
-	    addr: project_web_1.project_default:80
-	    proto: http
-	    host_header: site2.projecthost.docksal
-	    hostname: site2.ngrok.customdomain.com
-	  site3:
-	    addr: project_web_1.project_default:80
-	    proto: http
-	    host_header: site3.projecthost.docksal
-	    hostname: site3.ngrok.customdomain.com
-	  site4:
-	    addr: project_web_1.project_default:80
-	    proto: http
-	    host_header: site4.projecthost.docksal
-	    hostname: site4.ngrok.customdomain.com
-	```
+    ```yaml
+    authtoken: scrubbed
+    tunnels:
+      site1:
+        addr: project_web_1.project_default:80
+        proto: http
+        host_header: site1.projecthost.docksal
+        hostname: site1.ngrok.customdomain.com
+      site2:
+        addr: project_web_1.project_default:80
+        proto: http
+        host_header: site2.projecthost.docksal
+        hostname: site2.ngrok.customdomain.com
+      site3:
+        addr: project_web_1.project_default:80
+        proto: http
+        host_header: site3.projecthost.docksal
+        hostname: site3.ngrok.customdomain.com
+      site4:
+        addr: project_web_1.project_default:80
+        proto: http
+        host_header: site4.projecthost.docksal
+        hostname: site4.ngrok.customdomain.com
+    ```
 
 2. Run `fin share` to start ngrok and open the tunnels. It will automatically use the configuration file above.
 
-In the above example a wildcard domain is used. In this example that is `*.ngrok.customdomain.com`. Add this as a CNAME DNS entry pointed to the designated ngrok endpoint assigned to it in your dashboard. Additional documentation about adding a wildcard domain to your account can be found at https://ngrok.com/docs#wildcard.
+In the above example a wildcard domain is used. In this example that is `*.ngrok.customdomain.com`. Add this as a CNAME DNS entry pointed to the designated ngrok host assigned to it in your dashboard. Additional documentation about adding a wildcard domain to your account can be found at https://ngrok.com/docs#wildcard.
 
 {{% notice info %}}
 The above example leverages a Business account plan with ngrok, which allows for wildcard domains, multiple open tunnels and custom hostname/subdomains. See plans and pricing at https://ngrok.com/pricing.

--- a/docs/content/troubleshooting/common-issues.md
+++ b/docs/content/troubleshooting/common-issues.md
@@ -55,31 +55,62 @@ Sometimes Virtual Box fails to initialize its network interfaces properly.
 
 ## Issue 2. Error checking TLS Connection (VM is not accessible) {#issue-02}
 
+### 2a. Certificate validation, getsockopt connection refused:
+
 ```
 Error checking TLS connection: Error checking and/or regenerating the certs: There was an error validating certificates for host "192.168.64.100:2376": dial tcp 192.168.64.100:2376: getsockopt: connection refused
 You can attempt to regenerate them using 'docker-machine regenerate-certs [name]'.
 Be advised that this will trigger a Docker daemon restart which will stop running containers.
 ```
 
-Sometimes docker-machine certificates re-generation fails.
+#### How to Resolve
 
-### How to Resolve
+Sometimes docker-machine certificates re-generation fails. Perform the following steps to resolve:
 
 1. Perform `fin vm restart`
 2. If above did not help, then reboot your local host
 3. If above did not help, perform commands below and then reboot your host:
 
-```bash
-fin docker-machine regenerate-certs docksal -f
-fin vm restart
-```
+	```bash
+	fin docker-machine regenerate-certs docksal -f
+	fin vm restart
+	```
 
 4. In the rare cases when above did not help the only solution is to delete the existing VM and re-create it.
 
-```bash
-fin vm remove
-fin vm start
+	```bash
+	fin vm remove
+	fin vm start
+	```
+
+
+### 2b. Certificate validation, x509 certificate has expired 
+
 ```
+Error checking TLS connection: Error checking and/or regenerating the certs: There was an error validating certificates for host "192.168.64.100:2376": x509: certificate has expired or is not yet valid
+You can attempt to regenerate them using 'docker-machine regenerate-certs [name]'.
+Be advised that this will trigger a Docker daemon restart which might stop running containers.
+
+ ERROR:  Failed to properly access virtual machine
+        In case you see certificates problem, try rebooting your local host.
+        Common issues: https://docs.docksal.io/troubleshooting/common-issues/
+```
+
+#### How to Resolve
+
+For reference: https://docs.docker.com/machine/reference/regenerate-certs/
+
+If you see the above error where it mentions x509: certificate has expired or is not yet valid, then you need to regenerate your certificates with the added `--client-certs` argument to the regenerate command. Perform the following steps:
+
+1. Run the following command:
+
+	```bash
+	fin docker-machine regenerate-certs -f --client-certs docksal
+	fin vm restart
+	```
+
+2. Verify the docksal machine starts and that you can start your projects.
+
 
 
 ## Issue 3. Out-of-memory Issues {#issue-03}


### PR DESCRIPTION
Adds additional clarity around what to do when a cert has expired. Provides ngrok config file example with multiple tunnels.
