### PR TITLE
Added docs for missing SSE4.2 CPU instruction set

### DIFF
--- a/docs/content/getting-started/setup.md
+++ b/docs/content/getting-started/setup.md
@@ -22,6 +22,8 @@ CPU with SSE4.2 instruction set supported (most CPUs). If you get output from th
 cat /proc/cpuinfo | grep sse4_2
 ``` 
 
+If the output is empty, see the [troubleshooting](../troubleshooting/common-issues.md#sse4_2) docs for a workaround.  
+
 ### Windows
 
 Windows 10 and CPU with hardware virtualization (**VT-x/AMD-V**) supported and [enabled in BIOS](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Virtualization_Administration_Guide/sect-Virtualization-Troubleshooting-Enabling_Intel_VT_and_AMD_V_virtualization_hardware_extensions_in_BIOS.html).

--- a/docs/content/getting-started/setup.md
+++ b/docs/content/getting-started/setup.md
@@ -22,7 +22,7 @@ CPU with SSE4.2 instruction set supported (most CPUs). If you get output from th
 cat /proc/cpuinfo | grep sse4_2
 ``` 
 
-If the output is empty, see the [troubleshooting](../troubleshooting/common-issues.md#sse4_2) docs for a workaround.  
+If the output is empty, see the [troubleshooting](/troubleshooting/common-issues#sse4_2) docs for a workaround.  
 
 ### Windows
 

--- a/docs/content/troubleshooting/common-issues.md
+++ b/docs/content/troubleshooting/common-issues.md
@@ -424,8 +424,7 @@ fin system reset vhost-proxy
 ```
 
 {{% notice warning %}}
-There is no guarantee that pinning the vhost-proxy image long term won't result in incompatibility issues with 
-the latest versions of Docksal.
+There is no guarantee that pinning the vhost-proxy image won't result in incompatibility issues with the latest versions of Docksal.
 {{% /notice %}}
 
 Long term fix: consider switching to a host with a modern CPU with SSE 4.2 support.

--- a/docs/content/troubleshooting/common-issues.md
+++ b/docs/content/troubleshooting/common-issues.md
@@ -400,3 +400,32 @@ Grant **Full Disk Access** privileges  to `/sbin/nfsd`:
 Alternatively, you can move the project's codebase out of the restricted user folder (not helpful for external disks).
 
 See [blog post](https://blog.docksal.io/nfs-access-issues-on-macos-10-15-catalina-75cd23606913) for more details.
+
+
+## Issue 17. Host CPU does not support SSE 4.2 instruction set {#sse4_2}
+
+Symptoms:
+
+- `vhost-proxy` won't start
+- `fin docker exet -it docker-vhost-proxy nginx -t` outputs `Illegal instruction (core dumped)`
+- Output from `cat /proc/cpuinfo | grep sse4_2` on the host is empty. 
+
+Docksal's [vhost-proxy](../core/system-vhost-proxy.md) system service uses [OpenResty](https://github.com/openresty/openresty) 
+under the hood. The official OpenResty binary packages [require](https://github.com/openresty/openresty/issues/267#issuecomment-309296900) 
+SSE4.2 support in the host CPU.
+
+### How to Resolve
+
+As a temporary workaround, vhost-proxy can be downgraded to version 1.2:
+
+```bash
+fin config set --global IMAGE_VHOST_PROXY=docksal/vhost-proxy:1.2
+fin system reset vhost-proxy
+```
+
+{{% notice warning %}}
+There is no guarantee that pinning the vhost-proxy image long term won't result in incompatibility issues with 
+the latest versions of Docksal.
+{{% /notice %}}
+
+Long term fix: consider switching to a host with a modern CPU with SSE 4.2 support.

--- a/docs/content/troubleshooting/common-issues.md
+++ b/docs/content/troubleshooting/common-issues.md
@@ -410,7 +410,7 @@ Symptoms:
 - `fin docker exet -it docker-vhost-proxy nginx -t` outputs `Illegal instruction (core dumped)`
 - Output from `cat /proc/cpuinfo | grep sse4_2` on the host is empty. 
 
-Docksal's [vhost-proxy](../core/system-vhost-proxy.md) system service uses [OpenResty](https://github.com/openresty/openresty) 
+Docksal's [vhost-proxy](/core/system-vhost-proxy) system service uses [OpenResty](https://github.com/openresty/openresty) 
 under the hood. The official OpenResty binary packages [require](https://github.com/openresty/openresty/issues/267#issuecomment-309296900) 
 SSE4.2 support in the host CPU.
 


### PR DESCRIPTION
Added docs for missing SSE4.2 CPU instruction set.

Preview: https://deploy-preview-1414--docs-docksal-io.netlify.app/troubleshooting/common-issues#sse4_2