### PR TITLE
fixes spaces in project create for consistency

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -3252,9 +3252,9 @@ project_create ()
 		echo -e "${green}    7.${NC}  Drupal 7"
 		echo -e "${green}    8.${NC}  Wordpress"
 		echo -e "${green}    9.${NC}  Magento"
-		echo -e "${green}    10.${NC}  Laravel"
-		echo -e "${green}    11.${NC}  Symfony Skeleton"
-		echo -e "${green}    12.${NC}  Symfony WebApp"
+		echo -e "${green}    10.${NC} Laravel"
+		echo -e "${green}    11.${NC} Symfony Skeleton"
+		echo -e "${green}    12.${NC} Symfony WebApp"
 		echo -e "${green}    13.${NC} Grav CMS"
 		echo -e "${green}    14.${NC} Backdrop CMS"
 		echo


### PR DESCRIPTION
There were more spaces for 3 of the project types than the rest which made them look off. This PR just removes those spaces for those 3 projects to line them all up.
![wizard](https://user-images.githubusercontent.com/2090502/108242182-7a8e8a80-7101-11eb-82df-8bb9c2034ccb.png)

