### PR TITLE
Switch to Docker Compose file v3

### DIFF
--- a/stacks/overrides-dd-bind.yml
+++ b/stacks/overrides-dd-bind.yml
@@ -3,6 +3,8 @@
 # See: https://github.com/docksal/docksal/issues/1368
 # Upstream issue: https://github.com/docker/for-win/issues/6628
 
+version: "3.9"
+
 volumes:
   project_root:
     driver: local

--- a/stacks/overrides-dd-bind.yml
+++ b/stacks/overrides-dd-bind.yml
@@ -3,8 +3,6 @@
 # See: https://github.com/docksal/docksal/issues/1368
 # Upstream issue: https://github.com/docker/for-win/issues/6628
 
-version: "2.1"
-
 volumes:
   project_root:
     driver: local

--- a/stacks/overrides-ide.yml
+++ b/stacks/overrides-ide.yml
@@ -1,6 +1,8 @@
 # Adds Web IDE service to the project
 # The IDE can be accessed at ide-${VIRTUAL_HOST}
 
+version: "3.9"
+
 services:
 
   cli:

--- a/stacks/overrides-ide.yml
+++ b/stacks/overrides-ide.yml
@@ -1,8 +1,6 @@
 # Adds Web IDE service to the project
 # The IDE can be accessed at ide-${VIRTUAL_HOST}
 
-version: "2.1"
-
 services:
 
   cli:

--- a/stacks/overrides-xhprof.yml
+++ b/stacks/overrides-xhprof.yml
@@ -1,8 +1,6 @@
 # Adds XHProf service to the project
 # The XHProf Outputs can be accessed at xhprof.${VIRTUAL_HOST}
 
-version: "2.1"
-
 services:
 
   cli:

--- a/stacks/overrides-xhprof.yml
+++ b/stacks/overrides-xhprof.yml
@@ -1,6 +1,8 @@
 # Adds XHProf service to the project
 # The XHProf Outputs can be accessed at xhprof.${VIRTUAL_HOST}
 
+version: "3.9"
+
 services:
 
   cli:

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -35,6 +35,9 @@ services:
       - APACHE_FCGI_HOST_PORT=cli:9000
       - APACHE_BASIC_AUTH_USER
       - APACHE_BASIC_AUTH_PASS
+    << : *dns
+    << : *logging
+    << : *healthcheck
 
   # Web: Nginx
   nginx:

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -4,6 +4,20 @@
 
 version: "3.9"
 
+x-common-settings:
+  dns: &dns
+    dns:
+      - ${DOCKSAL_DNS1}
+      - ${DOCKSAL_DNS2}
+  healthcheck: &healthcheck
+    healthcheck:
+      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
+  logging: &logging
+    logging:
+      options:
+        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
+        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
+
 services:
   # Web: Apache
   apache:
@@ -21,15 +35,6 @@ services:
       - APACHE_FCGI_HOST_PORT=cli:9000
       - APACHE_BASIC_AUTH_USER
       - APACHE_BASIC_AUTH_PASS
-    dns:
-      - ${DOCKSAL_DNS1}
-      - ${DOCKSAL_DNS2}
-    logging:
-      options:
-        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
-        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
-    healthcheck:
-      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
 
   # Web: Nginx
   nginx:
@@ -48,15 +53,9 @@ services:
     - NGINX_SERVER_ROOT=/var/www/${DOCROOT}
     - NGINX_BASIC_AUTH_USER
     - NGINX_BASIC_AUTH_PASS
-    dns:
-    - ${DOCKSAL_DNS1}
-    - ${DOCKSAL_DNS2}
-    logging:
-      options:
-        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
-        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
-    healthcheck:
-      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
+    << : *dns
+    << : *logging
+    << : *healthcheck
 
   # DB: MySQL
   mysql:
@@ -76,15 +75,9 @@ services:
       - MYSQL_RANDOM_ROOT_PASSWORD
       - MYSQL_ONETIME_PASSWORD
       - MYSQL_INITDB_SKIP_TZINFO
-    dns:
-      - ${DOCKSAL_DNS1}
-      - ${DOCKSAL_DNS2}
-    logging:
-      options:
-        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
-        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
-    healthcheck:
-      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
+    << : *dns
+    << : *logging
+    << : *healthcheck
 
   # DB: MySQL
   mariadb:
