### PR TITLE
adds hosting variables documentation

### DIFF
--- a/docs/content/stack/configuration-variables.md
+++ b/docs/content/stack/configuration-variables.md
@@ -290,6 +290,23 @@ Note: `DOCKSAL_ENVIRONMENT` should not be set and will not work in the project's
 
 Defines a relative path to the Document Root of the web server. Final path will be `/var/www/$DOCROOT`, so by default it is `/var/www/docroot`. Change it to the desired directory (like `http`) or sub-directory as needed, or set to `.` to use the project root as web server Document Root.
 
+### HOSTING_ENV
+
+This variable is part of the hosting integration variable set. Use the environment designation of your hosting provider,
+e.g., `prod`, `test`, `dev`. WordPress is the only provider that doesn't need this. This variable can be overridden by 
+using the `--hosting-env` parameter in the `fin pull` command.
+
+### HOSTING_PLATFORM
+
+This variable is part of the hosting integration variable set. Use the platform hosting provider associated with your
+project `acquia`, `pantheon`, `platform.sh`, or set it to `drush` or `wp`. This variable can be overridden by using the
+`--hosting-platform` parameter in the `fin pull` command.
+
+### HOSTING_SITE
+
+This variable is part of the hosting integration variable set. Use the site id given by your hosting provider. This 
+variable can be overridden by using the `--hosting-env` parameter in the `fin pull` command.
+
 ### MYSQL_ALLOW_EMPTY_PASSWORD
 
 This is an optional variable. Set to `yes` to allow the container to be started with a blank password for the root user. NOTE: Setting this variable to `yes` is not recommended unless you really know what you are doing, since this will leave your MySQL instance completely unprotected, allowing anyone to gain complete superuser access.


### PR DESCRIPTION
Documentation for the HOSTING_* variables was missing from the configuration variables page.


Starting here: https://deploy-preview-1539--docs-docksal-io.netlify.app/stack/configuration-variables/#hosting-env