### PR TITLE
Added option for addons and other files to source the fin file

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -7996,6 +7996,11 @@ export DOCKSAL_CONTAINER_LOG_MAX_FILE
 # Container healthcheck settings
 export DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL
 
+# Allow other scripts to source the fin script
+if [[ "${BASH_SOURCE[0]}" != $0 ]]; then
+	return 0
+fi
+
 # Handle Alias
 if [[ "$1" == "@"* ]]; then
 	USED_ALIAS=${1#@}

--- a/docs/content/fin/custom-commands.md
+++ b/docs/content/fin/custom-commands.md
@@ -199,6 +199,20 @@ Commands are ran in the same exact way as normal except include the folder they 
 fin drupal/updb
 ```
 
+## Reusing fin functions
+
+To reuse some of the functionality within the `fin` command like `parse_params`, `is_linux`, or any of the functions it's possible to source the `fin` file.
+
+Including this in your command or addon would look like the following.
+
+```bash
+# Find the fin command
+fin=`which fin`
+
+# Source the file to use functions
+[[ -f ${fin} ]] && source $fin
+```
+
 ## More Examples
 
 Check the commands directory (examples/.docksal/commands) located in the [Docksal project](https://github.com/docksal/docksal) 

--- a/docs/content/fin/custom-commands.md
+++ b/docs/content/fin/custom-commands.md
@@ -201,7 +201,7 @@ fin drupal/updb
 
 ## Reusing fin functions
 
-To reuse some of the functionality within the `fin` command like `parse_params`, `is_linux`, or any of the functions it's possible to source the `fin` file.
+It is possible to source the `fin` file in order to reuse some of the functionality within the `fin` command like `parse_params`, `is_linux`, or any of the functions.
 
 Including this in your command or addon would look like the following.
 


### PR DESCRIPTION
Added option so that `fin` could be sourced for addons and commands and take advantage of the functions already provided in the main file.

Example of the usage:

```bash
# Find the fin command
fin=`which fin`

# Source the file to use functions
[[ -f ${fin} ]] && source $fin
```