@@ -104,15 +97,9 @@ services:
     - MYSQL_RANDOM_ROOT_PASSWORD
     - MYSQL_ONETIME_PASSWORD
     - MYSQL_INITDB_SKIP_TZINFO
-    dns:
-    - ${DOCKSAL_DNS1}
-    - ${DOCKSAL_DNS2}
-    logging:
-      options:
-        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
-        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
-    healthcheck:
-      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
+    << : *dns
+    << : *logging
+    << : *healthcheck
 
   # DB: PostgreSQL
   pgsql:
@@ -127,15 +114,9 @@ services:
       - POSTGRES_DB=${POSTGRES_DB:-default}
       - POSTGRES_USER=${POSTGRES_USER:-user}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-user}
-    dns:
-      - ${DOCKSAL_DNS1}
-      - ${DOCKSAL_DNS2}
-    logging:
-      options:
-        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
-        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
-    healthcheck:
-      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
+    << : *dns
+    << : *logging
+    << : *healthcheck
 
   # CLI - Used for all console commands and tools.
   cli:
@@ -178,15 +159,9 @@ services:
       - COMPOSER_DEFAULT_VERSION
       - COMPOSER_ALLOW_XDEBUG=${XDEBUG_ENABLED:-0}
       - COMPOSER_DISABLE_XDEBUG_WARN=${XDEBUG_ENABLED:-0}
-    dns:
-      - ${DOCKSAL_DNS1}
-      - ${DOCKSAL_DNS2}
-    logging:
-      options:
-        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
-        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
-    healthcheck:
-      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
+    << : *dns
+    << : *logging
+    << : *healthcheck
 
   # Varnish
   varnish:
@@ -199,30 +174,18 @@ services:
       - io.docksal.cert-name=${VIRTUAL_HOST_CERT_NAME:-none}
     environment:
       - VARNISH_BACKEND_HOST=web
-    dns:
-      - ${DOCKSAL_DNS1}
-      - ${DOCKSAL_DNS2}
-    logging:
-      options:
-        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
-        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
-    healthcheck:
-      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
+    << : *dns
+    << : *logging
+    << : *healthcheck
 
   # Memcached
   memcached:
     hostname: memcached
     image: ${MEMCACHED_IMAGE:-memcached:1.4-alpine}
     command: ["-m", "128"]  # Set memcached memory limit to 128 MB by default
-    dns:
-      - ${DOCKSAL_DNS1}
-      - ${DOCKSAL_DNS2}
-    logging:
-      options:
-        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
-        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
-    healthcheck:
-      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
+    << : *dns
+    << : *logging
+    << : *healthcheck
 
   # Redis
   redis:
@@ -231,15 +194,9 @@ services:
     environment:
       - REDIS_MAXMEMORY=${REDIS_MAXMEMORY:-256m}
       # Additional variables can be found https://github.com/wodby/redis
-    dns:
-      - ${DOCKSAL_DNS1}
-      - ${DOCKSAL_DNS2}
-    logging:
-      options:
-        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
-        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
-    healthcheck:
-      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
+    << : *dns
+    << : *logging
+    << : *healthcheck
 
   # Solr
   solr:
@@ -251,15 +208,9 @@ services:
       - io.docksal.virtual-host=solr.${VIRTUAL_HOST},solr.${VIRTUAL_HOST}.*
       - io.docksal.virtual-port=8983
       - io.docksal.cert-name=${VIRTUAL_HOST_CERT_NAME:-none}
-    dns:
-      - ${DOCKSAL_DNS1}
-      - ${DOCKSAL_DNS2}
-    logging:
-      options:
-        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
-        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
-    healthcheck:
-      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
+    << : *dns
+    << : *logging
+    << : *healthcheck
 
   # MailHog
   mail:
@@ -271,15 +222,9 @@ services:
       - io.docksal.virtual-host=mail.${VIRTUAL_HOST},mail.${VIRTUAL_HOST}.*
       - io.docksal.virtual-port=8025
       - io.docksal.cert-name=${VIRTUAL_HOST_CERT_NAME:-none}
-    dns:
-      - ${DOCKSAL_DNS1}
-      - ${DOCKSAL_DNS2}
-    logging:
-      options:
-        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
-        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
-    healthcheck:
-      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
+    << : *dns
+    << : *logging
+    << : *healthcheck
 
   # Blackfire
   blackfire:
