### PR TITLE
Added "none" stack type for projects just interested in DNS and Proxy

### DIFF
--- a/stacks/stack-none.yml
+++ b/stacks/stack-none.yml
@@ -1,0 +1,5 @@
+# Blank stack
+#
+# Useful for custom docker-compose needs that want to use Docksal DNS and Proxy
+
+version: "2.1"


### PR DESCRIPTION
Team, thank you first of all for Docksal. It has been immeasurably valuable to my teams. I have read [How to Contribute](https://github.com/docksal/docksal/blob/develop/CONTRIBUTING.md) and hope you will find this contribution valuable.

This simple PR introduces a "none" stack type for those that love your DNS and Vhost Proxy solution but that don't want to use the otherwise required CLI service. I tried this locally and it works exactly as I intend for a containerized Ansible development platform to replace the resource-costly VirtualBox. I am currently abusing the `node` stack type and overriding the CLI service, but would love a `none` type as is possible with `DOCKSAL_VOLUMES` to permit me to discontinue use of the `cli`-named service.

It may feel simply decorative, but there have been a few cases in my development where a "default CLI container" didn't feel right and we wind up setting `cli` to use a default alpine image so it will just auto-exit bash on project start.