### PR TITLE
Docs fixes

### DIFF
--- a/docs/content/getting-started/setup.md
+++ b/docs/content/getting-started/setup.md
@@ -3,6 +3,7 @@ title: "Install Docksal"
 weight: 1
 aliases:
   - /en/master/getting-started/setup/
+  - /en/master/getting-started/env-setup/
 ---
 
 ## System requirements

--- a/docs/static/robots-disallow.txt
+++ b/docs/static/robots-disallow.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,25 +1,19 @@
 [build]
-# This default build command adds the robots noindex directive to the site headers.
-# It is turned off for only for the production site by using [context.master] below
-# DO NOT REMOVE THIS
-publish = "docs/public"
-functions = "functions"
-command = "cd docs && hugo --enableGitInfo"
+  base = "docs"
+  publish = "docs/public"
+  # This default build command adds a blocking robots.txt file.
+  # It is turned off only for the production site by using [context.master] below.
+  # DO NOT REMOVE THIS
+  command = "mv static/robots-disallow.txt static/robots.txt && hugo --enableGitInfo -b $DEPLOY_PRIME_URL"
 
 [build.environment]
-HUGO_VERSION = "0.50"
+  HUGO_VERSION = "0.50"
 
 [context.production.environment]
-HUGO_BASEURL = "https://docs.docksal.io/"
-HUGO_ENV = "production"
-HUGO_ENABLEGITINFO = "true"
-
-[context.deploy-preview]
-command = "cd docs && hugo --enableGitInfo -b $DEPLOY_PRIME_URL"
-
-[context.branch-deploy]
-command = "cd docs && hugo --enableGitInfo -b $DEPLOY_PRIME_URL"
+  HUGO_BASEURL = "https://docs.docksal.io/"
+  HUGO_ENV = "production"
+  HUGO_ENABLEGITINFO = "true"
 
 [context.master]
-# This context is triggered by the `master` branch and allows search indexing
-command = "cd docs && hugo"
+  # This context is triggered by the `master` branch and allows search indexing
+  command = "hugo"


### PR DESCRIPTION
- Block search engines on feature/version branches of the docs
  - https://feature-docs-rtd-fixes--docs-docksal-io.netlify.app/robots.txt
- Docs: added a redirect for a common old URL used on RTD …
  - https://feature-docs-rtd-fixes--docs-docksal-io.netlify.app/en/master/getting-started/env-setup/ => https://feature-docs-rtd-fixes--docs-docksal-io.netlify.app/getting-started/setup/

Fixes #1447