### PR TITLE
Updated documentation for Xdebug

### DIFF
--- a/docs/content/tools/xdebug.md
+++ b/docs/content/tools/xdebug.md
@@ -125,7 +125,7 @@ You can run your scripts in console and debug them in the same way as browser re
           "name": "Listen for XDebug",
           "type": "php",
           "request": "launch",
-          "port": 9003,
+          "port": 9000,
           "pathMappings": {
             "/var/www/": "${workspaceFolder}"
           }
@@ -136,7 +136,7 @@ You can run your scripts in console and debug them in the same way as browser re
           "request": "launch",
           "program": "${file}",
           "cwd": "${fileDirname}",
-          "port": 9003,
+          "port": 9000,
           "pathMappings": {
             "/var/www/": "${workspaceFolder}"
           }
@@ -166,7 +166,7 @@ To debug Drush commands using Xdebug and VSCode, add the following to your path 
 ## Debugging with NetBeans {#netbeans}
 
 1. Follow the [setup instructions](#setup) to enable the Xdebug integration
-2. Open NetBeans Debugging configuration ("Tools> Options > PHP > Debugging") and set "DebuggerPort" to 9003
+2. Open NetBeans Debugging configuration ("Tools> Options > PHP > Debugging") and set "DebuggerPort" to 9000
 3. Open your project in NetBeans
 4. Configure project properties:
 
@@ -188,21 +188,10 @@ To debug Drush commands using Xdebug and VSCode, add the following to your path 
     - Search for "php-debug"
     - Click "Settings" button below plugin
     - "Server" can be set to `*`
-    - "Server Listen Port" should be set to 9003
+    - "Server Listen Port" should be set to 9000
     - Make sure "Continue to listen for debug sessions even if the debugger windows are all closed" is checked. This will make the debugger window open automatically.
 
-## Configuring Prior Versions
+## XDebug Modifications
 
-For versions of XDebug prior to v3.0.0, the following changes will need to be made to the projects `.docksal/docksal.yml`. Additionally, to note the port has changed 
-from 9000 to 9003
-
-```
-services:
-    cli:
-        environment:
-            - XDEBUG_CONFIG=remote_connect_back=0 remote_host=${DOCKSAL_HOST_IP}
-        expose:
-            - 9000
-
-```
+For versions of XDebug prior to v3.0.0, the following changes will need to be made to the projects `.docksal/docksal.yml`. To not introduce a breaking change within the CLI service and with IDEs the default port has been set back to 9000.
 

--- a/docs/content/tools/xdebug.md
+++ b/docs/content/tools/xdebug.md
@@ -195,3 +195,14 @@ To debug Drush commands using Xdebug and VSCode, add the following to your path 
 
 For versions of XDebug prior to v3.0.0, the following changes will need to be made to the projects `.docksal/docksal.yml`. To not introduce a breaking change within the CLI service and with IDEs the default port has been set back to 9000.
 
+## Configuring Prior Versions
+
+For versions of XDebug prior to v3.0.0, the following changes will need to be made to the projects `.docksal/docksal.yml`.
+
+```
+services:
+    cli:
+        environment:
+            - XDEBUG_CONFIG=remote_connect_back=0 remote_host=${DOCKSAL_HOST_IP}
+```
+


### PR DESCRIPTION
Modified XDebug documentation and reverted port back to 9000 as the port used for v3.x will use 9003 now.

To not introduce breaking change we will set the default port to be 9000.

Reference: https://github.com/docksal/service-cli/pull/218