### PR TITLE
Release 1.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New software versions
 
-- fin v1.96.0
+- fin v1.97.0
 - VirtualBox v6.1.10
 - docker v19.03.5 (v19.03.9 on Debian/Ubuntu)
 - docker-compose v1.26.0
@@ -20,6 +20,9 @@
 
 ### Changes and improvements
 
+- Added `DOCKSAL_DNS_DISABLED` global config switch to allow disabling the build-in `docksal-dns` service (#1376)
+  - Use this as a transition to the new `docksal.site` base domain for projects
+  - Helps address the DNS port binding issue on macOS (`listen udp 0.0.0.0:53: bind: address already in use`)
 - Added proxy variables to `fin run-cli` (#1252)
 - Passing the database argument when running `fin db cli` (#1263)
 - Changed uuid generation method (#1287)
@@ -46,6 +49,7 @@
 - Docker container logging
 - Adding a custom certificate for a project (#1359)
 - Accessing environment variables in cron jobs (#1365)
+- Updated DNS settings docs (#1376)
 
 
 ## 1.13.3 (2020-05-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New software versions
 
-- fin v1.98.0
+- fin v1.99.0
 
 ### New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 1.14.1 (2020-07-20)
+
+### New software versions
+
+- fin v1.98.0
+
+### New features
+
+- Updated projects to include Drupal 9 boilerplate projects (#1385)
+
+### Changes and improvements
+
+- Reverted back to using IP binding for system services with VirtualBox/boot2docker
+  - Only use `0.0.0.0` for vhost-proxy and dns with Docker Desktop 2.2.0.0+ on Mac/Windows
+- Bump `REQUIREMENTS_DOCKER_DESKTOP` to 2.1.0.5
+  - This is the last version before networking regressions were introduced (#1268)
+- Split docker versions based on environment (Linux, Docker Desktop, Boo2docker)
+  - `REQUIREMENTS_DOCKER='19.03.9'` - this is the earliest version available for Ubuntu 20.04 (focal) LTS
+  - `REQUIREMENTS_DOCKER_DD='19.03.8'` - this is the latest version available with Docker Desktop
+  - `REQUIREMENTS_DOCKER_B2D='19.03.5'` - this is the final boot2docker version
+  - Removed `REQUIREMENTS_DOCKER_DEBIAN`
+- Better handling of `ID_LIKE` in `is_debian` (#1377)
+- Added "DOCKSAL: NETWORKING" sections in sysinfo …
+  - Replaced "DOCKSAL: DNS"
+  - Prints network config variables
+  - Added check for DNS resolution/connectivity from containers (and not only host)
+- Added dns settings for run-cli
+
+### Documentation
+
+- Updated versions in setup docs
+  - Added a note in setup docs about Docker Desktop version regressions
+
+
 ## 1.14.0 (2020-07-15)
 
 ### New software versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## 1.14.0 (2020-07-15)
+
+### New software versions
+
+- fin v1.96.0
+- VirtualBox v6.1.10
+- docker v19.03.5 (v19.03.9 on Debian/Ubuntu)
+- docker-compose v1.26.0
+- Switched `vhost-proxy` to [docksal/vhost-proxy:1.6](https://github.com/docksal/service-vhost-proxy/releases/tag/v1.6.0)
+- Switched `cli` image to [docksal/cli:2.11-php7.3](https://github.com/docksal/service-cli/releases/tag/v2.11.0)
+
+### New features
+
+- Ubuntu 20.04 (focal) LTS support
+- PHP 7.4 ([docksal/cli:2.11-php7.4](https://github.com/docksal/service-cli/releases/tag/v2.11.0))
+- Xhprof integration (#1270)
+- Project autostart switch (#1285)
+
+### Changes and improvements
+
+- Added proxy variables to `fin run-cli` (#1252)
+- Passing the database argument when running `fin db cli` (#1263)
+- Changed uuid generation method (#1287)
+- Added a check that the VM IP matches what we expect
+- Fixed issue "error while removing network: network id has active endpoints" (#1293)
+- Fixed environment variables for `fin exec` running scripts (#1289)
+- Fixed issue with starting `cli` from `vhost-proxy` and missing ssh agent socket (#1291)
+- Fixed logic with `SSH_AUTH_SOCKET` (#1308)
+- Allow overriding `DOCKSAL_DNS_DOMAIN` with Docker Desktop 2.2.0.0+
+  - If users want to stick with the `.docksal` TLD on Docker Desktop for Windows, they can do so by manually pinning `DOCKSAL_DNS_DOMAIN` (`fin config set --global DOCKSAL_DNS_DOMAIN=docksal`) and then use `fin hosts add project.docksal` to manage DNS records using the OS hosts file.
+- Added logging settings for system containers (#1354)
+
+### Documentation
+
+- Added a section for locally-trusted HTTPS certs using `mkcert` (#1370)
+- Explained SSH agent proxy functionality (#1253)
+- Added a section for xhprof (#1270)
+- Updated NFS mounts and configuration (#1261)
+- Added troubleshooting docs for NFS issues on macOS Catalina (#1371)
+- PostreSQL support in stacks (#564)
+- Configuration information for Nginx
+- Lots minor fixes in docs
+- ElasticSearch persistent settings
+- Docker container logging
+- Adding a custom certificate for a project (#1359)
+- Accessing environment variables in cron jobs (#1365)
+
+
 ## 1.13.3 (2020-05-14)
 
 ### New software versions

--- a/bin/fin
+++ b/bin/fin
@@ -5943,12 +5943,13 @@ sysinfo ()
 
 		echo
 		echo "███  DOCKSAL: DNS"
-		TEST_URL="http://dns-test.docksal"
-		curl --connect-timeout 2 -sS http://dns-test.docksal >/dev/null
+		[[ ${DOCKSAL_DNS_DISABLED} == 0 ]] && echo "Enabled" || echo "Disabled"
+		TEST_URL="http://dns-test.${DOCKSAL_DNS_DOMAIN}"
+		curl --connect-timeout 2 -sS "${TEST_URL}" >/dev/null
 		if [[ $? != 0 ]]; then
-			echo "ERROR: Requesting $TEST_URL failed!"
+			echo "ERROR: Requesting ${TEST_URL} failed!"
 		else
-			echo "Successfully requested $TEST_URL"
+			echo "Successfully requested ${TEST_URL}"
 		fi
 
 		echo

--- a/bin/fin
+++ b/bin/fin
@@ -45,8 +45,9 @@ is_debian ()
 {
 	[[ "$OS_ID" == "ubuntu" ]] ||
 		[[ "$OS_ID" == "debian" ]] ||
-		[[ "$OS_ID_LIKE" == "ubuntu" ]] ||
-		[[ "$OS_ID_LIKE" == "debian" ]]
+		# ID_LIKE is a list of operating system identifiers (e.g., Pop!_OS has ID_LIKE="debian ubuntu")
+		[[ "$OS_ID_LIKE" =~ "ubuntu" ]] ||
+		[[ "$OS_ID_LIKE" =~ "debian" ]]
 }
 
 is_alpine ()

--- a/bin/fin
+++ b/bin/fin
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-FIN_VERSION=1.95.0
+FIN_VERSION=1.96.0
 
 if [[ "$TERM" != "dumb" ]]; then
 	# Console colors

--- a/bin/fin
+++ b/bin/fin
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-FIN_VERSION=1.98.0
+FIN_VERSION=1.99.0
 
 if [[ "$TERM" != "dumb" ]]; then
 	# Console colors

--- a/bin/fin
+++ b/bin/fin
@@ -7817,11 +7817,15 @@ if [[ "$DOCKSAL_DNS_DISABLED" == "1" ]]; then
 	export DOCKSAL_DNS_DOMAIN=docksal.site
 fi
 
-# DOCKSAL_IP - Docker/VM IP
-# DOCKSAL_DNS1 - IP used for DNS resolution by containers via docksal-dns (adds support for *.docksal domains)
-# DOCKSAL_DNS2 - a backup external DNS server
-export DOCKSAL_DNS1=${DOCKSAL_IP}
-export DOCKSAL_DNS2=${DOCKSAL_DNS_UPSTREAM:-$DOCKSAL_DEFAULT_DNS}
+# DNS resolution settings for containers
+if [[ "$DOCKSAL_DNS_DISABLED" == "0" ]]; then
+	export DOCKSAL_DNS1=${DOCKSAL_IP} # DNS resolution via docksal-dns (adds support for *.docksal domains)
+	export DOCKSAL_DNS2=${DOCKSAL_DNS_UPSTREAM:-$DOCKSAL_DEFAULT_DNS} # Backup external DNS server
+else
+	# TODO: get rid of container DNS settings altogether when docksal-dns is disabled
+	export DOCKSAL_DNS1=${DOCKSAL_DNS_UPSTREAM:-$DOCKSAL_DEFAULT_DNS} # External DNS server
+	export DOCKSAL_DNS2='9.9.9.9' # Backup external DNS
+fi
 
 # Create drives bind mounts on wsl
 # E.g. /mnt/c -> /c

--- a/bin/fin
+++ b/bin/fin
@@ -142,7 +142,7 @@ REQUIREMENTS_DOCKER_MACHINE='0.16.2'
 REQUIREMENTS_VBOX='6.1.10'  # Remember to update the download URLs below
 REQUIREMENTS_WINPTY='0.4.3'
 REQUIREMENTS_WINPTY_CYGWIN='2.8.0'
-REQUIREMENTS_DOCKER_DESKTOP='2.0.0.3'
+REQUIREMENTS_DOCKER_DESKTOP='2.1.0.5'  # This is the last version before networking regressions were introduced (#1268)
 
 # VirtualBox download URLs
 # Remember to update REQUIREMENTS_VBOX above

--- a/bin/fin
+++ b/bin/fin
@@ -293,6 +293,9 @@ URL_REPO_DRUPAL7="https://github.com/docksal/boilerplate-drupal7.git"
 URL_REPO_DRUPAL8="https://github.com/docksal/boilerplate-drupal8.git"
 URL_REPO_DRUPAL8COMPOSER="https://github.com/docksal/boilerplate-drupal8-composer.git"
 URL_REPO_DRUPAL8BLT="https://github.com/docksal/boilerplate-drupal8-blt.git"
+URL_REPO_DRUPAL9="https://github.com/docksal/boilerplate-drupal9.git"
+URL_REPO_DRUPAL9COMPOSER="https://github.com/docksal/boilerplate-drupal9-composer.git"
+URL_REPO_DRUPAL9BLT="https://github.com/docksal/boilerplate-drupal9-blt.git"
 URL_REPO_WORDPRESS="https://github.com/docksal/boilerplate-wordpress.git"
 URL_REPO_MAGENTO="https://github.com/docksal/boilerplate-magento.git"
 URL_REPO_GRAV="https://github.com/docksal/boilerplate-grav.git"
@@ -3187,27 +3190,30 @@ project_create ()
 	if [[ "$choice" == "" ]]; then
 		echo -e "${yellow}2. What would you like to install?${NC}"
 		echo -e "${blue}  PHP based${NC}"
-		echo -e "${green}    1.${NC}  Drupal 8"
-		echo -e "${green}    2.${NC}  Drupal 8 (Composer Version)"
-		echo -e "${green}    3.${NC}  Drupal 8 (BLT Version)"
-		echo -e "${green}    4.${NC}  Drupal 7"
-		echo -e "${green}    5.${NC}  Wordpress"
-		echo -e "${green}    6.${NC}  Magento"
-		echo -e "${green}    7.${NC}  Laravel"
-		echo -e "${green}    8.${NC}  Symfony Skeleton"
-		echo -e "${green}    9.${NC}  Symfony WebApp"
-		echo -e "${green}    10.${NC} Grav CMS"
-		echo -e "${green}    11.${NC} Backdrop CMS"
+		echo -e "${green}    1.${NC}  Drupal 9 (Composer Version)"
+		echo -e "${green}    2.${NC}  Drupal 9 (BLT Version)"
+		echo -e "${green}    3.${NC}  Drupal 9"
+		echo -e "${green}    4.${NC}  Drupal 8"
+		echo -e "${green}    5.${NC}  Drupal 8 (Composer Version)"
+		echo -e "${green}    6.${NC}  Drupal 8 (BLT Version)"
+		echo -e "${green}    7.${NC}  Drupal 7"
+		echo -e "${green}    8.${NC}  Wordpress"
+		echo -e "${green}    9.${NC}  Magento"
+		echo -e "${green}    10.${NC}  Laravel"
+		echo -e "${green}    11.${NC}  Symfony Skeleton"
+		echo -e "${green}    12.${NC}  Symfony WebApp"
+		echo -e "${green}    13.${NC} Grav CMS"
+		echo -e "${green}    14.${NC} Backdrop CMS"
 		echo
 		echo -e "${acqua}  Go based${NC}"
-		echo -e "${green}    12.${NC} Hugo"
+		echo -e "${green}    15.${NC} Hugo"
 		echo
 		echo -e "${lime}  JS based${NC}"
-		echo -e "${green}    13.${NC} Gatsby JS"
-		echo -e "${green}    14.${NC} Angular"
+		echo -e "${green}    16.${NC} Gatsby JS"
+		echo -e "${green}    17.${NC} Angular"
 		echo
 		echo -e "${magenta}  HTML${NC}"
-		echo -e "${green}    15.${NC} Static HTML site"
+		echo -e "${green}    18.${NC} Static HTML site"
 		echo
 		echo -e "${red}  Custom${NC}"
 		echo -e "${green}    0.${NC} Custom git repository"
@@ -3215,7 +3221,7 @@ project_create ()
 		echo -e ""
 
 		# TODO: UPDATE THIS VARIABLE IF YOU ADD MORE CHOICES!
-		local choices=15
+		local choices=18
 
 		while [[ "$choice" == "" ]]; do
 			read -p "Enter your choice (0-$choices): " choice
@@ -3229,76 +3235,91 @@ project_create ()
 	# Set target repo
 	case ${choice} in
 		1)
+			target_cms="Drupal 9 (Composer Version)"
+			target_host_name_search_string="drupal9.docksal"
+			target_repo="$URL_REPO_DRUPAL9COMPOSER"
+			;;
+		2)
+			target_cms="Drupal 9 (BLT Version)"
+			target_host_name_search_string="drupal9.docksal"
+			target_repo="$URL_REPO_DRUPAL9COMPOSER"
+			;;
+		3)
+			target_cms="Drupal 9 (BLT Version)"
+			target_host_name_search_string="drupal9.docksal"
+			target_repo="$URL_REPO_DRUPAL9BLT"
+			;;
+		4)
 			target_cms="Drupal 8"
 			target_host_name_search_string="drupal8.docksal"
 			target_repo="$URL_REPO_DRUPAL8"
 			;;
-		2)
+		5)
 			target_cms="Drupal 8 (Composer Version)"
 			target_host_name_search_string="drupal8.docksal"
 			target_repo="$URL_REPO_DRUPAL8COMPOSER"
 			;;
-		3)
+		6)
 			target_cms="Drupal 8 (BLT Version)"
 			target_host_name_search_string="drupal8.docksal"
 			target_repo="$URL_REPO_DRUPAL8BLT"
 			;;
-		4)
+		7)
 			target_cms="Drupal 7"
 			target_host_name_search_string="drupal7.docksal"
 			target_repo="$URL_REPO_DRUPAL7"
 			;;
-		5)
+		8)
 			target_cms="Wordpress"
 			target_host_name_search_string="wordpress.docksal"
 			target_repo="$URL_REPO_WORDPRESS"
 			;;
-		6)
+		9)
 			target_cms="Magento"
 			target_host_name_search_string="magento.docksal"
 			target_repo="$URL_REPO_MAGENTO"
 			;;
-		7)
+		10)
 			target_cms="Laravel"
 			target_host_name_search_string=""
 			target_repo="$URL_REPO_LARAVEL"
 			;;
-		8)
+		11)
 			target_cms="Symfony Skeleton"
 			target_host_name_search_string="symfony.docksal"
 			target_repo="$URL_REPO_SYMFONY_SKELETON"
 			;;
-		9)
+		12)
 			target_cms="Symfony WebApp"
 			target_host_name_search_string="symfony.docksal"
 			target_repo="$URL_REPO_SYMFONY_WEBAPP"
 			;;
-		10)
+		13)
 			target_cms="Grav CMS"
 			target_host_name_search_string=""
 			target_repo="$URL_REPO_GRAV"
 			;;
-		11)
+		14)
 			target_cms="Backdrop CMS"
 			target_host_name_search_string="backdrop.docksal"
 			target_repo="$URL_REPO_BACKDROP"
 			;;
-		12)
+		15)
 			target_cms="Hugo"
 			target_host_name_search_string=""
 			target_repo="$URL_REPO_HUGO"
 			;;
-		13)
+		16)
 			target_cms="Gatsby JS"
 			target_host_name_search_string=""
 			target_repo="$URL_REPO_GATSBY"
 			;;
-		14)
+		17)
 			target_cms="Angular"
 			target_host_name_search_string=""
 			target_repo="$URL_REPO_ANGULAR"
 			;;
-		15)
+		18)
 			target_cms="Plain HTML"
 			target_host_name_search_string=""
 			target_repo=""

