### PR TITLE
Create stack-platformsh.yml

### DIFF
--- a/stacks/stack-platformsh.yml
+++ b/stacks/stack-platformsh.yml
@@ -33,7 +33,7 @@ services:
     # Pin PHP version
     image: ${CLI_IMAGE:=docksal/cli:stable-php7.4}
 
-redis:
+  redis:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml
       service: redis

--- a/stacks/stack-platformsh.yml
+++ b/stacks/stack-platformsh.yml
@@ -1,0 +1,41 @@
+# Platform.sh alike stack
+# see https://github.com/platformsh-templates/drupal9
+#
+# - Nginx 1.14
+# - MariaDB 10.3
+# - PHP 7.4
+# - Redis 6.0
+
+version: "2.1"
+
+services:
+  # http(s)://VIRTUAL_HOST
+  web:
+    extends:
+      file: ${HOME}/.docksal/stacks/services.yml
+      service: nginx
+    # Pin nginx version
+    image: ${WEB_IMAGE:-docksal/nginx:1.14-edge}
+    depends_on:
+      - cli
+
+  db:
+    extends:
+      file: ${HOME}/.docksal/stacks/services.yml
+      service: mariadb
+    # Pin MariaDB version
+    image: ${DB_IMAGE:-docksal/mariadb:10.3-1.1}
+
+  cli:
+    extends:
+      file: ${HOME}/.docksal/stacks/services.yml
+      service: cli
+    # Pin PHP version
+    image: ${CLI_IMAGE:=docksal/cli:stable-php7.4}
+
+redis:
+    extends:
+      file: ${HOME}/.docksal/stacks/services.yml
+      service: redis
+    # Pin Redis version
+    image: ${REDIS_IMAGE:-wodby/redis:6.0}


### PR DESCRIPTION
Create a docksal stack alike the Platform.sh stack, based on their recommended defaults in [platformsh-template for Drupal 9](https://github.com/platformsh-templates/drupal9).

They use MariaDB 10.4, but using 10.3 here until https://github.com/docksal/service-mariadb/pull/9 is merged

We try to keep our project environments up to date with platformsh's templates, so it seems to make sense there is a stack to use rather than overriding services and images each time.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docksal/docksal/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Write a short summary that describes the changes in this pull request:
-->
