### PR TITLE
IDE config fix for xdebug v3

### DIFF
--- a/docs/content/tools/xdebug.md
+++ b/docs/content/tools/xdebug.md
@@ -191,13 +191,10 @@ To debug Drush commands using Xdebug and VSCode, add the following to your path 
     - "Server Listen Port" should be set to 9000
     - Make sure "Continue to listen for debug sessions even if the debugger windows are all closed" is checked. This will make the debugger window open automatically.
 
-## XDebug Modifications
+## XDebug v2 Modifications
 
-For versions of XDebug prior to v3.0.0, the following changes will need to be made to the projects `.docksal/docksal.yml`. To not introduce a breaking change within the CLI service and with IDEs the default port has been set back to 9000.
-
-## Configuring Prior Versions
-
-For versions of XDebug prior to v3.0.0, the following changes will need to be made to the projects `.docksal/docksal.yml`.
+For versions of XDebug prior to v3.0.0 (prior to docksal/cli [v2.13](https://github.com/docksal/service-cli/releases/tag/v2.13.0)), 
+the following changes will need to be made to the projects `.docksal/docksal.yml`: 
 
 ```
 services:
@@ -206,3 +203,6 @@ services:
             - XDEBUG_CONFIG=remote_connect_back=0 remote_host=${DOCKSAL_HOST_IP}
 ```
 
+XDebug v3 switched the default IDE listener port (`xdebug.client_port`) from `9000` to `9003`. 
+To avoid introducing a breaking change within the CLI service and with IDEs, Docksal uses port `9000` for both XDebug 
+versions (v2 and v3).

--- a/stacks/overrides-ide.yml
+++ b/stacks/overrides-ide.yml
@@ -7,7 +7,7 @@ services:
 
   cli:
     environment:
-      - XDEBUG_CONFIG=remote_host=ide remote_port=9000  # Point xdebug to the dbgp client in the ide container
+      - XDEBUG_CONFIG=client_host=ide # Point xdebug (v3) to the dbgp client in the ide container
 
   ide:
     extends:
@@ -20,10 +20,10 @@ services:
     environment:
       - IDE_ENABLED
       - IDE_PASSWORD
-      # Point xdebug to the dbgp server (started by IDE) in the ide container.
+      # Point xdebug (v3) to the dbgp server (started by IDE) in the ide container.
       # This is only necessary for debugging php cli sessions initiated directly in the IDE.
       # Normally, you'd be launching a cli script manually inside the cli container and not inside IDE (ide container).
-      - XDEBUG_CONFIG=remote_host=ide remote_port=9000
+      - XDEBUG_CONFIG=client_host=ide
     labels:
       - io.docksal.virtual-host=ide-${VIRTUAL_HOST},ide-${VIRTUAL_HOST}.*
       - io.docksal.virtual-port=8080


### PR DESCRIPTION
- Updated IDE settings for xdebug v3 compatibility
- Updated xdebug docs. Clarified that xdebug v3 was introduced in docksal/cli v2.13

Related: https://github.com/docksal/service-cli/pull/248