--- a/bin/fin
+++ b/bin/fin
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-FIN_VERSION=1.97.0
+FIN_VERSION=1.98.0
 
 if [[ "$TERM" != "dumb" ]]; then
 	# Console colors

--- a/bin/fin
+++ b/bin/fin
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-FIN_VERSION=1.96.0
+FIN_VERSION=1.97.0
 
 if [[ "$TERM" != "dumb" ]]; then
 	# Console colors

--- a/bin/fin
+++ b/bin/fin
@@ -215,6 +215,8 @@ DOCKSAL_ENVIRONMENT="${DOCKSAL_ENVIRONMENT:-local}"
 export DOCKSAL_IP="192.168.64.100"
 export DOCKSAL_HOST_IP="192.168.64.1"
 export DOCKSAL_SUBNET="192.168.64.1/24"
+# Allow turning built-in DNS features on/off. Set to "1" to switch to external DNS (which will be standard in v2)
+DOCKSAL_DNS_DISABLED="${DOCKSAL_DNS_DISABLED:-0}"
 # For environments, where access to external DNS servers is blocked, DOCKSAL_DNS_UPSTREAM should be set to the LAN DNS server
 DOCKSAL_DEFAULT_DNS="8.8.8.8"
 # For visibility on this variable
@@ -223,7 +225,7 @@ DOCKSAL_DNS_UPSTREAM="${DOCKSAL_DNS_UPSTREAM}"
 DOCKSAL_DNS_DOMAIN_DEFAULT="docksal"
 DOCKSAL_DNS_DOMAIN="${DOCKSAL_DNS_DOMAIN:-$DOCKSAL_DNS_DOMAIN_DEFAULT}"
 # Allow disabling the DNS resolver configuration (in case there are issues with it). Set to "true" to activate.
