### PR TITLE
Allow disabling build-in docksal-dns service

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -225,7 +225,7 @@ DOCKSAL_DNS_UPSTREAM="${DOCKSAL_DNS_UPSTREAM}"
 DOCKSAL_DNS_DOMAIN_DEFAULT="docksal"
 DOCKSAL_DNS_DOMAIN="${DOCKSAL_DNS_DOMAIN:-$DOCKSAL_DNS_DOMAIN_DEFAULT}"
 # Allow disabling the DNS resolver configuration (in case there are issues with it). Set to "true" to activate.
-DOCKSAL_NO_DNS_RESOLVER="${DOCKSAL_NO_DNS_RESOLVER}"
+DOCKSAL_NO_DNS_RESOLVER="${DOCKSAL_NO_DNS_RESOLVER:-0}"
 # Set to "true" to enable logging DNS queries in docksal-dns. View logs via "fin docker logs docksal-dns"
 DOCKSAL_DNS_DEBUG="${DOCKSAL_DNS_DEBUG}"
 
@@ -4123,12 +4123,10 @@ configure_resolver_wsl () {
 # Configure system-wide *.docksal resolver (Windows is not supported)
 configure_resolver ()
 {
-	# Skip if built-in DNS is disabled
-	[[ "$DOCKSAL_DNS_DISABLED" == "1" ]] && return
-	# Do not configure the resolver if asked so
-	[[ "$DOCKSAL_NO_DNS_RESOLVER" != "" ]] && return
-
 	local mode="${1:-on}"
+
+	# Global DNS resolver kill switch
+	[[ "$DOCKSAL_NO_DNS_RESOLVER" != "0" ]] && mode='off'
 
 	if [[ "$mode" == "on" ]]; then
 		echo-green "Enabling automatic *.$DOCKSAL_DNS_DOMAIN DNS resolver..."
@@ -4158,8 +4156,6 @@ configure_resolver ()
 				_confirm "Continue?"
 			fi
 		fi
-	elif [[ "$mode" == "off" ]]; then
-		echo-green "Disabling automatic *.$DOCKSAL_DNS_DOMAIN DNS resolver..."
 	fi
 
 	is_mac && configure_resolver_mac "$mode" && return $?
@@ -7732,14 +7728,9 @@ fi
 
 # Network settings
 
-# Use external DNS domain if built-in DNS is disabled
-if [[ "$DOCKSAL_DNS_DISABLED" == "1" ]]; then
-	export DOCKSAL_DNS_DOMAIN=docksal.site
-fi
-
-# Do not configure internal DNS resolver with Docker Desktop for Windows
-# Use the external docksal.site domain instead of the internal one. This is necessary to have a working setup
-# out of the box without the need to ask the user to manually configure DNS records using "fin hosts".
+# Disable internal DNS resolver and use external domain with Docker Desktop for Windows
+# This is necessary to have a working setup out of the box without the need to ask the user to manually configure DNS
+# records using "fin hosts".
 # See https://github.com/docksal/docksal/issues/1276
 if is_wsl && is_docker_native; then
 	# Only proceed if DOCKSAL_DNS_DOMAIN was not explicitly set (matches the default)
@@ -7750,6 +7741,12 @@ if is_wsl && is_docker_native; then
 			export DOCKSAL_DNS_DOMAIN=docksal.site
 		fi
 	fi
+fi
+
+# Disable internal DNS resolver and use external domain if docksal-dns is disabled
+if [[ "$DOCKSAL_DNS_DISABLED" == "1" ]]; then
+	export DOCKSAL_NO_DNS_RESOLVER=1
+	export DOCKSAL_DNS_DOMAIN=docksal.site
 fi
 
 # DOCKSAL_IP - Docker/VM IP

--- a/bin/fin
+++ b/bin/fin
@@ -215,6 +215,8 @@ DOCKSAL_ENVIRONMENT="${DOCKSAL_ENVIRONMENT:-local}"
 export DOCKSAL_IP="192.168.64.100"
 export DOCKSAL_HOST_IP="192.168.64.1"
 export DOCKSAL_SUBNET="192.168.64.1/24"
+# Allow turning built-in DNS features on/off. Set to "0" to switch to external DNS (which will be standard in v2)
+DOCKSAL_DNS_ENABLED="${DOCKSAL_DNS_ENABLED:-1}"
 # For environments, where access to external DNS servers is blocked, DOCKSAL_DNS_UPSTREAM should be set to the LAN DNS server
 DOCKSAL_DEFAULT_DNS="8.8.8.8"
 # For visibility on this variable
@@ -847,7 +849,10 @@ is_docksal_running ()
 	# Assume Docksal is running when the following system services are running
 	(echo "$system_services" | grep 'docksal-vhost-proxy' >/dev/null 2>&1) || return 1
 	(echo "$system_services" | grep 'docksal-ssh-agent' >/dev/null 2>&1) || return 1
-	(echo "$system_services" | grep 'docksal-dns' >/dev/null 2>&1) || return 1
+	# Skip if built-in DNS is disabled
+	if [[ "$DOCKSAL_DNS_ENABLED" != "0" ]]; then
+		(echo "$system_services" | grep 'docksal-dns' >/dev/null 2>&1) || return 1
+	fi
 
 	return 0
 }
@@ -3967,6 +3972,12 @@ detect_dns ()
 # Start system-wide dns service
 install_dns_service ()
 {
+	# Skip/disable if built-in DNS is disabled
+	if [[ "$DOCKSAL_DNS_ENABLED" == "0" ]]; then
+		docker rm -f docksal-dns >/dev/null 2>&1 || true
+		return
+	fi
+
 	detect_dns
 
 	# Open up dns in virtualized environments
@@ -4112,6 +4123,8 @@ configure_resolver_wsl () {
 # Configure system-wide *.docksal resolver (Windows is not supported)
 configure_resolver ()
 {
+	# Skip if built-in DNS is disabled
+	[[ "$DOCKSAL_DNS_ENABLED" == "0" ]] && return
 	# Do not configure the resolver if asked so
 	[[ "$DOCKSAL_NO_DNS_RESOLVER" != "" ]] && return
 
@@ -7718,6 +7731,11 @@ if ! is_windows; then
 fi
 
 # Network settings
+
+# Use external DNS domain if built-in DNS is disabled
+if [[ "$DOCKSAL_DNS_ENABLED" == "0" ]]; then
+	export DOCKSAL_DNS_DOMAIN=docksal.site
+fi
 
 # Do not configure internal DNS resolver with Docker Desktop for Windows
 # Use the external docksal.site domain instead of the internal one. This is necessary to have a working setup

--- a/bin/fin
+++ b/bin/fin
@@ -215,8 +215,8 @@ DOCKSAL_ENVIRONMENT="${DOCKSAL_ENVIRONMENT:-local}"
 export DOCKSAL_IP="192.168.64.100"
 export DOCKSAL_HOST_IP="192.168.64.1"
 export DOCKSAL_SUBNET="192.168.64.1/24"
-# Allow turning built-in DNS features on/off. Set to "0" to switch to external DNS (which will be standard in v2)
-DOCKSAL_DNS_ENABLED="${DOCKSAL_DNS_ENABLED:-1}"
+# Allow turning built-in DNS features on/off. Set to "1" to switch to external DNS (which will be standard in v2)
+DOCKSAL_DNS_DISABLED="${DOCKSAL_DNS_DISABLED:-0}"
 # For environments, where access to external DNS servers is blocked, DOCKSAL_DNS_UPSTREAM should be set to the LAN DNS server
 DOCKSAL_DEFAULT_DNS="8.8.8.8"
 # For visibility on this variable
@@ -850,7 +850,7 @@ is_docksal_running ()
 	(echo "$system_services" | grep 'docksal-vhost-proxy' >/dev/null 2>&1) || return 1
 	(echo "$system_services" | grep 'docksal-ssh-agent' >/dev/null 2>&1) || return 1
 	# Skip if built-in DNS is disabled
-	if [[ "$DOCKSAL_DNS_ENABLED" != "0" ]]; then
+	if [[ "$DOCKSAL_DNS_DISABLED" == "0" ]]; then
 		(echo "$system_services" | grep 'docksal-dns' >/dev/null 2>&1) || return 1
 	fi
 
@@ -3973,7 +3973,7 @@ detect_dns ()
 install_dns_service ()
 {
 	# Skip/disable if built-in DNS is disabled
-	if [[ "$DOCKSAL_DNS_ENABLED" == "0" ]]; then
+	if [[ "$DOCKSAL_DNS_DISABLED" == "1" ]]; then
 		docker rm -f docksal-dns >/dev/null 2>&1 || true
 		return
 	fi
@@ -4124,7 +4124,7 @@ configure_resolver_wsl () {
 configure_resolver ()
 {
 	# Skip if built-in DNS is disabled
-	[[ "$DOCKSAL_DNS_ENABLED" == "0" ]] && return
+	[[ "$DOCKSAL_DNS_DISABLED" == "1" ]] && return
 	# Do not configure the resolver if asked so
 	[[ "$DOCKSAL_NO_DNS_RESOLVER" != "" ]] && return
 
@@ -7733,7 +7733,7 @@ fi
 # Network settings
 
 # Use external DNS domain if built-in DNS is disabled
-if [[ "$DOCKSAL_DNS_ENABLED" == "0" ]]; then
+if [[ "$DOCKSAL_DNS_DISABLED" == "1" ]]; then
 	export DOCKSAL_DNS_DOMAIN=docksal.site
 fi
 

--- a/docs/content/stack/configuration-variables.md
+++ b/docs/content/stack/configuration-variables.md
@@ -95,15 +95,30 @@ This is automatically set to `0.0.0.0` (meaning "listen on all network interface
 Override the default DNS server that Docksal uses. For environments where access to Google DNS server (`8.8.8.8`) 
 is blocked, it should be set to the LAN DNS server. This is often true for VPN users or users behind a corporate firewall.
 
+### DOCKSAL_NO_DNS_RESOLVER
+
+`Default: 0`
+
+Set to `1` and run `fin system reset` to disable the DNS resolver configuration.
+
+This can be used if there are issues with DNS resolution on the host machine while running Docksal.
+
+Also check `DOCKSAL_DNS_DISABLED` as it may be a better option than just disabling the host resolver configuration.
+
 ### DOCKSAL_DNS_DISABLED
 
 `Default: 0`
 
-Set to `1` and do `fin system restart` to completely disable `docksal-dns` service on any platform. 
-Useful when `docksal-dns` is conflicting with corporate rules or if some other software restricts it (`0.0.0.0:53: bind: address already in use`). 
+Set to `1` and do `fin system reset` to disable the `docksal-dns` built-in service and switch to using the public 
+`.docksal.site` base domain. This automatically sets `DOCKSAL_DNS_DOMAIN=docksal.site` and  `DOCKSAL_NO_DNS_RESOLVER=1`.
 
-For Docksal projects to work you will need to switch to using `docksal.site` TLD, or use `fin hosts` commands subset to edit 
-OS-wide hosts file in semi-automatic mode, or manually add project host to the OS-wide hosts file.
+Useful when `docksal-dns` is conflicting with corporate rules or if some other software restricts it 
+(`0.0.0.0:53: bind: address already in use`). 
+
+Projects that do not override the `VIRTUAL_HOST` variable will switch to the new `docksal.site` base domain after running 
+`fin project restart`. Projects that hardcode `VIRTUAL_HOST` will either need to update the value 
+(e.g., `VIRTUAL_HOST=myproject.docksal.site`) or use [fin hosts](/fin/fin-help/#hosts) command to manage host records. 
+semi-automatic mode.
 
 ### DOCKSAL_HEALTHCHECK_TIMEOUT
 
@@ -126,10 +141,6 @@ This is usually good in combination with `CI=true`.
 **macOS only.**  
 Sets the location of the folder on the host machine to mount to VirtualBox or Docker Desktop with NFS. 
 See [file sharing](/core/file-sharing/) for more information.
-
-### DOCKSAL_NO_DNS_RESOLVER
-
-Allow disabling the DNS resolver configuration (in case there are issues with it). Set to `true` to activate.
 
 ### DOCKSAL_SSH_AGENT_USE_HOST
 

--- a/docs/content/stack/configuration-variables.md
+++ b/docs/content/stack/configuration-variables.md
@@ -95,6 +95,16 @@ This is automatically set to `0.0.0.0` (meaning "listen on all network interface
 Override the default DNS server that Docksal uses. For environments where access to Google DNS server (`8.8.8.8`) 
 is blocked, it should be set to the LAN DNS server. This is often true for VPN users or users behind a corporate firewall.
 
+### DOCKSAL_DNS_DISABLED
+
+`Default: 0`
+
+Set to `1` and do `fin system restart` to completely disable `docksal-dns` service on any platform. 
+Useful when `docksal-dns` is conflicting with corporate rules or if some other software restricts it (`0.0.0.0:53: bind: address already in use`). 
+
+For Docksal projects to work you will need to switch to using `docksal.site` TLD, or use `fin hosts` commands subset to edit 
+OS-wide hosts file in semi-automatic mode, or manually add project host to the OS-wide hosts file.
+
 ### DOCKSAL_HEALTHCHECK_TIMEOUT
 
 `Default: 60`


### PR DESCRIPTION
In [v1.13.3](https://github.com/docksal/docksal/releases/tag/1.13.3) we switched to binding system services to `0.0.0.0` to workaround regressions in the recent Docker Desktop versions. Unfortunately, this brought up the old forgotten issues of conflicting ports on the host systems (#1348, #1375).

This PR adds  the `DOCKSAL_DNS_DISABLED` switch which can be used to turn off the docksal-dns built-in service and switch the Docksal instance to using the public `.docksal.site` base domain instead of the internal `.docksal`.

Usage:

```
fin config set --global DOCKSAL_DNS_DISABLED=1
fin system reset
```

Projects that do not set `VIRTUAL_HOST` variable manually will switch to the new `docksal.site` domain (after a `fin project restart`).

Projects that hardcode `VIRTUAL_HOST` will either need to update the value to, e.g., `VIRTUAL_HOST=myproject.docksal.site` or use `fin hosts` to manage host records manually.

ToDOs not covered in this PR:

- Getting rid of the `dns` settings in stack files (`DOCKSAL_DNS1` and `DOCKSAL_DNS2`). This should not be an issue as DOCKSAL_DNS2 always points to upstream DNS service and serves as a fallback when `DOCKSAL_DNS1` (docksal-dns) is not available. We could just make `DOCKSAL_DNS1` equal to `DOCKSAL_DNS2` for the time being.

Fixes #1375 