### PR TITLE
Fix Dockerfile example to use proper shell

### DIFF
--- a/docs/content/stack/extend-images.md
+++ b/docs/content/stack/extend-images.md
@@ -66,6 +66,7 @@ RUN \
 
 # All further commands will be performed as the docker user.
 USER docker
+SHELL ["/bin/bash", "-c"]
 
 # Install additional global npm dependencies
 RUN \


### PR DESCRIPTION
Let example use bash as default shell as long as docksal relies on it everywhere

If it's not a bash then it produces errors like this on container creation phase:
![image](https://user-images.githubusercontent.com/8169225/96444258-a0b92200-1216-11eb-89c9-8856c19e4fef.png)

