### PR TITLE
Switched cli to docksal/cli:php7.4-3.0

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -370,7 +370,7 @@ URL_WINPTY="https://github.com/rprichard/winpty/releases/download/${REQUIREMENTS
 IMAGE_SSH_AGENT=${IMAGE_SSH_AGENT:-docksal/ssh-agent:1.3}
 IMAGE_VHOST_PROXY=${IMAGE_VHOST_PROXY:-docksal/vhost-proxy:1.7}
 IMAGE_DNS=${IMAGE_DNS:-docksal/dns:1.1}
-IMAGE_RUN_CLI=${IMAGE_RUN_CLI:-docksal/cli:2.13-php7.3}
+IMAGE_RUN_CLI=${IMAGE_RUN_CLI:-docksal/cli:php7.4-3.0}
 
 #---------------------------- Helper functions --------------------------------
 

--- a/docs/content/stack/images-versions.md
+++ b/docs/content/stack/images-versions.md
@@ -53,14 +53,27 @@ e.g., `fin image registry docksal/cli`, to see list of available CLI images. [Se
 
 | Image| Notes |
 |------|-------|
+| `docksal/cli:php8.0-3.0` | PHP 8.0, Nodejs 14.17.3, Ruby 2.5.5, Python 2.7.16, msmtp |
+| `docksal/cli:php7.4-3.0` | *Default image* PHP 7.4, Nodejs 14.17.3, Ruby 2.7.2, Python 2.7.16, msmtp |
+| `docksal/cli:php7.3-3.0` | PHP 7.3, Nodejs 14.17.3, Ruby 2.5.5, Python 3.8.3, msmtp |
+| `docksal/cli:php8.0-3`    | Latest 3.x image version of PHP 8.0 flavor, convenient when [extending images](/stack/extend-images)
+| `docksal/cli:php7.4-3`    | Latest 3.x image version of PHP 7.4 flavor, convenient when [extending images](/stack/extend-images)
+| `docksal/cli:php7.3-3`    | Latest 3.x image version of PHP 7.3 flavor, convenient when [extending images](/stack/extend-images)
 | `docksal/cli:2.13-php7.4` | PHP 7.4, Nodejs 14.15.0, Ruby 2.7.2, Python 3.8.3, msmtp |
-| `docksal/cli:2.13-php7.3` | *Default image* PHP 7.3, Nodejs 12.18.1, Ruby 2.7.1, Python 3.8.3, msmtp |
-| `docksal/cli:2-php7.4`    | Latest 2.x image version of PHP 7.4 flavor, convenient when [extending images](/stack/extend-images)
-| `docksal/cli:2-php7.3`    | Latest 2.x image version of PHP 7.3 flavor, convenient when [extending images](/stack/extend-images)
+| `docksal/cli:2.13-php7.3` | PHP 7.3, Nodejs 14.15.0, Ruby 2.7.2, Python 3.8.3, msmtp |
 | `docksal/cli:2.11-php7.2` | *Deprecated* PHP 7.2, Nodejs 12.18.1, Ruby 2.7.1, Python 3.8.3, msmtp |
 | `docksal/cli:2.10-php7.1` | *Deprecated* PHP 7.1, Nodejs 12.13.0, Ruby 2.6.5, Python 3.8.3, msmtp |
 | `docksal/cli:2.5-php7.0`  | *Deprecated* PHP 7.0, mhsendmail |
 | `docksal/cli:2.5-php5.6`  | *Deprecated* PHP 5.6, mhsendmail |
+
+{{% notice warning %}}
+v3 images use a new image tag naming convention, which aligns with the rest of the recent Docksal images. 
+"2.13-php7.4" => "php7.4-3.0"
+{{% /notice %}}
+
+{{% notice info %}}
+v3 images bundle stock Debian versions of Ruby and Python, thus there is a version drop for those compared to v2 images.
+{{% /notice %}}
 
 ## Apache
 

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -124,7 +124,7 @@ services:
   # CLI - Used for all console commands and tools.
   cli:
     hostname: cli
-    image: ${CLI_IMAGE:-docksal/cli:2.13-php7.3}
+    image: ${CLI_IMAGE:-docksal/cli:php7.4-3.0}
     volumes:
       - project_root:/var/www:rw,nocopy,cached  # Project root volume
       - docksal_ssh_agent:/.ssh-agent:ro  # Shared ssh-agent socket


### PR DESCRIPTION
cli v3 is a major release. The most notable changes are:

- PHP 8.0 image version
- arm64 support

There are also some potentially breaking changes. Details here:
https://github.com/docksal/service-cli/releases/tag/v3.0.0

To test:

```
fin config set CLI_IMAGE=docksal/cli:php7.4-3.0
fin up
```
