### PR TITLE
Make healthcheck interval configurable

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -279,7 +279,8 @@ else
 	DOCKSAL_SSH_AGENT_USE_HOST="${DOCKSAL_SSH_AGENT_USE_HOST:-0}"
 fi
 
-# Healthcheck timeout
+# Project healthcheck timeout
+# Total time (seconds) before the _project_ healthcheck is considered failed
 DOCKSAL_HEALTHCHECK_TIMEOUT=${DOCKSAL_HEALTHCHECK_TIMEOUT:-60}
 
 # Logging settings
@@ -1495,32 +1496,32 @@ _vhost_proxy_connect ()
 # https://github.com/docksal/docksal/issues/225#issuecomment-306604063
 _healthcheck_wait ()
 {
-	local delay=5
-	local timeout=$DOCKSAL_HEALTHCHECK_TIMEOUT
+	local delay=5 # Delay (seconds) before rerunning the check
+	local timeout=${DOCKSAL_HEALTHCHECK_TIMEOUT} # Total time (seconds) before the healthcheck is considered failed
 	local elapsed=0
 	local status=""
-	local FILTER="label=com.docker.compose.project=$COMPOSE_PROJECT_NAME"
+	local FILTER="label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}"
 
 	sleep 1 # Small sleep to give quick containers time to start
-	status=$(docker ps --filter "$FILTER" --format '{{ .Status }}')
+	status=$(docker ps --filter "${FILTER}" --format '{{ .Status }}')
 
 	# While one or more containers are starting wait for them
-	while [[ "$status" =~ "(health: starting)" ]]; do
+	while [[ "${status}" =~ "(health: starting)" ]]; do
 		echo "Waiting for project stack to become ready..."
-		sleep "$delay";
+		sleep ${delay};
 		elapsed=$((elapsed + delay))
 		if ((elapsed > timeout)); then
 			echo-error "Project heathcheck has timed out" \
-				"One or more containers did not enter a healthy state within $timeout seconds of the project start." \
+				"One or more containers did not enter a healthy state within ${timeout} seconds of the project start." \
 				"See ${yellow}fin project status${NC} for details" \
 				"Check ${yellow}fin logs${NC} for more details"
 			return 1
 		fi
-		status=$(docker ps --filter "$FILTER" --format '{{ .Status }}')
+		status=$(docker ps --filter "${FILTER}" --format '{{ .Status }}')
 	done
 
-	# All contaners have started, check the final status
-	if [[ "$status" =~ "(health: unhealthy)" ]]; then
+	# All containers have started, check the final status
+	if [[ "${status}" =~ "(health: unhealthy)" ]]; then
 		echo-error "One or more containers are not healthy" \
 			"See ${yellow}fin project status${NC} for details"
 			"This is most likely due to a project misconfiguration."

--- a/bin/fin
+++ b/bin/fin
@@ -283,9 +283,14 @@ fi
 # Total time (seconds) before the _project_ healthcheck is considered failed
 DOCKSAL_HEALTHCHECK_TIMEOUT=${DOCKSAL_HEALTHCHECK_TIMEOUT:-60}
 
-# Logging settings
+# Container Logging settings
 DOCKSAL_CONTAINER_LOG_MAX_SIZE=${DOCKSAL_CONTAINER_LOG_MAX_SIZE:-1m}
 DOCKSAL_CONTAINER_LOG_MAX_FILE=${DOCKSAL_CONTAINER_LOG_MAX_FILE:-10}
+
+# Container healthcheck settings
+# Default health-interval option for all containers
+# Note: Setting this too low (<5s) will result in a considerable load with lots of running containers (20+)
+DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL=${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL:-10s}
 
 #---------------------------- URL references --------------------------------
 GITHUB_API="https://api.github.com"
@@ -3970,6 +3975,7 @@ install_proxy_service ()
 		${mount_certs} \
 		--log-opt max-size=${DOCKSAL_CONTAINER_LOG_MAX_SIZE} \
 		--log-opt max-file=${DOCKSAL_CONTAINER_LOG_MAX_FILE} \
+		--health-interval=${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL} \
 		"${IMAGE_VHOST_PROXY}" >/dev/null
 	if_failed_error "Failed starting the proxy service."
 }
@@ -4061,6 +4067,7 @@ install_dns_service ()
 		--mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
 		--log-opt max-size=${DOCKSAL_CONTAINER_LOG_MAX_SIZE} \
 		--log-opt max-file=${DOCKSAL_CONTAINER_LOG_MAX_FILE} \
+		--health-interval=${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL} \
 		"${IMAGE_DNS}" >/dev/null
 	if_failed_error "Failed starting the DNS service."
 }
@@ -4253,6 +4260,7 @@ install_sshagent_service ()
 		--mount type=volume,src=docksal_ssh_agent,dst=/.ssh-agent \
 		--log-opt max-size=${DOCKSAL_CONTAINER_LOG_MAX_SIZE} \
 		--log-opt max-file=${DOCKSAL_CONTAINER_LOG_MAX_FILE} \
+		--health-interval=${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL} \
 		"${IMAGE_SSH_AGENT}" $ssh_service_args >/dev/null
 	if_failed_error "Failed starting the SSH agent service."
 
@@ -7975,6 +7983,9 @@ export MYSQL_DATABASE=${MYSQL_DATABASE:-default}
 # Container logging settings
 export DOCKSAL_CONTAINER_LOG_MAX_SIZE
 export DOCKSAL_CONTAINER_LOG_MAX_FILE
