### PR TITLE
Release 1.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 1.13.3 (2020-05-14)
+
+### New software versions
+
+- fin v1.94.0
+
+### Changes and improvements
+
+- Docker Desktop 2.3.0.2 compatibility fixes (Mac and Windows)
+  - Bind system services to `0.0.0.0` by default in virtualized environments (fixes #1268, fixes #1342)
+  - Dropped the dependency on DockerNAT interface on Windows (fixes #1276) 
+    - Do not configure DNS resolver with Docker Desktop for Windows
+    - Use the external `docksal.site` TLD with Docker Desktop for Windows v2.2.0.0+. This is necessary to have a working setup out of the box without the need to ask the user to manually configure DNS records using "fin hosts".
+
+### Experimental
+
+- Try the new external TDL for your Docksal projects!
+    ```
+    fin config set --global DOCKSAL_DNS_DOMAIN=docksal.site
+    ```
+    Note: This option is enforced with Docker Desktop for Windows 2.2.0.0+
+
+
+## 1.13.2 (2019-03-15)
+
+### Documentation
+
+- Added a section about setting/checking `DOCKSAL_VOLUMES` (#1275, #1296)
+- Added warnings in install docs about Docker Desktop versions (#1268)
+
+
 ## 1.13.1 (2019-12-17)
 
 ### New software versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New software versions
 
-- fin v1.94.0
+- fin v1.95.0
 
 ### Changes and improvements
 

--- a/bin/fin
+++ b/bin/fin
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-FIN_VERSION=1.93.0
+FIN_VERSION=1.94.0
 
 if [[ "$TERM" != "dumb" ]]; then
 	# Console colors

--- a/bin/fin
+++ b/bin/fin
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-FIN_VERSION=1.94.0
+FIN_VERSION=1.95.0
 
 if [[ "$TERM" != "dumb" ]]; then
 	# Console colors

--- a/bin/fin
+++ b/bin/fin
@@ -3947,10 +3947,6 @@ install_dns_service ()
 {
 	detect_dns
 
-	# Match with DOCKSAL_VHOST_PROXY_IP by default for simplicity
-	# E.g, if vhost-proxy is exposed on 0.0.0.0, then do the same for dns
-	DOCKSAL_DNS_IP="${DOCKSAL_DNS_IP:-$DOCKSAL_VHOST_PROXY_IP}"
-
 	# Open up dns in virtualized environments
 	# This helps with recurring regressions with binding to an IP in Docker Desktop
 	( ! is_linux ) && DOCKSAL_DNS_IP="0.0.0.0"

--- a/bin/fin
+++ b/bin/fin
@@ -7663,8 +7663,11 @@ fi
 # out of the box without the need to ask the user to manually configure DNS records using "fin hosts".
 # See https://github.com/docksal/docksal/issues/1276
 if ( is_windows || is_wsl ) && is_docker_native; then
-	export DOCKSAL_NO_DNS_RESOLVER=1
-	export DOCKSAL_DNS_DOMAIN=docksal.site
+	# Limit this to Docker Desktop for Windows 2.2.0.0+, which it is absolutely necessary
+	if (( $(ver_to_int $(docker_desktop_version)) >= $(ver_to_int '2.2.0.0') )); then
+		export DOCKSAL_NO_DNS_RESOLVER=1
+		export DOCKSAL_DNS_DOMAIN=docksal.site
+	fi
 fi
 
 # DOCKSAL_IP - Docker/VM IP

--- a/bin/fin
+++ b/bin/fin
@@ -1034,7 +1034,7 @@ docker_desktop_version ()
 		echo $(defaults read /Applications/Docker.app/Contents/Info.plist CFBundleShortVersionString) 2>/dev/null
 	fi
 
-	if is_windows || is_wsl; then
+	if is_wsl; then
 		grep -Po '"Informational":.*?[^\\]"' '/mnt/c/Program Files/Docker/Docker/resources/componentsVersion.json' | cut -d : -f2 | awk -F\" '{print $2}'
 	fi
 }
@@ -7662,7 +7662,7 @@ fi
 # Use the external docksal.site domain instead of the internal one. This is necessary to have a working setup
 # out of the box without the need to ask the user to manually configure DNS records using "fin hosts".
 # See https://github.com/docksal/docksal/issues/1276
-if ( is_windows || is_wsl ) && is_docker_native; then
+if is_wsl && is_docker_native; then
 	# Limit this to Docker Desktop for Windows 2.2.0.0+, which it is absolutely necessary
 	if (( $(ver_to_int $(docker_desktop_version)) >= $(ver_to_int '2.2.0.0') )); then
 		export DOCKSAL_NO_DNS_RESOLVER=1

--- a/bin/fin
+++ b/bin/fin
@@ -1028,27 +1028,14 @@ is_vbox_version ()
 }
 
 # Print Docker Desktop version
-# @param $1 --short - prints short version instead of full
-# Example output (--short): 2.0.0.3
 docker_desktop_version ()
 {
-	local short=${1}
-
 	if is_mac; then
 		echo $(defaults read /Applications/Docker.app/Contents/Info.plist CFBundleShortVersionString) 2>/dev/null
 	fi
 
 	if is_windows || is_wsl; then
-		# Calling these should be done in quotes and via "bash -c" to expand arguments properly
-		local DockerCli=''
-		is_windows && DockerCli='/cygdrive/c/Program Files/Docker/Docker/DockerCli.exe'
-		is_wsl && DockerCli='/mnt/c/Program Files/Docker/Docker/DockerCli.exe'
-
-		if [[ ${short} ]]; then
-			"${DockerCli}" -Version | tr -d '\r' | grep 'Version: ' | sed 's/.* \(.*\) .*/\1/g'
-		else
-			"${DockerCli}" -Version
-		fi
+		grep -Po '"Informational":.*?[^\\]"' '/mnt/c/Program Files/Docker/Docker/resources/componentsVersion.json' | cut -d : -f2 | awk -F\" '{print $2}'
 	fi
 }
 
@@ -5947,7 +5934,7 @@ sysinfo ()
 		echo
 		echo "███  DOCKER DESKTOP"
 		echo "EXPECTED VERSION: ${REQUIREMENTS_DOCKER_DESKTOP}"
-		docker_desktop_version
+		echo "DETECTED VERSION: $(docker_desktop_version)"
 	fi
 
 	# Diagnostics information

--- a/bin/fin
+++ b/bin/fin
@@ -3846,6 +3846,10 @@ install_proxy_service ()
 		[[ "$PROJECTS_ROOT" != "" ]] && echo-warning "PROJECTS_ROOT ($PROJECTS_ROOT) is not a valid directory"
 	fi
 
+	# Open up vhost-proxy in virtualized environments
+	# This helps with recurring regressions with binding to an IP in Docker Desktop
+	( ! is_linux ) && DOCKSAL_VHOST_PROXY_IP="0.0.0.0"
+
 	# Open up vhost-proxy to the world in CI/Sandbox/PWD environments
 	( is_ci || is_pwd || is_katacoda ) && DOCKSAL_VHOST_PROXY_IP="0.0.0.0"
 
@@ -3946,6 +3950,10 @@ install_dns_service ()
 	# Match with DOCKSAL_VHOST_PROXY_IP by default for simplicity
 	# E.g, if vhost-proxy is exposed on 0.0.0.0, then do the same for dns
 	DOCKSAL_DNS_IP="${DOCKSAL_DNS_IP:-$DOCKSAL_VHOST_PROXY_IP}"
+
+	# Open up dns in virtualized environments
+	# This helps with recurring regressions with binding to an IP in Docker Desktop
+	( ! is_linux ) && DOCKSAL_DNS_IP="0.0.0.0"
 
 	# Stop and remove existing container
 	docker rm -f docksal-dns >/dev/null 2>&1 || true

--- a/bin/fin
+++ b/bin/fin
@@ -226,7 +226,7 @@ DOCKSAL_NO_DNS_RESOLVER="${DOCKSAL_NO_DNS_RESOLVER}"
 DOCKSAL_DNS_DEBUG="${DOCKSAL_DNS_DEBUG}"
 
 # Docker for Windows
-DOCKER_WIN_NETWORK="vEthernet (DockerNAT)"
+DOCKER_WIN_NETWORK="Loopback Pseudo-Interface 1"
 
 # Declaring possible vhost-proxy settings overrides
 DOCKSAL_VHOST_PROXY_IP="${DOCKSAL_VHOST_PROXY_IP}"

--- a/bin/fin
+++ b/bin/fin
@@ -7673,13 +7673,8 @@ fi
 # DOCKSAL_IP - Docker/VM IP
 # DOCKSAL_DNS1 - IP used for DNS resolution by containers via docksal-dns (adds support for *.docksal domains)
 # DOCKSAL_DNS2 - a backup external DNS server
-if is_docker_native || is_wsl; then
-	export DOCKSAL_DNS1=${DOCKSAL_IP}
-	export DOCKSAL_DNS2=${DOCKSAL_DNS_UPSTREAM:-$DOCKSAL_DEFAULT_DNS}
-else
-	export DOCKSAL_DNS1=${DOCKSAL_IP}
-	export DOCKSAL_DNS2=${DOCKSAL_DNS_UPSTREAM:-$DOCKSAL_DEFAULT_DNS}
-fi
+export DOCKSAL_DNS1=${DOCKSAL_IP}
+export DOCKSAL_DNS2=${DOCKSAL_DNS_UPSTREAM:-$DOCKSAL_DEFAULT_DNS}
 
 # Create drives bind mounts on wsl
 # E.g. /mnt/c -> /c

--- a/bin/fin
+++ b/bin/fin
@@ -7670,6 +7670,16 @@ if ! is_windows; then
 fi
 
 # Network settings
+
+# Do not configure internal DNS resolver with Docker Desktop for Windows
+# Use the external docksal.site domain instead of the internal one. This is necessary to have a working setup
+# out of the box without the need to ask the user to manually configure DNS records using "fin hosts".
+# See https://github.com/docksal/docksal/issues/1276
+if ( is_windows || is_wsl ) && is_docker_native; then
+	export DOCKSAL_NO_DNS_RESOLVER=1
+	export DOCKSAL_DNS_DOMAIN=docksal.site
+fi
+
 # DOCKSAL_IP - Docker/VM IP
 # DOCKSAL_DNS1 - IP used for DNS resolution by containers via docksal-dns (adds support for *.docksal domains)
 # DOCKSAL_DNS2 - a backup external DNS server

--- a/bin/fin
+++ b/bin/fin
@@ -217,6 +217,7 @@ export DOCKSAL_SUBNET="192.168.64.1/24"
 # For environments, where access to external DNS servers is blocked, DOCKSAL_DNS_UPSTREAM should be set to the LAN DNS server
 DOCKSAL_DEFAULT_DNS="8.8.8.8"
 # For visibility on this variable
+DOCKSAL_DNS_IP="${DOCKSAL_DNS_IP}"
 DOCKSAL_DNS_UPSTREAM="${DOCKSAL_DNS_UPSTREAM}"
 DOCKSAL_DNS_DOMAIN="${DOCKSAL_DNS_DOMAIN:-docksal}"
 # Allow disabling the DNS resolver configuration (in case there are issues with it). Set to "true" to activate.
@@ -3941,6 +3942,11 @@ detect_dns ()
 install_dns_service ()
 {
 	detect_dns
+
+	# Match with DOCKSAL_VHOST_PROXY_IP by default for simplicity
+	# E.g, if vhost-proxy is exposed on 0.0.0.0, then do the same for dns
+	DOCKSAL_DNS_IP="${DOCKSAL_DNS_IP:-$DOCKSAL_VHOST_PROXY_IP}"
+
 	# Stop and remove existing container
 	docker rm -f docksal-dns >/dev/null 2>&1 || true
 	# This container cannot use the host's resolver configuration. The host itself may be configured to use this
@@ -3949,7 +3955,7 @@ install_dns_service ()
 	# When user disconnects from that network, the backup DNS will handle name resolution (assuming it is reachable).
 	echo "   upstream $DOCKSAL_DNS_UPSTREAM"
 	docker run -d --name docksal-dns --label "io.docksal.group=system" --restart=unless-stopped \
-		-p "${DOCKSAL_IP}:53:53/udp" --cap-add=NET_ADMIN --dns="$DOCKSAL_DNS_UPSTREAM" --dns="9.9.9.9" \
+		-p "${DOCKSAL_DNS_IP:-$DOCKSAL_IP}:53:53/udp" --cap-add=NET_ADMIN --dns="$DOCKSAL_DNS_UPSTREAM" --dns="9.9.9.9" \
 		-e DNS_IP="$DOCKSAL_IP" -e DNS_DOMAIN="$DOCKSAL_DNS_DOMAIN" -e LOG_QUERIES="$DOCKSAL_DNS_DEBUG" \
 		--mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
 		"${IMAGE_DNS}" >/dev/null

--- a/docs/content/fin/fin-help.md
+++ b/docs/content/fin/fin-help.md
@@ -8,7 +8,7 @@ aliases:
 ## fin {#fin}
 
 	
-	Docksal command line utility v1.94.0
+	Docksal command line utility v1.95.0
 	
 	Usage: fin <command>
 	

--- a/docs/content/fin/fin-help.md
+++ b/docs/content/fin/fin-help.md
@@ -8,7 +8,7 @@ aliases:
 ## fin {#fin}
 
 	
-	Docksal command line utility v1.93.0
+	Docksal command line utility v1.94.0
 	
 	Usage: fin <command>
 	

--- a/docs/content/stack/configuration-variables.md
+++ b/docs/content/stack/configuration-variables.md
@@ -68,6 +68,11 @@ Useful for CI environments that fake tty and thus "freeze" waiting for user inpu
 This is the domain name used for Docksal project URLs, i.e., `http://$PROJECT_NAME.$DOCKSAL_DNS_DOMAIN`. 
 Project named `myproject` will result in `http://myproject.docksal` URL by default.
 
+## DOCKSAL_DNS_IP
+
+Can be used to override IP binding for the docksal-dns system service. E.g., `DOCKSAL_DNS_IP=0.0.0.0`.
+Defaults to the value set for `DOCKSAL_VHOST_PROXY_IP` (for simplicity).
+
 ### DOCKSAL_DNS_UPSTREAM
 
 `Default: autodetected with fallback to 8.8.8.8`

--- a/docs/content/stack/configuration-variables.md
+++ b/docs/content/stack/configuration-variables.md
@@ -70,7 +70,11 @@ Project named `myproject` will result in `http://myproject.docksal` URL by defau
 
 ## DOCKSAL_DNS_IP
 
-Can be used to override IP binding for the docksal-dns system service, e.g., DOCKSAL_DNS_IP=0.0.0.0.
+Can be used to override IP binding for the docksal-dns system service (Linux only).
+
+This is automatically set to `0.0.0.0` (meaning "listen on all network interfaces") for:
+
+- all virtualized environments (all macOS and Windows installation modes)
 
 ### DOCKSAL_DNS_UPSTREAM
 
@@ -136,10 +140,12 @@ Allows for overriding the Docksal version used for checking for updates. Can be 
 
 ### DOCKSAL_VHOST_PROXY_IP
 
-`Default: 192.168.64.100`
+Can be used to override IP binding for the docksal-vhost-proxy system service (Linux only).
 
-Used to set the IP address for the Docksal reverse proxy to listen on. 
-When `CI` variable is set to `true` this will be set to `0.0.0.0`.
+This is automatically set to `0.0.0.0` (meaning "listen on all network interfaces") for:
+
+- all virtualized environments (all macOS and Windows installation modes)
+- CI environments (`CI` variable is set to `true`)
 
 ### GIT_USER_EMAIL (global or project)
 

--- a/docs/content/stack/configuration-variables.md
+++ b/docs/content/stack/configuration-variables.md
@@ -71,7 +71,6 @@ Project named `myproject` will result in `http://myproject.docksal` URL by defau
 ## DOCKSAL_DNS_IP
 
 Can be used to override IP binding for the docksal-dns system service. E.g., `DOCKSAL_DNS_IP=0.0.0.0`.
-Defaults to the value set for `DOCKSAL_VHOST_PROXY_IP` (for simplicity).
 
 ### DOCKSAL_DNS_UPSTREAM
 

--- a/docs/content/stack/configuration-variables.md
+++ b/docs/content/stack/configuration-variables.md
@@ -70,7 +70,7 @@ Project named `myproject` will result in `http://myproject.docksal` URL by defau
 
 ## DOCKSAL_DNS_IP
 
-Can be used to override IP binding for the docksal-dns system service. E.g., `DOCKSAL_DNS_IP=0.0.0.0`.
+Can be used to override IP binding for the docksal-dns system service, e.g., DOCKSAL_DNS_IP=0.0.0.0.
 
 ### DOCKSAL_DNS_UPSTREAM
 


### PR DESCRIPTION
# 1.13.3 (2020-05-14)

## New software versions

- fin v1.95.0

### Changes and improvements

- Docker Desktop 2.3.0.2 compatibility fixes (Mac and Windows)
  - Bind system services to `0.0.0.0` by default in virtualized environments (fixes #1268, fixes #1342)
  - Dropped the dependency on DockerNAT interface on Windows (fixes #1276) 
    - Do not configure DNS resolver with Docker Desktop for Windows
    - Use the external `docksal.site` TLD with Docker Desktop for Windows v2.2.0.0+. This is necessary to have a working setup out of the box without the need to ask the user to manually configure DNS records using "fin hosts".

### Experimental

- Try the new external TDL for your Docksal projects!
    ```
    fin config set --global DOCKSAL_DNS_DOMAIN=docksal.site
    ```
    Note: This option is enforced with Docker Desktop for Windows 2.2.0.0+