### PR TITLE
adds versions links for docs site

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -11,12 +11,32 @@ theme = "learn"
 
   google_tag_manager = "GTM-58ST6XD"
 
-  version = "v1.13.0"
+  version = "v1.14.0"
+
+  [[params.versions]]
+  version = "v1.14.0"
+  branch = "v1.14.0"
+  url = "https://docs.docksal.io"
+
+  [[params.versions]]
+  version = "v1.13.3"
+  branch = "v1.13.3"
+  url = "https://v1-13-3.docs.docksal.io/"
+
+  [[params.versions]]
+  version = "v1.13.2"
+  branch = "v1.13.2"
+  url = "https://v1-13-2.docs.docksal.io/"
+
+  [[params.versions]]
+  version = "v1.13.1"
+  branch = "v1.13.1"
+  url = "https://v1-13-1.docs.docksal.io/"
 
   [[params.versions]]
   version = "v1.13.0"
   branch = "v1.13.0"
-  url = "https://docs.docksal.io"
+  url = "https://v1-13-0.docs.docksal.io/"
 
   [[params.versions]]
   version = "v1.12.3"


### PR DESCRIPTION
The versions config hasn't been updated since the last major version release. This includes our 1.13.x versions and the upcoming 1.14.0 release.