### PR TITLE
adds documentation for platformsh alike stack

### DIFF
--- a/docs/content/service/db/options.md
+++ b/docs/content/service/db/options.md
@@ -3,7 +3,7 @@ title: "db: Service Options"
 weight: 1
 ---
 
-The default stack uses MySQL for the db service while the pantheon stack uses MariaDB.
+The default stack uses MySQL for the db service while the pantheon and platformsh stacks use MariaDB.
 Docksal has also defined PostreSQL as a db service option. You do not have to make any
 configuration changes to use MySQL, but if you want to specify the use of MariaDB or PostreSQL,
 you will need to modify your `docksal.yml` file.

--- a/docs/content/service/web/options.md
+++ b/docs/content/service/web/options.md
@@ -3,7 +3,7 @@ title: "web: Service Options"
 weight: 1
 ---
 
-The default stack uses Apache for the db service while the pantheon stack uses nginx.
+The default stack uses Apache for the db service while the pantheon and platformsh stacks use nginx.
 If you use the default stack, you do not have to make any configuration changes to use Apache, but 
 if you want to specify the use of nginx, you will need to modify your `docksal.yml` file.
 

--- a/docs/content/stack/understanding-stack-config.md
+++ b/docs/content/stack/understanding-stack-config.md
@@ -66,6 +66,7 @@ These files are a good reference when you begin creating a [custom project confi
 | `stack-default-nodb.yml`   | The default stack sans the `db` service. |
 | `stack-node.yml`           | Suitable for NodeJS projects. Consists of the `cli` service only. |
 | `stack-pantheon.yml`       | [Pantheon](https://www.pantheon.io/) alike stack with Nginx, MariaDB, PHP-FPM, Solr, Varnish and Redis. |
+| `stack-platformsh.yml`     | [Platform.sh](https://platform.sh/) alike stack with Nginx, MariaDB, PHP-FPM, and Redis. |
 | `volumes-*.yml`            | Different bindings for Docker volumes. Docksal picks the default based on the host OS/hypervisor. |
 
 To enable a particular stack config, use the `DOCKSAL_STACK` configuration variable in your project:


### PR DESCRIPTION
With the merging of the platformsh alike stack, documentation needed to be added to the stack options.
