### PR TITLE
Fixed and cleaned up build and tests

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -46,78 +46,79 @@ jobs:
           #- wp
 
     steps:
-      - name: Check Docker version
-        run: docker version
-      - name: Install latest Docker
-        run: |
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-          sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs)  stable"
-          sudo apt-get update
-          sudo apt-get install docker-ce
-      - name: Check Docker version
-        run: docker version
-      # This is a hack to work around https://github.com/jwilder/docker-gen/issues/315.
-      # Support ticket is open with Github to make sure that this is okay.
-      - name: Update Docker cgroup and restart service
+#      - name: Install latest Docker
+#        run: |
+#          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+#          sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs)  stable"
+#          sudo apt-get update
+#          sudo apt-get install docker-ce
+      # Hack to fix docker-gen in Github Actions
+      # Drops docker daemon config with custom cgroup (which docker-gen does not support)
+      # See https://github.com/jwilder/docker-gen/issues/315
+      - name: Fix docker-gen in Github Actions
         run: |
           sudo rm /etc/docker/daemon.json
           sudo service docker restart
       -
-        name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
-      -
-        name: Checkout
-        uses: actions/checkout@v2
-      -
-        name: "Install SSH Key Key"
+        name: Install BATS (tests)
         run: |
-          mkdir $HOME/.ssh || true
+          git clone https://github.com/bats-core/bats-core.git
+          cd bats-core
+          sudo ./install.sh /usr/local
+          bats -v
+#      -
+#        name: Login to DockerHub
+#        uses: docker/login-action@v1
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#      -
+#        name: Login to GitHub Container Registry
+#        uses: docker/login-action@v1
+#        with:
+#          registry: ghcr.io
+#          username: ${{ secrets.GHCR_USERNAME }}
+#          password: ${{ secrets.GHCR_TOKEN }}
+      -
+        name: Install SSH key (tests)
+        run: |
+          mkdir -p $HOME/.ssh
           echo "${SSH_KEY}" | base64 --decode > $HOME/.ssh/project_key
           chmod 400 $HOME/.ssh/project_key
         env:
           SSH_KEY: ${{ env.SSH_KEY }}
+#      -
+#        name: Install modified version of BATS
+#        run: |
+#          git clone https://github.com/docksal/bats.git tests/scripts/bats
+#          sudo tests/scripts/bats/install.sh /usr/local
+#          bats -v
       -
-        name: "Install modified version of BATS"
-        run: |
-          git clone https://github.com/docksal/bats.git tests/scripts/bats
-          sudo tests/scripts/bats/install.sh /usr/local
-          bats -v
+        name: Checkout
+        uses: actions/checkout@v2
       -
-        name: "Install version of Fin within current branch"
-        run: sudo cp ./bin/fin /usr/local/bin/fin
-      -
-        name: "Current Version of Fin"
-        run: fin version
-      -
-        name: "Calculate correct branch to use"
+        # Calculate branch for Docksal installation
+        # Use develop for 3rd-party PRs
+        name: Calculate branch
         id: use_branch
         run: |
           USE_BRANCH="$(echo ${GITHUB_REF#refs/heads/})"
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" && "${GITHUB_REPOSITORY}" == "${REPO}" ]]; then USE_BRANCH="${PR_BRANCH}"; fi
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" && "${GITHUB_REPOSITORY}" != "${REPO}" ]]; then USE_BRANCH='develop'; fi
-          echo "##[set-output name=branch;]$(echo ${USE_BRANCH})"
+          echo "::set-output name=branch::$(echo ${USE_BRANCH})"
+          echo "branch: ${USE_BRANCH}"
         env:
           PR_BRANCH: ${{ github.base_ref }}
       -
-        name: "Run Fin Update to Install Tools"
-        run: fin update
+        name: Install Docksal
+        run: curl -sSL http://get.docksal.io | bash
         env:
           DOCKSAL_VERSION: ${{ steps.use_branch.outputs.branch }}
       -
-        name: "Get information about system"
+        name: fin sysinfo
         run: fin sysinfo
       -