@@ -287,8 +232,9 @@ services:
     environment:
       - BLACKFIRE_SERVER_ID
       - BLACKFIRE_SERVER_TOKEN
-    healthcheck:
-      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
+    << : *dns
+    << : *logging
+    << : *healthcheck
 
   # Elastic Search
   elasticsearch:
@@ -296,9 +242,6 @@ services:
     image: ${ELASTICSEARCH_IMAGE:-elasticsearch:6.5.3}
     ports:
       - "${ELASTICSEARCH_PORT_MAPPING:-9200}"
-    dns:
-      - ${DOCKSAL_DNS1}
-      - ${DOCKSAL_DNS2}
     environment:
       - bootstrap.memory_lock=true
       - discovery.type=single-node
@@ -307,9 +250,6 @@ services:
       memlock:
         soft: -1
         hard: -1
-    logging:
-      options:
-        max-size: ${DOCKSAL_CONTAINER_LOG_MAX_SIZE}
-        max-file: ${DOCKSAL_CONTAINER_LOG_MAX_FILE}
-    healthcheck:
-      interval: ${DOCKSAL_CONTAINER_HEALTHCHECK_INTERVAL}
+    << : *dns
+    << : *logging
+    << : *healthcheck

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -2,7 +2,7 @@
 # To use any service extend it from this file located at ${HOME}/.docksal/stacks/services.yml.
 # See ${HOME}/.docksal/stacks/default.yml for a basic LAMP stack extending from web, db and cli services in this file.
 
-version: "2.1"
+version: "3.9"
 
 services:
   # Web: Apache

--- a/stacks/stack-acquia.yml
+++ b/stacks/stack-acquia.yml
@@ -7,6 +7,8 @@
 # - Memcached 1.4
 # - ApacheSolr 4.5
 
+version: "3.9"
+
 services:
   # http(s)://VIRTUAL_HOST
   web:

--- a/stacks/stack-acquia.yml
+++ b/stacks/stack-acquia.yml
@@ -7,8 +7,6 @@
 # - Memcached 1.4
 # - ApacheSolr 4.5
 
-version: "2.1"
-
 services:
   # http(s)://VIRTUAL_HOST
   web:

--- a/stacks/stack-default-nodb.yml
+++ b/stacks/stack-default-nodb.yml
@@ -1,7 +1,5 @@
 # Default stack sans DB
 
-version: "2.1"
-
 services:
   # Web
   web:

--- a/stacks/stack-default-nodb.yml
+++ b/stacks/stack-default-nodb.yml
@@ -1,5 +1,7 @@
 # Default stack sans DB
 
+version: "3.9"
+
 services:
   # Web
   web:

--- a/stacks/stack-default.yml
+++ b/stacks/stack-default.yml
@@ -3,6 +3,8 @@
 # - MySQL 5.6
 # - PHP 7.2
 
+version: "3.9"
+
 services:
   # http(s)://VIRTUAL_HOST
   web:

--- a/stacks/stack-default.yml
+++ b/stacks/stack-default.yml
@@ -3,8 +3,6 @@
 # - MySQL 5.6
 # - PHP 7.2
 
-version: "2.1"
-
 services:
   # http(s)://VIRTUAL_HOST
   web:

--- a/stacks/stack-node.yml
+++ b/stacks/stack-node.yml
@@ -1,5 +1,7 @@
 # Node.js stack
 
+version: "3.9"
+
 services:
   cli:
     extends:

--- a/stacks/stack-node.yml
+++ b/stacks/stack-node.yml
@@ -1,7 +1,5 @@
 # Node.js stack
 
-version: "2.1"
-
 services:
   cli:
     extends:

--- a/stacks/stack-pantheon.yml
+++ b/stacks/stack-pantheon.yml
@@ -7,6 +7,8 @@
 # - Redis 4.0
 # - ApacheSolr 3.6
 
+version: "3.9"
+
 services:
   # http(s)://VIRTUAL_HOST
   web:

--- a/stacks/stack-pantheon.yml
+++ b/stacks/stack-pantheon.yml
@@ -7,8 +7,6 @@
 # - Redis 4.0
 # - ApacheSolr 3.6
 
-version: "2.1"
-
 services:
   # http(s)://VIRTUAL_HOST
   web:

