### PR TITLE
Logging for Service Containers

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -6071,6 +6071,11 @@ load_global_configuration ()
 load_configuration ()
 {
 	check_project_root
+	
+	# Export Logging File Variables
+	export DOCKSAL_CONTAINER_LOG_MAX_SIZE
+	export DOCKSAL_CONTAINER_LOG_MAX_FILE
+	
 	# Re-load global env file once again, since 'up' resets some variables to force re-reading config
 	set -a; source "$CONFIG_ENV"; set +a
 

--- a/bin/fin
+++ b/bin/fin
@@ -6071,11 +6071,7 @@ load_global_configuration ()
 load_configuration ()
 {
 	check_project_root
-	
-	# Export Logging File Variables
-	export DOCKSAL_CONTAINER_LOG_MAX_SIZE
-	export DOCKSAL_CONTAINER_LOG_MAX_FILE
-	
+
 	# Re-load global env file once again, since 'up' resets some variables to force re-reading config
 	set -a; source "$CONFIG_ENV"; set +a
 
@@ -7783,6 +7779,10 @@ export MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-root}
 export MYSQL_USER=${MYSQL_USER:-user}
 export MYSQL_PASSWORD=${MYSQL_PASSWORD:-user}
 export MYSQL_DATABASE=${MYSQL_DATABASE:-default}
+
+# Container logging settings
+export DOCKSAL_CONTAINER_LOG_MAX_SIZE
+export DOCKSAL_CONTAINER_LOG_MAX_FILE
 
 # Handle Alias
 if [[ "$1" == "@"* ]]; then

--- a/bin/fin
+++ b/bin/fin
@@ -3890,8 +3890,8 @@ install_proxy_service ()
 		--mount type=volume,src=docksal_projects,dst=/projects \
 		--mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
 		${mount_certs} \
-        --log-opt max-size=${DOCKSAL_CONTAINER_LOG_MAX_SIZE} \
-        --log-opt max-file=${DOCKSAL_CONTAINER_LOG_MAX_FILE} \
+        	--log-opt max-size=${DOCKSAL_CONTAINER_LOG_MAX_SIZE} \
+        	--log-opt max-file=${DOCKSAL_CONTAINER_LOG_MAX_FILE} \
 		"${IMAGE_VHOST_PROXY}" >/dev/null
 	if_failed_error "Failed starting the proxy service."
 }

--- a/bin/fin
+++ b/bin/fin
@@ -276,6 +276,10 @@ fi
 # Healthcheck timeout
 DOCKSAL_HEALTHCHECK_TIMEOUT=${DOCKSAL_HEALTHCHECK_TIMEOUT:-60}
 
+# Logging settings
+DOCKSAL_CONTAINER_LOG_MAX_SIZE=${DOCKSAL_CONTAINER_LOG_MAX_SIZE:-1m}
+DOCKSAL_CONTAINER_LOG_MAX_FILE=${DOCKSAL_CONTAINER_LOG_MAX_FILE:-10}
+
 #---------------------------- URL references --------------------------------
 GITHUB_API="https://api.github.com"
 URL_REPO="https://raw.githubusercontent.com/docksal/docksal"
@@ -3886,6 +3890,8 @@ install_proxy_service ()
 		--mount type=volume,src=docksal_projects,dst=/projects \
 		--mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
 		${mount_certs} \
+        --log-opt max-size=${DOCKSAL_CONTAINER_LOG_MAX_SIZE} \
+        --log-opt max-file=${DOCKSAL_CONTAINER_LOG_MAX_FILE} \
 		"${IMAGE_VHOST_PROXY}" >/dev/null
 	if_failed_error "Failed starting the proxy service."
 }

--- a/docs/content/stack/configuration-variables.md
+++ b/docs/content/stack/configuration-variables.md
@@ -61,6 +61,18 @@ Set to `1` to suppress alerts about the outdated Docksal version.
 If set to `1`, all yes/no confirms will automatically be answered yes. 
 Useful for CI environments that fake tty and thus "freeze" waiting for user input.
 
+### DOCKSAL_CONTAINER_LOG_MAX_FILE
+
+`Default: 10`
+
+The number of docker log files that should be kept before they are removed.
+
+### DOCKSAL_CONTAINER_LOG_MAX_SIZE
+
+`Default: 1m`
+
+The size of the docker logs before they are rotated.
+
 ### DOCKSAL_DNS_DOMAIN
 
 `Default: docksal`

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -24,6 +24,10 @@ services:
     dns:
       - ${DOCKSAL_DNS1}
       - ${DOCKSAL_DNS2}
+    logging:
+      options:
+        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
+        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
 
   # Web: Apache (DEPRECATED)
   # TODO: remove November 2019
@@ -45,6 +49,10 @@ services:
     dns:
       - ${DOCKSAL_DNS1}
       - ${DOCKSAL_DNS2}
+    logging:
+      options:
+        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
+        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
 
   # Web: Nginx
   nginx:
@@ -66,6 +74,10 @@ services:
     dns:
     - ${DOCKSAL_DNS1}
     - ${DOCKSAL_DNS2}
+    logging:
+      options:
+        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
+        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
 
   # DB: MySQL
   mysql:
@@ -88,6 +100,10 @@ services:
     dns:
       - ${DOCKSAL_DNS1}
       - ${DOCKSAL_DNS2}
+    logging:
+      options:
+        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
+        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
 
   # DB: MySQL
   mariadb:
@@ -110,6 +126,10 @@ services:
     dns:
     - ${DOCKSAL_DNS1}
     - ${DOCKSAL_DNS2}
+    logging:
+      options:
+        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
+        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
 
   # DB: PostgreSQL
   pgsql:
@@ -127,6 +147,10 @@ services:
     dns:
       - ${DOCKSAL_DNS1}
       - ${DOCKSAL_DNS2}
+    logging:
+      options:
+        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
+        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
 
   # CLI - Used for all console commands and tools.
   cli:
@@ -172,6 +196,10 @@ services:
     dns:
       - ${DOCKSAL_DNS1}
       - ${DOCKSAL_DNS2}
+    logging:
+      options:
+        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
+        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
 
   # Varnish
   varnish:
@@ -187,6 +215,10 @@ services:
     dns:
       - ${DOCKSAL_DNS1}
       - ${DOCKSAL_DNS2}
+    logging:
+      options:
+        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
+        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
 
   # Memcached
   memcached:
@@ -196,6 +228,10 @@ services:
     dns:
       - ${DOCKSAL_DNS1}
       - ${DOCKSAL_DNS2}
+    logging:
+      options:
+        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
+        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
 
   # Redis
   redis:
@@ -207,6 +243,10 @@ services:
     dns:
       - ${DOCKSAL_DNS1}
       - ${DOCKSAL_DNS2}
+    logging:
+      options:
+        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
+        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
 
   # Solr
   solr:
@@ -221,6 +261,10 @@ services:
     dns:
       - ${DOCKSAL_DNS1}
       - ${DOCKSAL_DNS2}
+    logging:
+      options:
+        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
+        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
 
   # MailHog
   mail:
@@ -235,6 +279,10 @@ services:
     dns:
       - ${DOCKSAL_DNS1}
       - ${DOCKSAL_DNS2}
+    logging:
+      options:
+        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
+        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
 
   # Blackfire
   blackfire:
@@ -259,3 +307,8 @@ services:
       memlock:
         soft: -1
         hard: -1
+    logging:
+      options:
+        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
+        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
+


### PR DESCRIPTION
Added ability for all services included in stacks to have logging options configured. Additionally, added logging options of the system services.

I used defaults of 10 files and 1m file size as the default.