-        name: "Execute tests"
+        name: Tests
         run: tests/scripts/${SUITE}.sh
         env:
           SUITE: ${{ matrix.suite }}

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -46,12 +46,6 @@ jobs:
           #- wp
 
     steps:
-#      - name: Install latest Docker
-#        run: |
-#          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-#          sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs)  stable"
-#          sudo apt-get update
-#          sudo apt-get install docker-ce
       # Hack to fix docker-gen in Github Actions
       # Drops docker daemon config with custom cgroup (which docker-gen does not support)
       # See https://github.com/jwilder/docker-gen/issues/315
@@ -66,19 +60,6 @@ jobs:
           cd bats-core
           sudo ./install.sh /usr/local
           bats -v
-#      -
-#        name: Login to DockerHub
-#        uses: docker/login-action@v1
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
-#      -
-#        name: Login to GitHub Container Registry
-#        uses: docker/login-action@v1
-#        with:
-#          registry: ghcr.io
-#          username: ${{ secrets.GHCR_USERNAME }}
-#          password: ${{ secrets.GHCR_TOKEN }}
       -
         name: Install SSH key (tests)
         run: |
@@ -87,15 +68,6 @@ jobs:
           chmod 400 $HOME/.ssh/project_key
         env:
           SSH_KEY: ${{ env.SSH_KEY }}
-#      -
-#        name: Install modified version of BATS
-#        run: |
-#          git clone https://github.com/docksal/bats.git tests/scripts/bats
-#          sudo tests/scripts/bats/install.sh /usr/local
-#          bats -v
-      -
-        name: Checkout
-        uses: actions/checkout@v2
       -
         # Calculate branch for Docksal installation
         # Use develop for 3rd-party PRs
@@ -118,6 +90,9 @@ jobs:
         name: fin sysinfo
         run: fin sysinfo
       -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
         name: Tests
         run: tests/scripts/${SUITE}.sh
         env:
@@ -127,4 +102,3 @@ jobs:
       #   if: ${{ matrix.suite }} == "project"
       #   name: "Execute Boilerplate Tests"
       #   run: tests/scripts/boilerplates.sh
-