--- a/stacks/stack-platformsh.yml
+++ b/stacks/stack-platformsh.yml
@@ -6,8 +6,6 @@
 # - PHP 7.4
 # - Redis 6.0
 
-version: "2.1"
-
 services:
   # http(s)://VIRTUAL_HOST
   web:

--- a/stacks/stack-platformsh.yml
+++ b/stacks/stack-platformsh.yml
@@ -6,6 +6,8 @@
 # - PHP 7.4
 # - Redis 6.0
 
+version: "3.9"
+
 services:
   # http(s)://VIRTUAL_HOST
   web:

--- a/stacks/volumes-bind.yml
+++ b/stacks/volumes-bind.yml
@@ -1,6 +1,8 @@
 # Bind mount project volumes
 # Same as mounting host folders, but via named volumes.
 
+version: "3.9"
+
 volumes:
   cli_home:  # /home/docker volume in cli
   project_root:  # Project root volume (bind mount)

--- a/stacks/volumes-bind.yml
+++ b/stacks/volumes-bind.yml
@@ -1,8 +1,6 @@
 # Bind mount project volumes
 # Same as mounting host folders, but via named volumes.
 
-version: "2.1"
-
 volumes:
   cli_home:  # /home/docker volume in cli
   project_root:  # Project root volume (bind mount)

--- a/stacks/volumes-nfs.yml
+++ b/stacks/volumes-nfs.yml
@@ -3,8 +3,6 @@
 # Pros: very good performance, almost realtime file sync 
 # Cons: no inotify/fs watchers
 
-version: "2.1"
-
 volumes:
   cli_home:  # /home/docker volume in cli
   project_root:  # Project root volume (NFS)

--- a/stacks/volumes-nfs.yml
+++ b/stacks/volumes-nfs.yml
@@ -3,6 +3,8 @@
 # Pros: very good performance, almost realtime file sync 
 # Cons: no inotify/fs watchers
 
+version: "3.9"
+
 volumes:
   cli_home:  # /home/docker volume in cli
   project_root:  # Project root volume (NFS)

--- a/stacks/volumes-none.yml
+++ b/stacks/volumes-none.yml
@@ -4,6 +4,8 @@
 # Can be used to provision completely blank environments and have all work (code checkout, etc.) done inside cli.
 # Provides THE BEST fs performance.
 
+version: "3.9"
+
 volumes:
   cli_home:  # /home/docker volume in cli
   project_root: # Project root volume

--- a/stacks/volumes-none.yml
+++ b/stacks/volumes-none.yml
@@ -4,8 +4,6 @@
 # Can be used to provision completely blank environments and have all work (code checkout, etc.) done inside cli.
 # Provides THE BEST fs performance.
 
-version: "2.1"
-
 volumes:
   cli_home:  # /home/docker volume in cli
   project_root: # Project root volume

--- a/stacks/volumes-unison.yml
+++ b/stacks/volumes-unison.yml
@@ -3,8 +3,6 @@
 # Pros: native fs performance, fast file sync, inotify/fs watchers support.
 # Cons: 2x space usage (a mirror of the code base is maintained in a Docker volume), initial sync delay
 
-version: "2.1"
-
 volumes:
   cli_home:  # /home/docker volume in cli
   project_root: # Project root volume

--- a/stacks/volumes-unison.yml
+++ b/stacks/volumes-unison.yml
@@ -3,6 +3,8 @@
 # Pros: native fs performance, fast file sync, inotify/fs watchers support.
 # Cons: 2x space usage (a mirror of the code base is maintained in a Docker volume), initial sync delay
 
+version: "3.9"
+
 volumes:
   cli_home:  # /home/docker volume in cli
   project_root: # Project root volume


### PR DESCRIPTION
v2 and v3 Docker Compose file formats were [merged together](https://github.com/docker/compose/pull/7588) in docker-compose v1.27+

This means, we can safely switch to the latest compose file v3.9 and continue to use `extends` + all of the new features and options that we were not able to use while stuck on 2.1, like [extension-fields](https://docs.docker.com/compose/compose-file/compose-file-v3/#extension-fields) and [yaml anchors](https://yaml.org/spec/1.2/spec.html#id2765878).

Moreover, the "version" property is now optional and combining files with different versions will not result in an error. This used to be a major blocker for us to even consider updating the compose file format version, since that would be a breaking change for every single Docksal project out there.

Closes: #701 