### PR TITLE
Fix issue "error while removing network: network id has active endpoints"

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -1203,15 +1203,11 @@ _confirm ()
 _disconnect_network ()
 {
 	local network=$1
-	# get containers list, attached to the network
-	local containers=$(docker ps -aq --no-trunc -f "network=${network}")
-
-	# disconnect containers from network
-	for container in ${containers}
-	do
-		docker network disconnect -f "${network}" "${container}" &>/dev/null || true
-	done
+	# disconect all containers, connected to project network
+	# '-I {}' and '{}' can be used to position the argument passed by xargs.
+	xargs -I {} docker network disconnect -f "$network" {} &>/dev/null <<< "$(docker ps -aq --no-trunc -f "network=${network}")"
 }
+
 _start_containers ()
 {
 	check_docker_running

--- a/bin/fin
+++ b/bin/fin
@@ -1298,7 +1298,7 @@ _remove_containers ()
 	if [[ $1 == "" ]]; then
 		echo-yellow "Removing containers..."
 
-		# Disconnect proxy from the project network, otherwise network will not be removed.
+		# Disconnect all containers from the project network, otherwise network will not be removed.
 		# Figure out the default project network name
 		local network="${COMPOSE_PROJECT_NAME_SAFE}_default"
 		_disconnect_network "${network}"

--- a/bin/fin
+++ b/bin/fin
@@ -1268,7 +1268,7 @@ _stop_containers ()
 		local network_name="${COMPOSE_PROJECT_NAME_SAFE}_default"
 
 		# "docker network inspect" does not list inactive endpoints (stopped containers), so cannot be used here
-		# Instead, we'll assume we should disconnect all project containers + vhost-proxy from the project network.
+		# Instead, we'll assume we should disconnect all project containers + vhost-proxy + docksal-ssh-proxy from the project network.
 		local project_containers=$(docker ps -aq \
 			--filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME_SAFE}" 2>/dev/null)
 		# Note: there should be no quotes around ${network_containers} or it won't be split properly
@@ -1276,6 +1276,7 @@ _stop_containers ()
 			docker network disconnect -f "${network_name}" "${container}" &>/dev/null || true
 		done
 		docker network disconnect -f "${network_name}" docksal-vhost-proxy &>/dev/null || true
+		docker network disconnect -f "${network_name}" docksal-ssh-proxy &>/dev/null || true
 		docker network rm "${network_name}" &>/dev/null || true
 	fi
 
@@ -1298,7 +1299,8 @@ _remove_containers ()
 		# Disconnect proxy from the project network, otherwise network will not be removed.
 		# Figure out the default project network name
 		local network="${COMPOSE_PROJECT_NAME_SAFE}_default"
-		docker network disconnect "$network" docksal-vhost-proxy >/dev/null 2>&1
+		docker network disconnect "$network" docksal-vhost-proxy >/dev/null 2>&1 || true
+		docker network disconnect "$network" docksal-ssh-proxy >/dev/null 2>&1 || true
 
 		# Taking the whole docker-compose project down (this removes containers, volumes, and networks)
 		docker-compose down --volumes --remove-orphans

--- a/bin/fin
+++ b/bin/fin
@@ -1203,8 +1203,8 @@ _confirm ()
 _disconnect_network ()
 {
 	local network=$1
-	# get containers list, attached to network
-	local containers=$(docker container ls -aq --no-trunc -f "network=${network}")
+	# get containers list, attached to the network
+	local containers=$(docker ps -aq --no-trunc -f "network=${network}")
 
 	# disconnect containers from network
 	for container in ${containers}

--- a/bin/fin
+++ b/bin/fin
@@ -1200,7 +1200,18 @@ _confirm ()
 }
 
 #-------------------------- Containers management -----------------------------
+_disconnect_network ()
+{
+	local network=$1
+	# get containers list, attached to network
+	local containers=$(docker container ls -aq --no-trunc -f "network=${network}")
 
+	# disconnect containers from network
+	for container in ${containers}
+	do
+		docker network disconnect -f "${network}" "${container}" &>/dev/null || true
+	done
+}
 _start_containers ()
 {
 	check_docker_running
@@ -1265,19 +1276,10 @@ _stop_containers ()
 		echo-green "Disconnecting project network..."
 		# There is a limit of about 30 docker networks per host, so unused (stopped projects') networks should be dropped.
 		# The project network will be automatically recreated by docker-compose up.
-		local network_name="${COMPOSE_PROJECT_NAME_SAFE}_default"
+		local network="${COMPOSE_PROJECT_NAME_SAFE}_default"
+		_disconnect_network "${network}"
 
-		# "docker network inspect" does not list inactive endpoints (stopped containers), so cannot be used here
-		# Instead, we'll assume we should disconnect all project containers + vhost-proxy + docksal-ssh-proxy from the project network.
-		local project_containers=$(docker ps -aq \
-			--filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME_SAFE}" 2>/dev/null)
-		# Note: there should be no quotes around ${network_containers} or it won't be split properly
-		for container in ${project_containers}; do
-			docker network disconnect -f "${network_name}" "${container}" &>/dev/null || true
-		done
-		docker network disconnect -f "${network_name}" docksal-vhost-proxy &>/dev/null || true
-		docker network disconnect -f "${network_name}" docksal-ssh-proxy &>/dev/null || true
-		docker network rm "${network_name}" &>/dev/null || true
+		docker network rm "${network}" &>/dev/null || true
 	fi
 
 	echo-green "Stopping services..."
@@ -1299,8 +1301,7 @@ _remove_containers ()
 		# Disconnect proxy from the project network, otherwise network will not be removed.
 		# Figure out the default project network name
 		local network="${COMPOSE_PROJECT_NAME_SAFE}_default"
-		docker network disconnect "$network" docksal-vhost-proxy >/dev/null 2>&1 || true
-		docker network disconnect "$network" docksal-ssh-proxy >/dev/null 2>&1 || true
+		_disconnect_network "${network}"
 
 		# Taking the whole docker-compose project down (this removes containers, volumes, and networks)
 		docker-compose down --volumes --remove-orphans


### PR DESCRIPTION
Sometimes `docksal-ssh-proxy` container remains connected to the project network. in this case command `fin rm -f` returns error:
```
Error response from daemon: error while removing network: network drupal8_default id 4abb0c2a4df4ca9475cf5bef8cdb790542bb663f1c87608c66b21fefd0225011 has active endpoints
```
and project network cant be deleted. this PR fix this issue