### PR TITLE
Better handling of ID_LIKE in is_debian

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -45,8 +45,9 @@ is_debian ()
 {
 	[[ "$OS_ID" == "ubuntu" ]] ||
 		[[ "$OS_ID" == "debian" ]] ||
-		[[ "$OS_ID_LIKE" == "ubuntu" ]] ||
-		[[ "$OS_ID_LIKE" == "debian" ]]
+		# ID_LIKE is a list of operating system identifiers (e.g., Pop!_OS has ID_LIKE="debian ubuntu")
+		[[ "$OS_ID_LIKE" =~ "ubuntu" ]] ||
+		[[ "$OS_ID_LIKE" =~ "debian" ]]
 }
 
 is_alpine ()


### PR DESCRIPTION
Fixes Debian based systems detection which specify multiple OS IDs in ID_LIKE (e.g., Pop!_OS has ID_LIKE="debian ubuntu")

Fixes #1374