### PR TITLE
Fix database selection when running `db cli` without arguments

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -5420,17 +5420,16 @@ _mysql ()
 	# MYSQL_* variable expansion happens here
 	local __dump_password="${dbpassword:-$MYSQL_ROOT_PASSWORD}"
 	local __database="${db:-$MYSQL_DATABASE}"
-
-	if [[ "${ARGV[*]}" != "" ]]; then
-		# Some arguments were passwed, allow non-interactive run
-		if is_tty; then
-			${winpty} docker exec -it "$container_id" mysql -u${__dump_user} -p${__dump_password} ${__database} -e "${ARGV[*]}"
-		else
-			docker exec "$container_id" mysql -u${__dump_user} -p${__dump_password} ${__database} -e "${ARGV[*]}"
-		fi
-	else
-		${winpty} docker exec -it "$container_id" mysql -u${__dump_user} -p${__dump_password} ${__database}
+	local ptyCommand=''
+	if is_tty; then
+		ptyCommand="${winpty}"
 	fi
+
+	${ptyCommand} docker exec -it "${container_id}" mysql \
+		-u"${__dump_user}" \
+		-p"${__dump_password}" \
+		${__database} \
+		${ARGV:+-e "${ARGV[*]}"}
 }
 
 # Show databases list

--- a/bin/fin
+++ b/bin/fin
@@ -5420,12 +5420,12 @@ _mysql ()
 	# MYSQL_* variable expansion happens here
 	local __dump_password="${dbpassword:-$MYSQL_ROOT_PASSWORD}"
 	local __database="${db:-$MYSQL_DATABASE}"
-	local ptyCommand=''
-	if is_tty; then
-		ptyCommand="${winpty}"
+	local __pty_command=''
+	if is_tty || [[ -z "${ARGV[*]}" ]]; then
+		__pty_command="${winpty}"
 	fi
 
-	${ptyCommand} docker exec -it "${container_id}" mysql \
+	${__pty_command} docker exec -it "${container_id}" mysql \
 		-u"${__dump_user}" \
 		-p"${__dump_password}" \
 		${__database} \


### PR DESCRIPTION
Previously, when running `fin db cli` the database parameter was not passed in
causing a MySQL CLI interface to open up without a database selected. This
fixes it by streamlining the invocation of `mysql`.

Changes include:
- Centralize a local `ptyCommand` variable to get rid of a separate `mysql` invocation
- Use optional expansion for the `-e` argument to get rid of another `mysql` invocation
- Use shell argument escaping for username, password and database name

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docksal/docksal/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Write a short summary that describes the changes in this pull request:
-->
