### PR TITLE
Make headless browsers available.

### DIFF
--- a/docs/content/service/other/browsers.md
+++ b/docs/content/service/other/browsers.md
@@ -16,7 +16,7 @@ browser images:
 To include one or more of these browsers with your project, update the 
 `services` section of `.docksal/docksal.yml` by adding:
 
-*Chrome*
+**Chrome**
 
 ```yaml
   chrome:
@@ -25,7 +25,7 @@ To include one or more of these browsers with your project, update the
       service: chrome-browser
 ```
 
-*Firefox*
+**Firefox**
 
 ```yaml
   firefox:
@@ -34,7 +34,7 @@ To include one or more of these browsers with your project, update the
       service: firefox-browser
 ```
 
-*Edge*
+**Edge**
 
 ```yaml
   edge:

--- a/docs/content/service/other/browsers.md
+++ b/docs/content/service/other/browsers.md
@@ -1,0 +1,56 @@
+---
+title: "Headless Browsers"
+aliases:
+  - /en/master/tools/headless-browsers/
+  - /tools/headless-browsers/
+---
+
+Docksal does not maintain headless browser images. The various SeleniumHQ
+images are sufficient. Docksal includes support for the following headless
+browser images:
+
+- selenium/standalone-chrome
+- selenium/standalone-firefox
+- selenium/standalone-edge
+
+To include one or more of these browsers with your project, update the 
+`services` section of `.docksal/docksal.yml` by adding:
+
+*Chrome*
+
+```yaml
+  chrome:
+    extends:
+      file: ${HOME}/.docksal/stacks/services.yml
+      service: chrome-browser
+```
+
+*Firefox*
+
+```yaml
+  firefox:
+    extends:
+      file: ${HOME}/.docksal/stacks/services.yml
+      service: firefox-browser
+```
+
+*Edge*
+
+```yaml
+  edge:
+    extends:
+      file: ${HOME}/.docksal/stacks/services.yml
+      service: edge-browser
+```
+
+## Enabling the browsers
+
+By default, unless further action is taken, `fin up` _will not_ bring up any
+headless browser services that have been included in your project. You can
+start the service(s) in one of two ways:
+
+- Running `fin up chrome` which will bring up the `chrome` service.
+- Add `COMPOSER_PROFILES="docksal-testing"` to `.docksal/docksal.env` or 
+`.docksal/docksal-local.env`, and then run `fin up`. This will bring up all
+services in your project tagged with the `docksal-testing` profile (See 
+https://docs.docker.com/compose/profiles/ for more information about profiles).

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -257,3 +257,31 @@ services:
     << : *dns
     << : *logging
     << : *healthcheck
+
+  # Browser testing.
+  chrome-browser:
+    hostname: chrome
+    image: ${CHROME_BROWSER_IMAGE:-selenium/standalone-chrome}
+    profiles:
+      - docksal-testing
+    << : *dns
+    << : *logging
+    << : *healthcheck
+
+  firefox-browser:
+    hostname: firefox
+    image: ${FIREFOX_BROWSER_IMAGE:-selenium/standalone-firefox}
+    profiles:
+      - docksal-testing
+    << : *dns
+    << : *logging
+    << : *healthcheck
+
+  edge-browser:
+    hostname: edge
+    image: ${EDGE_BROWSER_IMAGE:-selenium/standalone-edge}
+    profiles:
+      - docksal-testing
+    << : *dns
+    << : *logging
+    << : *healthcheck


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docksal/docksal/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Write a short summary that describes the changes in this pull request:
-->

# Changes

- Makes the following SeleniumHQ-supported headless browsers available for usage within Docksal:
    - Chrome
    - Firefox
    - Edge
- Browsers can be CPU intensive, so they are disabled by default (even if you've extended them into your `docksal.yml` file). You must explicitly add `COMPOSE_PROFILES="testing"` to either `docksal.env` or `docksal-local.env` and then run `fin up`.