--- a/tests/project.bats
+++ b/tests/project.bats
@@ -96,7 +96,9 @@ teardown() {
 	unset output
 
 	# Test output in TTY vs no-TTY mode.
-	[[ "$(fin exec echo)" != "$(fin exec -T echo)" ]]
+	# This test used to work in Travis CI, since Travis emulated a TTY environment.
+	# It does not pass with Github Actions. Commented out.
+	# [[ "$(fin exec echo)" != "$(fin exec -T echo)" ]]
 
 	# Test the no-TTY output is a "clean" string (does not have extra control characters and can be compared)
 	run fin exec -T pwd

--- a/tests/project.bats
+++ b/tests/project.bats
@@ -184,16 +184,17 @@ teardown() {
 
 	# Setup
 	rm -rf .docksal docroot
+	vhost="test-project.${DOCKSAL_DNS_DOMAIN}"
 
 	# Test
 	# Run non-interactively to skip prompts
 	run bash -c "echo 'fin init' | bash"
 	echo "$output" | grep "Configuration was generated."
-	echo "$output" | grep "http://test-project.docksal"
+	echo "$output" | grep "http://${vhost}"
 	unset output
 
 	# Check if site is available and its name is correct
-	run curl -sLI http://test-project.docksal
+	run curl -sLI "http://${vhost}"
 	echo "$output" | grep "X-Powered-By: PHP"
 	unset output
 }

--- a/tests/scripts/acquia.sh
+++ b/tests/scripts/acquia.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 fin ssh-key add project_key
 fin config set --global "SECRET_ACAPI_EMAIL=${SECRET_ACAPI_EMAIL}"
 fin config set --global "SECRET_ACAPI_KEY=${SECRET_ACAPI_KEY}"

--- a/tests/scripts/boilerplates.sh
+++ b/tests/scripts/boilerplates.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # Triggers builds for boilerplate-* repos when master branch is tested
 # $1 - repo name, e.g. docksal/boilerplate-drupal7
 build_trigger() {

--- a/tests/scripts/commands.sh
+++ b/tests/scripts/commands.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 mkdir "$GITHUB_WORKSPACE/../test-commands"
 cd mkdir "$GITHUB_WORKSPACE/../test-commands"
 bats "$GITHUB_WORKSPACE/tests/commands.bats"

--- a/tests/scripts/commands.sh
+++ b/tests/scripts/commands.sh
@@ -3,5 +3,5 @@
 set -euo pipefail
 
 mkdir "$GITHUB_WORKSPACE/../test-commands"
-cd mkdir "$GITHUB_WORKSPACE/../test-commands"
+cd "$GITHUB_WORKSPACE/../test-commands"
 bats "$GITHUB_WORKSPACE/tests/commands.bats"

--- a/tests/scripts/config.sh
+++ b/tests/scripts/config.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 mkdir "$GITHUB_WORKSPACE/../test-config"
 cd "$GITHUB_WORKSPACE/../test-config"
 bats "$GITHUB_WORKSPACE/tests/config.bats"

--- a/tests/scripts/db.sh
+++ b/tests/scripts/db.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 mkdir "$GITHUB_WORKSPACE/../test-db"
 cd "$GITHUB_WORKSPACE/../test-db"
 bats "$GITHUB_WORKSPACE/tests/db.bats"

--- a/tests/scripts/drush.sh
+++ b/tests/scripts/drush.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 fin ssh-key add project_key
 
 mkdir "$GITHUB_WORKSPACE/../test-pull"

--- a/tests/scripts/github-build-trigger
+++ b/tests/scripts/github-build-trigger
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # Used to trigger Github Action builds for the dependent repos
 #
 # Usage: github-build-trigger repo-name

--- a/tests/scripts/macos.sh
+++ b/tests/scripts/macos.sh
@@ -26,6 +26,8 @@ echo -e "Going to work in ${yellow}$TESTS_DIR${NC}"
 echo -n "Press Enter to continue..."
 read -p ""
 
+set -euo pipefail
+
 # Cleanup tests dir
 rm -rf "$TESTS_DIR"
 mkdir -p "$GITHUB_WORKSPACE"

--- a/tests/scripts/pantheon.sh
+++ b/tests/scripts/pantheon.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 fin ssh-key add project_key
 fin config set --global "SECRET_TERMINUS_TOKEN=${SECRET_TERMINUS_TOKEN}"
 

--- a/tests/scripts/platform.sh
+++ b/tests/scripts/platform.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 fin ssh-key add project_key
 fin config set --global "SECRET_PLATFORMSH_CLI_TOKEN=${SECRET_PLATFORMSH_CLI_TOKEN}"
 

--- a/tests/scripts/project.sh
+++ b/tests/scripts/project.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 mkdir "$GITHUB_WORKSPACE/../test-project"
 cd "$GITHUB_WORKSPACE/../test-project"
 mkdir .docksal

--- a/tests/scripts/quicktest.sh
+++ b/tests/scripts/quicktest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # Use it to debug tests that are failing for mysterious reasons.
 # Uncomment quicktest provider in the travis.yml, and push.
 # Once build starts, manually cancel other provider jobs in Travis UI to avoid waiting for them

--- a/tests/scripts/system.sh
+++ b/tests/scripts/system.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 bats "$GITHUB_WORKSPACE/tests/system.bats"

--- a/tests/scripts/wp.sh
+++ b/tests/scripts/wp.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 fin ssh-key add project_key
 
 mkdir "$GITHUB_WORKSPACE/../test-pull"


### PR DESCRIPTION
- GitHun Actions config cleanup/overhaul
- Fixed Docksal domain in project.bats tests
- Disabled TTY vs no-TTY tests …
  - It is irrelevant in Github Actions, since Github Actions does not emulate a TTY (like Travis CI does).
- Use `set -euo pipefail` in test scripts …
  - Otherwise only the last failure in the script counts as test failure...
- Fixed typo in tests/scripts/commands.sh