+
+# Container healthcheck settings
+export DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL
 
 # Handle Alias
 if [[ "$1" == "@"* ]]; then

--- a/bin/fin
+++ b/bin/fin
@@ -3968,8 +3968,8 @@ install_proxy_service ()
 		--mount type=volume,src=docksal_projects,dst=/projects \
 		--mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
 		${mount_certs} \
-        	--log-opt max-size=${DOCKSAL_CONTAINER_LOG_MAX_SIZE} \
-        	--log-opt max-file=${DOCKSAL_CONTAINER_LOG_MAX_FILE} \
+		--log-opt max-size=${DOCKSAL_CONTAINER_LOG_MAX_SIZE} \
+		--log-opt max-file=${DOCKSAL_CONTAINER_LOG_MAX_FILE} \
 		"${IMAGE_VHOST_PROXY}" >/dev/null
 	if_failed_error "Failed starting the proxy service."
 }
@@ -4059,6 +4059,8 @@ install_dns_service ()
 		-p "${DOCKSAL_DNS_IP:-$DOCKSAL_IP}:53:53/udp" --cap-add=NET_ADMIN --dns="$DOCKSAL_DNS_UPSTREAM" --dns="9.9.9.9" \
 		-e DNS_IP="$DOCKSAL_IP" -e DNS_DOMAIN="$DOCKSAL_DNS_DOMAIN" -e LOG_QUERIES="$DOCKSAL_DNS_DEBUG" \
 		--mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
+		--log-opt max-size=${DOCKSAL_CONTAINER_LOG_MAX_SIZE} \
+		--log-opt max-file=${DOCKSAL_CONTAINER_LOG_MAX_FILE} \
 		"${IMAGE_DNS}" >/dev/null
 	if_failed_error "Failed starting the DNS service."
 }
@@ -4249,6 +4251,8 @@ install_sshagent_service ()
 	docker volume create --name docksal_ssh_agent >/dev/null 2>&1
 	docker run -d --name docksal-ssh-agent --label "io.docksal.group=system" --restart=unless-stopped \
 		--mount type=volume,src=docksal_ssh_agent,dst=/.ssh-agent \
+		--log-opt max-size=${DOCKSAL_CONTAINER_LOG_MAX_SIZE} \
+		--log-opt max-file=${DOCKSAL_CONTAINER_LOG_MAX_FILE} \
 		"${IMAGE_SSH_AGENT}" $ssh_service_args >/dev/null
 	if_failed_error "Failed starting the SSH agent service."
 

--- a/docs/content/stack/configuration-variables.md
+++ b/docs/content/stack/configuration-variables.md
@@ -73,6 +73,13 @@ The number of docker log files that should be kept before they are removed.
 
 The size of the docker logs before they are rotated.
 
+### DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL
+
+`Default: 10s`
+
+Can be used to increase container healthcheck interval and thus help with excessive load produced by healthchecks from 
+many concurrently running containers.
+
 ### DOCKSAL_DNS_DOMAIN
 
 `Default: docksal`

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -28,6 +28,8 @@ services:
       options:
         max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
         max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
+    healthcheck:
+      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
 
   # Web: Apache (DEPRECATED)
   # TODO: remove November 2019
@@ -53,6 +55,8 @@ services:
       options:
         max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
         max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
+    healthcheck:
+      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
 
   # Web: Nginx
   nginx:
@@ -78,6 +82,8 @@ services:
       options:
         max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
         max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
+    healthcheck:
+      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
 
   # DB: MySQL
   mysql:
@@ -104,6 +110,8 @@ services:
       options:
         max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
         max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
+    healthcheck:
+      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
 
   # DB: MySQL
   mariadb:
@@ -130,6 +138,8 @@ services:
       options:
         max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
         max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
+    healthcheck:
+      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
 
   # DB: PostgreSQL
   pgsql:
@@ -151,6 +161,8 @@ services:
       options:
         max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
         max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
+    healthcheck:
+      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
 
   # CLI - Used for all console commands and tools.
   cli:
@@ -203,6 +215,8 @@ services:
       options:
         max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
         max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
+    healthcheck:
+      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
 
   # Varnish
   varnish:
@@ -222,6 +236,8 @@ services:
       options:
         max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
         max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
+    healthcheck:
+      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
 
   # Memcached
   memcached:
@@ -235,6 +251,8 @@ services:
       options:
         max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
         max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
+    healthcheck:
+      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
 
   # Redis
   redis:
@@ -250,6 +268,8 @@ services:
       options:
         max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
         max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
+    healthcheck:
+      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
 
   # Solr
   solr:
@@ -268,6 +288,8 @@ services:
       options:
         max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
         max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
+    healthcheck:
+      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
 
   # MailHog
   mail:
@@ -286,6 +308,8 @@ services:
       options:
         max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
         max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
+    healthcheck:
+      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
 
   # Blackfire
   blackfire:
@@ -293,6 +317,8 @@ services:
     environment:
       - BLACKFIRE_SERVER_ID
       - BLACKFIRE_SERVER_TOKEN
+    healthcheck:
+      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
 
   # Elastic Search
   elasticsearch:
@@ -315,4 +341,5 @@ services:
       options:
         max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
         max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
-
+    healthcheck:
+      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}


### PR DESCRIPTION
- Added `DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL` variable
  - Default: `10s` (was `5s`, set in individual container image Docketfile's)
  - Can be used to increase container healthcheck interval and thus help reduce idle load produced by healthchecks

Resolves #1453 