### PR TITLE
ensure share works with env variables set

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -5794,8 +5794,10 @@ ngrok_share ()
 
 	# Add -host-header by default if no arguments are included.
 	if [[ "${ARGS}" == "ngrok http" ]]; then
-		ARGS="${ARGS} -host-header '${NGROK_VIRTUAL_HOST}' ${container_name}.${network}:${NGROK_PORT}"
+		ARGS="${ARGS} -host-header '${NGROK_VIRTUAL_HOST}'"
 	fi
+	# Add host and port to the command
+	ARGS="${ARGS} ${container_name}.${network}:${NGROK_PORT}"
 
 	${winpty} docker run --rm ${NGROK_VOLUME} -it \
 		--publish 4040 \


### PR DESCRIPTION
Previously if you set docksal.env vars for `ngrok` sharing failed as we did not set the host and port.
This fixes `fin share` those arguments are set even if `docksal.env` variables are set

This is a smaller change that fixes  #1047. That seems to be part of a larger rewrite of ngrok and I am hoping this can be merged and released as a minor release to make `fin share` useable for those who want to use ngrok authentication or other options. 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docksal/docksal/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Write a short summary that describes the changes in this pull request:
-->
