### PR TITLE
Support for branch name in "fin project create"

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -3403,7 +3403,7 @@ project_create ()
 	echo -e "${green}Cloning repository...${NC}"
 	run_cli git clone \
 		$( [[ "${target_branch}" != "" ]] && echo "--branch=${target_branch}" ) \
-		"${target_repo}" "${project_name}" --depth=1
+		"${target_repo}" "${project_name}" --depth=1 --no-tags
 	[[ $? != 0 ]] && _confirm "Checkout finished with errors. Do you wish to continue?"
 
 	cd "${project_name}"

--- a/bin/fin
+++ b/bin/fin
@@ -3404,7 +3404,7 @@ project_create ()
 	run_cli git clone \
 		$( [[ "${target_branch}" != "" ]] && echo "--branch=${target_branch}" ) \
 		"${target_repo}" "${project_name}" --depth=1 --no-tags
-	[[ $? != 0 ]] && _confirm "Checkout finished with errors. Do you wish to continue?"
+	[[ $? != 0 ]] && _confirm "Checkout finished with errors. Do you wish to continue with project init?"
 
 	cd "${project_name}"
 

--- a/bin/fin
+++ b/bin/fin
@@ -1844,6 +1844,8 @@ show_help_project() {
 	printh "" "Drupal, Wordpress, Magento, Laravel, Backdrop, Hugo, Gatsby, and others"
 	printh "  --name=name" "Provide project name upfront"
 	printh "  --choice=#" "Provide software choice number upfront"
+	printh "  --repo=name" "Clone from a custom repo: name (--choice is set to '0' automatically)"
+	printh "  --branch=name" "Clone from a custom repo: branch name (optional)"
 	printh "  --yes (-y)" "Avoid confirmation"
 	echo
 	printh "config" "Show project configuration"
@@ -3198,8 +3200,11 @@ project_create ()
 
 	# Read repo from params if available
 	if [[ "$repo" != "" ]]; then
-		local target_repo="$repo"
 		local choice="0"
+		local target_repo="$repo"
+		# Read branch from params if available
+		local target_branch
+		[[ "$branch" != "" ]] && target_branch="$branch"
 	fi
 
 	# Determine project name
@@ -3376,6 +3381,7 @@ project_create ()
 	echo -e "Project folder:   ${yellow}$(pwd)/$project_name${NC}"
 	echo -e "Project software: ${yellow}${target_cms}${NC}"
 	echo -e "Source repo:      ${yellow}${target_repo}${NC}"
+	echo -e "Source branch:    ${yellow}${target_branch:-<default>}${NC}"
 	echo -e "Project URL:      ${yellow}http://${project_virtual_host_name}${NC}"
 	echo
 
@@ -3395,8 +3401,10 @@ project_create ()
 	fi
 
 	echo -e "${green}Cloning repository...${NC}"
-	run_cli git clone -b master "${target_repo}" "${project_name}" --depth=1
-	[ ! $? -eq 0 ] && _confirm "Checkout finished with errors. Do you wish to continue?"
+	run_cli git clone \
+		$( [[ "${target_branch}" != "" ]] && echo "--branch=${target_branch}" ) \
+		"${target_repo}" "${project_name}" --depth=1
+	[[ $? != 0 ]] && _confirm "Checkout finished with errors. Do you wish to continue?"
 
 	cd "${project_name}"
 

--- a/docs/content/fin/fin-help.md
+++ b/docs/content/fin/fin-help.md
@@ -78,6 +78,8 @@ aliases:
 	                           	Drupal, Wordpress, Magento, Laravel, Backdrop, Hugo, Gatsby, and others
 	    --name=name            	Provide project name upfront
 	    --choice=#             	Provide software choice number upfront
+	    --repo=name            	Clone from a custom repo: name (--choice is set to '0' automatically)
+	    --branch=name          	Clone from a custom repo: branch name (optional)
 	    --yes (-y)             	Avoid confirmation
 	
 	  config                   	Show project configuration
@@ -363,7 +365,7 @@ aliases:
 	
 	View output from containers.
 	
-	Usage: logs [options] [SERVICE...]
+	Usage: logs [options] [--] [SERVICE...]
 	
 	Options:
 	    --no-color          Produce monochrome output.


### PR DESCRIPTION
Resolves #1435 

- Added support for branch name in fin project create
- Regenerated fin help docs

Example:

```
$ fin project create --name=myd8 --repo=git@github.com:docksal/boilerplate-drupal8.git --branch=feature/circleci

Project folder:   /Users/leonid/Work/Labs/docksal/docksal/myd8
Project software: Custom git repository
Source repo:      git@github.com:docksal/boilerplate-drupal8.git
Source branch:    feature/circleci
Project URL:      http://myd8.docksal

Do you wish to proceed? [y/n]:
```