### PR TITLE
Use environment variables for DB connection

### DIFF
--- a/docs/content/tools/drupal.md
+++ b/docs/content/tools/drupal.md
@@ -17,10 +17,10 @@ Below are sample settings for Drupal 7 and Drupal8.
 ```php
 # Docksal DB connection settings.
 $databases['default']['default'] = array (
-  'database' => 'default',
-  'username' => 'user',
-  'password' => 'user',
-  'host' => 'db',
+  'database' => getenv('MYSQL_DATABASE'),
+  'username' => getenv('MYSQL_USER'),
+  'password' => getenv('MYSQL_PASSWORD'),
+  'host' => getenv('MYSQL_HOST'),
   'driver' => 'mysql',
 );
 ```


### PR DESCRIPTION
Changing instructions for Drupal to use environment variables injected into container as it is instructed on https://docs.docksal.io/getting-started/project-setup/#launching-your-first-docksal-stack
