### PR TITLE
Updating cli version to latest

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -350,7 +350,7 @@ URL_WINPTY="https://github.com/rprichard/winpty/releases/download/${REQUIREMENTS
 IMAGE_SSH_AGENT=${IMAGE_SSH_AGENT:-docksal/ssh-agent:1.3}
 IMAGE_VHOST_PROXY=${IMAGE_VHOST_PROXY:-docksal/vhost-proxy:1.6}
 IMAGE_DNS=${IMAGE_DNS:-docksal/dns:1.1}
-IMAGE_RUN_CLI=${IMAGE_RUN_CLI:-docksal/cli:2.11-php7.3}
+IMAGE_RUN_CLI=${IMAGE_RUN_CLI:-docksal/cli:2.13-php7.3}
 
 #---------------------------- Helper functions --------------------------------
 

--- a/docs/content/stack/images-versions.md
+++ b/docs/content/stack/images-versions.md
@@ -47,8 +47,8 @@ In you custom stacks or custom Dockerfiles you can use this latest image tags.
 
 | Image| Notes |
 |------|-------|
-| `docksal/cli:2.11-php7.4` | PHP 7.4, Nodejs 14.15.0, Ruby 2.7.2, Python 3.8.3, msmtp |
-| `docksal/cli:2.11-php7.3` | *Default image* PHP 7.3, Nodejs 12.18.1, Ruby 2.7.1, Python 3.8.3, msmtp |
+| `docksal/cli:2.13-php7.4` | PHP 7.4, Nodejs 14.15.0, Ruby 2.7.2, Python 3.8.3, msmtp |
+| `docksal/cli:2.13-php7.3` | *Default image* PHP 7.3, Nodejs 12.18.1, Ruby 2.7.1, Python 3.8.3, msmtp |
 | `docksal/cli:2-php7.4`    | Latest 2.x image version of PHP 7.4 flavor, convenient when [extending images](/stack/extend-images)
 | `docksal/cli:2-php7.3`    | Latest 2.x image version of PHP 7.3 flavor, convenient when [extending images](/stack/extend-images)
 | `docksal/cli:2.11-php7.2` | *Deprecated* PHP 7.2, Nodejs 12.18.1, Ruby 2.7.1, Python 3.8.3, msmtp |

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -88,7 +88,7 @@ services:
   # DB: MySQL
   mysql:
     hostname: db
-    image: ${DB_IMAGE:-docksal/mysql:5.6-1.5}
+    image: ${DB_IMAGE:-docksal/mysql:5.7-1.5}
     ports:
       - "${MYSQL_PORT_MAPPING:-3306}"
     volumes:

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -167,7 +167,7 @@ services:
   # CLI - Used for all console commands and tools.
   cli:
     hostname: cli
-    image: ${CLI_IMAGE:-docksal/cli:2.12-php7.3}
+    image: ${CLI_IMAGE:-docksal/cli:2.13-php7.3}
     volumes:
       - project_root:/var/www:rw,nocopy,cached  # Project root volume
       - docksal_ssh_agent:/.ssh-agent:ro  # Shared ssh-agent socket


### PR DESCRIPTION
The updated run-cli is necessary to have access now to Composer 2, which more projects are now updated to require.

The basic service cli update was missed with the last update.