### PR TITLE
Reminder to keep docksal.io installation instructions up to date

### DIFF
--- a/docs/content/getting-started/setup.md
+++ b/docs/content/getting-started/setup.md
@@ -94,7 +94,7 @@ with the version linked below.
 
 1. Install Docker Desktop for Mac v2.1.0.3
 
-    [![Docker Desktop for Mac v2.1.0.3](https://img.shields.io/badge/download-Docker%20Desktop%20for%20Mac-blue.svg?logo=docker&style=for-the-badge&classes=inline)](https://download.docker.com/mac/stable/38240/Docker.dmg)
+    [![Docker Desktop for Mac v2.1.0.3](https://img.shields.io/badge/download-Docker%20Desktop%20for%20Mac-blue.svg?logo=docker&style=for-the-badge&classes=inline)](https://download.docker.com/mac/stable/38240/Docker.dmg) <!-- when changing this version please change https://github.com/docksal/docksal.io/tree/master/src/pages/installation.js as well -->
 
 1. Start Docker Desktop
 
@@ -200,7 +200,7 @@ with the version linked below.
 
 3. Install Docker Desktop for Windows v2.1.0.3
 
-    [![Docker Desktop for Windows v2.1.0.3](https://img.shields.io/badge/download-Docker%20Desktop%20for%20Windows-blue.svg?logo=docker&style=for-the-badge&classes=inline)](https://download.docker.com/win/stable/38240/Docker%20Desktop%20Installer.exe)
+    [![Docker Desktop for Windows v2.1.0.3](https://img.shields.io/badge/download-Docker%20Desktop%20for%20Windows-blue.svg?logo=docker&style=for-the-badge&classes=inline)](https://download.docker.com/win/stable/38240/Docker%20Desktop%20Installer.exe) <!-- when changing this version please change https://github.com/docksal/docksal.io/tree/master/src/pages/installation.js as well -->
     
 4. Configure Docker Desktop on Windows
 


### PR DESCRIPTION
This change adds comments so that when new versions of Docker Desktop are pointed at there is a reminder that those new versions also need to be referenced in the installation instructions on Docksal.io. See https://github.com/docksal/docksal.io/pull/19