### PR TITLE
Documentation updates for services

### DIFF
--- a/docs/content/service/db/options.md
+++ b/docs/content/service/db/options.md
@@ -10,8 +10,8 @@ you will need to modify your `docksal.yml` file.
 
 ## MariaDB Configuration {#mariadb-config}
 
-Docksal has defined a db service with a PostreSQL image. To set your db service to use PostreSQL instead of MySQL,
-set the db service in your `docksal.yml` file.
+Docksal has defined a db service with a MariaDB image. To set your db service to use MariaDB
+instead of MySQL, set the db service in your `docksal.yml` file.
 
 ```yaml
 version: "2.1"

--- a/docs/content/service/other/elasticsearch.md
+++ b/docs/content/service/other/elasticsearch.md
@@ -41,3 +41,25 @@ To have a static port assigned, override the `ELASTICSEARCH_PORT_MAPPING` variab
 ELASTICSEARCH_PORT_MAPPING='9200:9200'
 ```
 In this case, the current project elastic search will be accessible at `192.168.64.100:9200`.
+
+## Persistent Settings
+
+If a settings value for elastic search such as `max_map_count` needs to be set and persist
+through project starts, you may need to make modifications for your environment.
+
+### Docker for Mac
+
+Edit then `git commit` the following file:
+
+```
+~/Library/Containers/com.docker.docker/Data/database/com.docker.driver.amd64-linux/etc/sysctl.conf
+```
+
+### Docker Machine (VirtualBox)
+
+```
+fin vm ssh
+sudo touch /var/lib/boot2docker/bootlocal.sh
+sudo chmod +x /var/lib/boot2docker/bootlocal.sh
+echo 'sysctl -w vm.max_map_count=262144' | sudo tee -a /var/lib/boot2docker/bootlocal.sh
+```

--- a/docs/content/service/web/options.md
+++ b/docs/content/service/web/options.md
@@ -10,8 +10,8 @@ if you want to specify the use of nginx, you will need to modify your `docksal.y
 
 ## nginx Configuration {#nginx-config}
 
-Docksal has defined a db service with a PostreSQL image. To set your db service to use PostreSQL instead of MySQL,
-set the db service in your `docksal.yml` file.
+Docksal has defined a web service with an nginx image. To set your db service to use
+nginx instead of Apache, set the db service in your `docksal.yml` file.
 
 ```yaml
 version: "2.1"


### PR DESCRIPTION
I noticed some copy/paste errors that I didn't update with services. This updates the information for the correct service.

This also includes the documentation on elasticsearch persistent settings.
Closes #725 