-DOCKSAL_NO_DNS_RESOLVER="${DOCKSAL_NO_DNS_RESOLVER}"
+DOCKSAL_NO_DNS_RESOLVER="${DOCKSAL_NO_DNS_RESOLVER:-0}"
 # Set to "true" to enable logging DNS queries in docksal-dns. View logs via "fin docker logs docksal-dns"
 DOCKSAL_DNS_DEBUG="${DOCKSAL_DNS_DEBUG}"
 
@@ -847,7 +849,10 @@ is_docksal_running ()
 	# Assume Docksal is running when the following system services are running
 	(echo "$system_services" | grep 'docksal-vhost-proxy' >/dev/null 2>&1) || return 1
 	(echo "$system_services" | grep 'docksal-ssh-agent' >/dev/null 2>&1) || return 1
-	(echo "$system_services" | grep 'docksal-dns' >/dev/null 2>&1) || return 1
+	# Skip if built-in DNS is disabled
+	if [[ "$DOCKSAL_DNS_DISABLED" == "0" ]]; then
+		(echo "$system_services" | grep 'docksal-dns' >/dev/null 2>&1) || return 1
+	fi
 
 	return 0
 }
@@ -3967,6 +3972,12 @@ detect_dns ()
 # Start system-wide dns service
 install_dns_service ()
 {
+	# Skip/disable if built-in DNS is disabled
+	if [[ "$DOCKSAL_DNS_DISABLED" == "1" ]]; then
+		docker rm -f docksal-dns >/dev/null 2>&1 || true
+		return
+	fi
+
 	detect_dns
 
 	# Open up dns in virtualized environments
@@ -4112,10 +4123,10 @@ configure_resolver_wsl () {
 # Configure system-wide *.docksal resolver (Windows is not supported)
 configure_resolver ()
 {
-	# Do not configure the resolver if asked so
-	[[ "$DOCKSAL_NO_DNS_RESOLVER" != "" ]] && return
-
 	local mode="${1:-on}"
+
+	# Global DNS resolver kill switch
+	[[ "$DOCKSAL_NO_DNS_RESOLVER" != "0" ]] && mode='off'
 
 	if [[ "$mode" == "on" ]]; then
 		echo-green "Enabling automatic *.$DOCKSAL_DNS_DOMAIN DNS resolver..."
@@ -4145,8 +4156,6 @@ configure_resolver ()
 				_confirm "Continue?"
 			fi
 		fi
-	elif [[ "$mode" == "off" ]]; then
-		echo-green "Disabling automatic *.$DOCKSAL_DNS_DOMAIN DNS resolver..."
 	fi
 
 	is_mac && configure_resolver_mac "$mode" && return $?
@@ -7719,9 +7728,9 @@ fi
 
 # Network settings
 
-# Do not configure internal DNS resolver with Docker Desktop for Windows
-# Use the external docksal.site domain instead of the internal one. This is necessary to have a working setup
-# out of the box without the need to ask the user to manually configure DNS records using "fin hosts".
+# Disable internal DNS resolver and use external domain with Docker Desktop for Windows
+# This is necessary to have a working setup out of the box without the need to ask the user to manually configure DNS
+# records using "fin hosts".
 # See https://github.com/docksal/docksal/issues/1276
 if is_wsl && is_docker_native; then
 	# Only proceed if DOCKSAL_DNS_DOMAIN was not explicitly set (matches the default)
@@ -7732,6 +7741,12 @@ if is_wsl && is_docker_native; then
 			export DOCKSAL_DNS_DOMAIN=docksal.site
 		fi
 	fi
+fi
+
+# Disable internal DNS resolver and use external domain if docksal-dns is disabled
+if [[ "$DOCKSAL_DNS_DISABLED" == "1" ]]; then
+	export DOCKSAL_NO_DNS_RESOLVER=1
+	export DOCKSAL_DNS_DOMAIN=docksal.site
 fi
 
 # DOCKSAL_IP - Docker/VM IP

--- a/docs/content/fin/fin-help.md
+++ b/docs/content/fin/fin-help.md
@@ -8,7 +8,7 @@ aliases:
 ## fin {#fin}
 
 	
-	Docksal command line utility v1.96.0
+	Docksal command line utility v1.97.0
 	
 	Usage: fin <command>
 	

--- a/docs/content/fin/fin-help.md
+++ b/docs/content/fin/fin-help.md
@@ -8,7 +8,7 @@ aliases:
 ## fin {#fin}
 
 	
-	Docksal command line utility v1.95.0
+	Docksal command line utility v1.96.0
 	
 	Usage: fin <command>
 	

--- a/docs/content/fin/fin-help.md
+++ b/docs/content/fin/fin-help.md
@@ -8,7 +8,7 @@ aliases:
 ## fin {#fin}
 
 	
-	Docksal command line utility v1.97.0
+	Docksal command line utility v1.98.0
 	
 	Usage: fin <command>
 	

--- a/docs/content/fin/fin-help.md
+++ b/docs/content/fin/fin-help.md
@@ -8,7 +8,7 @@ aliases:
 ## fin {#fin}
 
 	
-	Docksal command line utility v1.98.0
+	Docksal command line utility v1.99.0
 	
 	Usage: fin <command>
 	

--- a/docs/content/getting-started/setup.md
+++ b/docs/content/getting-started/setup.md
@@ -66,9 +66,9 @@ Click the preferred option to proceed to option-specific docs.
 
 With this method, Docker will run inside a VM in VirtualBox.
 
-1. Install VirtualBox v5.2.32
+1. Install VirtualBox v6.1.10
 
-    [![Download VirtualBox v5.2.32](https://img.shields.io/badge/download-VirtualBox%20for%20Mac-blue.svg?logo=dropbox&style=for-the-badge&classes=inline)](http://download.virtualbox.org/virtualbox/5.2.32/VirtualBox-5.2.32-132073-OSX.dmg)
+    [![Download VirtualBox v6.1.10](https://img.shields.io/badge/download-VirtualBox%20for%20Mac-blue.svg?logo=dropbox&style=for-the-badge&classes=inline)](https://download.virtualbox.org/virtualbox/6.1.10/VirtualBox-6.1.10-138449-OSX.dmg)
 
 1. Enable Kernel extension ([Why?](https://developer.apple.com/library/content/technotes/tn2459/_index.html))
 
@@ -88,13 +88,14 @@ With this method, Docker will run inside a VM in VirtualBox.
 ### macOS with Docker Desktop {#install-macos-docker-for-mac}
 
 {{% notice warning %}}
-Docker Desktop v2.2.0.0+ versions introduced a regression that breaks Docksal. Please refrain from updating and stick 
-with the version linked below.
+Starting with Docker Desktop v2.2.0.0+, the eTDL (base domain) for Docksal projects had to be changed from `docksal` to 
+`docksal.site`. If this change has adverse effects for your project(s), you can downgrade Docker Desktop 
+to [v2.1.0.5](https://download.docker.com/mac/stable/40693/Docker.dmg) as a temporary measure.
 {{% /notice %}}
 
-1. Install Docker Desktop for Mac v2.1.0.4
+1. Install Docker Desktop for Mac v2.3.0.3
 
-    [![Docker Desktop for Mac v2.1.0.4](https://img.shields.io/badge/download-Docker%20Desktop%20for%20Mac-blue.svg?logo=docker&style=for-the-badge&classes=inline)](https://download.docker.com/mac/stable/39773/Docker.dmg) <!-- when changing this version please change https://github.com/docksal/docksal.io/tree/master/src/pages/installation.js as well -->
+    [![Docker Desktop for Mac v2.3.0.3](https://img.shields.io/badge/download-Docker%20Desktop%20for%20Mac-blue.svg?logo=docker&style=for-the-badge&classes=inline)](https://download.docker.com/mac/stable/45519/Docker.dmg) <!-- when changing this version please change https://github.com/docksal/docksal.io/tree/master/src/pages/installation.js as well -->
 
 1. Start Docker Desktop
 
@@ -186,8 +187,9 @@ Click the preferred option to proceed to option-specific docs.
 ### Windows and Docker Desktop {#install-windows-docker-for-windows} 
 
 {{% notice warning %}}
-Docker Desktop v2.2.0.0+ versions introduced a regression that breaks Docksal. Please refrain from updating and stick 
-with the version linked below.
+Starting with Docker Desktop v2.2.0.0+, the eTDL (base domain) for Docksal projects had to be changed from `docksal` to 
+`docksal.site`. If this change has adverse effects for your project(s), you can downgrade Docker Desktop 
+to [v2.1.0.5](https://download.docker.com/win/stable/40693/Docker%20Desktop%20Installer.exe) as a temporary measure. 
 {{% /notice %}}
 
 1. Enable Windows Subsystem for Linux (WSL) support
@@ -198,9 +200,9 @@ with the version linked below.
 
     [![Ubuntu App for Windows](https://img.shields.io/badge/Ubuntu%2018.04%20App-orange.svg?logo=ubuntu&style=for-the-badge&classes=inline)](https://www.microsoft.com/en-us/p/ubuntu-1804-lts/9n9tngvndl3q)
 
-3. Install Docker Desktop for Windows v2.1.0.3
+3. Install Docker Desktop for Windows v2.3.0.3
 
-    [![Docker Desktop for Windows v2.1.0.3](https://img.shields.io/badge/download-Docker%20Desktop%20for%20Windows-blue.svg?logo=docker&style=for-the-badge&classes=inline)](https://download.docker.com/win/stable/38240/Docker%20Desktop%20Installer.exe) <!-- when changing this version please change https://github.com/docksal/docksal.io/tree/master/src/pages/installation.js as well -->
+    [![Docker Desktop for Windows v2.3.0.3](https://img.shields.io/badge/download-Docker%20Desktop%20for%20Windows-blue.svg?logo=docker&style=for-the-badge&classes=inline)](https://download.docker.com/win/stable/45519/Docker%20Desktop%20Installer.exe) <!-- when changing this version please change https://github.com/docksal/docksal.io/tree/master/src/pages/installation.js as well -->
     
 4. Configure Docker Desktop on Windows
 

--- a/docs/content/stack/configuration-variables.md
+++ b/docs/content/stack/configuration-variables.md
@@ -95,6 +95,31 @@ This is automatically set to `0.0.0.0` (meaning "listen on all network interface
 Override the default DNS server that Docksal uses. For environments where access to Google DNS server (`8.8.8.8`) 
 is blocked, it should be set to the LAN DNS server. This is often true for VPN users or users behind a corporate firewall.
 
+### DOCKSAL_NO_DNS_RESOLVER
+
+`Default: 0`
+
+Set to `1` and run `fin system reset` to disable the DNS resolver configuration.
+
+This can be used if there are issues with DNS resolution on the host machine while running Docksal.
+
+Also check `DOCKSAL_DNS_DISABLED` as it may be a better option than just disabling the host resolver configuration.
+
+### DOCKSAL_DNS_DISABLED
+
+`Default: 0`
+
+Set to `1` and do `fin system reset` to disable the `docksal-dns` built-in service and switch to using the public 
+`.docksal.site` base domain. This automatically sets `DOCKSAL_DNS_DOMAIN=docksal.site` and  `DOCKSAL_NO_DNS_RESOLVER=1`.
+
+Useful when `docksal-dns` is conflicting with corporate rules or if some other software restricts it 
+(`0.0.0.0:53: bind: address already in use`). 
+
+Projects that do not override the `VIRTUAL_HOST` variable will switch to the new `docksal.site` base domain after running 
+`fin project restart`. Projects that hardcode `VIRTUAL_HOST` will either need to update the value 
+(e.g., `VIRTUAL_HOST=myproject.docksal.site`) or use [fin hosts](/fin/fin-help/#hosts) command to manage host records. 
+semi-automatic mode.
+
 ### DOCKSAL_HEALTHCHECK_TIMEOUT
 
 `Default: 60`
@@ -116,10 +141,6 @@ This is usually good in combination with `CI=true`.
 **macOS only.**  
 Sets the location of the folder on the host machine to mount to VirtualBox or Docker Desktop with NFS. 
 See [file sharing](/core/file-sharing/) for more information.
-
-### DOCKSAL_NO_DNS_RESOLVER
-
-Allow disabling the DNS resolver configuration (in case there are issues with it). Set to `true` to activate.
 
 ### DOCKSAL_SSH_AGENT_USE_HOST
 


### PR DESCRIPTION
## 1.14.1 (2020-07-20)

### New software versions

- fin v1.99.0

### New features

- Updated projects to include Drupal 9 boilerplate projects (#1385)

### Changes and improvements

- Reverted back to using IP binding for system services with VirtualBox/boot2docker
  - Only use `0.0.0.0` for vhost-proxy and dns with Docker Desktop 2.2.0.0+ on Mac/Windows
- Adjusted DNS settings for containers
  - When `docksal-dns` is disabled, use DOCKSAL_DNS_UPSTREAM / DOCKSAL_DEFAULT_DNS as primary DNS
- Bump `REQUIREMENTS_DOCKER_DESKTOP` to 2.1.0.5
  - This is the last version before networking regressions were introduced (#1268)
- Split docker versions based on environment (Linux, Docker Desktop, Boo2docker)
  - `REQUIREMENTS_DOCKER='19.03.9'` - this is the earliest version available for Ubuntu 20.04 (focal) LTS
  - `REQUIREMENTS_DOCKER_DD='19.03.8'` - this is the latest version available with Docker Desktop
  - `REQUIREMENTS_DOCKER_B2D='19.03.5'` - this is the final boot2docker version
  - Removed `REQUIREMENTS_DOCKER_DEBIAN`
- Better handling of `ID_LIKE` in `is_debian` (#1377)
- Added "DOCKSAL: NETWORKING" sections in sysinfo …
  - Replaced "DOCKSAL: DNS"
  - Prints network config variables
  - Added check for DNS resolution/connectivity from containers (and not only host)
- Added dns settings for run-cli

### Documentation

- Updated versions in setup docs
  - Added a note in setup docs about Docker Desktop version regressions
