### PR TITLE
fin share-v2 and cloudflared service

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -39,6 +39,7 @@ jobs:
           - db
           - system
           - commands
+          - share-v2
           #- acquia
           #- pantheon
           #- platform

--- a/bin/fin
+++ b/bin/fin
@@ -6075,17 +6075,6 @@ ngrok_share ()
 
 # Cloudflare Tunnel (cloudflared) integration
 
-# Check requirements
-cloudflared_check_requirements ()
-{
-	if [[ "$(host_arch_new)" != "amd64" ]]; then
-		echo-error "Host architecture not supported" \
-			"This feature is only available on ${yellow}amd64${NC} architecture."
-		# Quit here unless were are in debug mode
-		! [[ ${FIN_DEBUG} == 1 || "${1}" == "debug" ]] && exit 1
-	fi
-}
-
 # Check whether cloudflared container is running
 cloudflared_is_running ()
 {
@@ -8714,7 +8703,6 @@ case "$1" in
 		ngrok_share "$@"
 		;;
 	share-v2)
-		cloudflared_check_requirements
 		shift
 		case "$1" in
 			start)

--- a/bin/fin
+++ b/bin/fin
@@ -6075,6 +6075,17 @@ ngrok_share ()
 
 # Cloudflare Tunnel (cloudflared) integration
 
+# Check requirements
+cloudflared_check_requirements ()
+{
+	if [[ "$(host_arch_new)" != "amd64" ]]; then
+		echo-error "Host architecture not supported" \
+			"This feature is only available on ${yellow}amd64${NC} architecture."
+		# Quit here unless were are in debug mode
+		! [[ ${FIN_DEBUG} == 1 || "${1}" == "debug" ]] && exit 1
+	fi
+}
+
 # Check whether cloudflared container is running
 cloudflared_is_running ()
 {
@@ -8703,6 +8714,7 @@ case "$1" in
 		ngrok_share "$@"
 		;;
 	share-v2)
+		cloudflared_check_requirements
 		shift
 		case "$1" in
 			start)

--- a/bin/fin
+++ b/bin/fin
@@ -6366,6 +6366,7 @@ load_configuration ()
 	# Re-load global env file once again, since 'up' resets some variables to force re-reading config
 	set -a; source "$CONFIG_ENV"; set +a
 
+	ENV_FILE=""
 	# Mac and Linux use ":"" as a separator, Windows uses ";"
 	local SEPARATOR=':'; is_windows && SEPARATOR=';'
 	local env_file="$(get_project_path_dc)/.docksal/docksal.env"
@@ -6388,87 +6389,85 @@ load_configuration ()
 	# This is used to print the list of included env files in `fin config`
 	export ENV_FILE
 
-	# Set COMPOSE_FILE unless it has been already set by user
+	COMPOSE_FILE=""
+	yml_file="$(get_project_path_dc)/.docksal/docksal.yml"
+
+	# Allow to define the stack file via DOCKSAL_STACK
+	# Set it to "default" if empty and there is no project yml file
+	[[ "$DOCKSAL_STACK" == "" ]] && export DOCKSAL_STACK=""
+	[[ "$DOCKSAL_STACK" == "" ]] && [[ ! -f "$yml_file" ]] && DOCKSAL_STACK='default'
+	stack_yml_file="$(get_config_dir_dc)/stacks/stack-$DOCKSAL_STACK.yml"
+	[[ "$DOCKSAL_STACK" != "" && ! -f "$stack_yml_file" ]] &&
+		echo-error "Incorrect stack definition '$DOCKSAL_STACK'" \
+			"Stack file does not exist: $stack_yml_file" &&
+		exit 1
+
+	# Include both the stack and the project yml files if both exist
+	if [[ -f "$stack_yml_file" ]] && [[ -f "$yml_file" ]]; then
+		COMPOSE_FILE="${stack_yml_file}${SEPARATOR}${yml_file}"
+	# Otherwise try including only one that exists
+	else
+		[[ -f "$stack_yml_file" ]] && COMPOSE_FILE="$stack_yml_file"
+		[[ -f "$yml_file" ]] && COMPOSE_FILE="$yml_file"
+	fi
+
+	# Throw an error if COMPOSE_FILE is empty here
 	if [[ "$COMPOSE_FILE" == "" ]]; then
-		yml_file="$(get_project_path_dc)/.docksal/docksal.yml"
+		echo-error "No configuration files found." "Expected in $yml_file"
+		exit 1
+	else
+		# Include docksal-local.yml (if exists)
+		# Allow using this with the pre-configured stacks by not checking docksal.env presence.
+		local local_yml_file="$(get_project_path_dc)/.docksal/docksal-${DOCKSAL_ENVIRONMENT}.yml"
+		[[ -f "$local_yml_file" ]] && COMPOSE_FILE="${COMPOSE_FILE}${SEPARATOR}${local_yml_file}"
+	fi
 
-		# Allow to define the stack file via DOCKSAL_STACK
-		# Set it to "default" if empty and there is no project yml file
-		[[ "$DOCKSAL_STACK" == "" ]] && export DOCKSAL_STACK=""
-		[[ "$DOCKSAL_STACK" == "" ]] && [[ ! -f "$yml_file" ]] && DOCKSAL_STACK='default'
-		stack_yml_file="$(get_config_dir_dc)/stacks/stack-$DOCKSAL_STACK.yml"
-		[[ "$DOCKSAL_STACK" != "" && ! -f "$stack_yml_file" ]] &&
-			echo-error "Incorrect stack definition '$DOCKSAL_STACK'" \
-				"Stack file does not exist: $stack_yml_file" &&
+	DOCKSAL_VOLUMES=""
+	# Include a volumes yml if requested. Use bind mount volumes by default.
+	if is_mac; then
+		# Default to NFS volumes on Mac (both VirtualBox and Docker Desktop)
+		DOCKSAL_VOLUMES=${DOCKSAL_VOLUMES:-nfs}
+	else
+		# Bind mounted volumes on all other systems
+		DOCKSAL_VOLUMES=${DOCKSAL_VOLUMES:-bind}
+	fi
+	if [[ "$DOCKSAL_VOLUMES" != "disabled" ]]; then
+		volumes_yml_file="$(get_config_dir_dc)/stacks/volumes-$DOCKSAL_VOLUMES.yml"
+		if [[ -f "$volumes_yml_file" ]]; then
+			COMPOSE_FILE="${volumes_yml_file}${SEPARATOR}${COMPOSE_FILE}"
+		else
+			echo-error "Volumes definition not found in ${volumes_yml_file}." \
+				"Please check that ${yellow}DOCKSAL_VOLUMES${NC} is set properly." \
+				"You may need to run ${yellow}fin update${NC} to download volume definitions."
 			exit 1
+		fi
+	fi
+	export DOCKSAL_VOLUMES
 
-		# Include both the stack and the project yml files if both exist
-		if [[ -f "$stack_yml_file" ]] && [[ -f "$yml_file" ]]; then
-			COMPOSE_FILE="${stack_yml_file}${SEPARATOR}${yml_file}"
-		# Otherwise try including only one that exists
-		else
-			[[ -f "$stack_yml_file" ]] && COMPOSE_FILE="$stack_yml_file"
-			[[ -f "$yml_file" ]] && COMPOSE_FILE="$yml_file"
-		fi
+	# Fix bind volumes on Docker Desktop v2.3.0.2+
+	# See https://github.com/docksal/docksal/issues/1368
+	overrides_dd_bind_file="$(get_config_dir_dc)/stacks/overrides-dd-bind.yml"
+	if [[ -f "${overrides_dd_bind_file}" ]] && \
+		is_docker_native && \
+		(( $(ver_to_int $(docker_desktop_version)) >= $(ver_to_int '2.3.0.2') )) && \
+		[[ "$DOCKSAL_VOLUMES" == "bind" ]];
+	then
+		COMPOSE_FILE="${COMPOSE_FILE}${SEPARATOR}${overrides_dd_bind_file}"
+	fi
 
-		# Throw an error if COMPOSE_FILE is empty here
-		if [[ "$COMPOSE_FILE" == "" ]]; then
-			echo-error "No configuration files found." "Expected in $yml_file"
-			exit 1
-		else
-			# Include docksal-local.yml (if exists)
-			# Allow using this with the pre-configured stacks by not checking docksal.env presence.
-			local local_yml_file="$(get_project_path_dc)/.docksal/docksal-${DOCKSAL_ENVIRONMENT}.yml"
-			[[ -f "$local_yml_file" ]] && COMPOSE_FILE="${COMPOSE_FILE}${SEPARATOR}${local_yml_file}"
-		fi
+	# Enable VSCode (Coder) IDE
+	overrides_ide_file="$(get_config_dir_dc)/stacks/overrides-ide.yml"
+	if [[ -f "${overrides_ide_file}" ]] && [[ "$IDE_ENABLED" != "" ]] && [[ "$IDE_ENABLED" != "0" ]]; then
+		COMPOSE_FILE="${COMPOSE_FILE}${SEPARATOR}${overrides_ide_file}"
+	fi
 
-		# Include a volumes yml if requested. Use bind mount volumes by default.
-		if is_mac; then
-			# Default to NFS volumes on Mac (both VirtualBox and Docker Desktop)
-			DOCKSAL_VOLUMES=${DOCKSAL_VOLUMES:-nfs}
-		else
-			# Bind mounted volumes on all other systems
-			DOCKSAL_VOLUMES=${DOCKSAL_VOLUMES:-bind}
-		fi
-		if [[ "$DOCKSAL_VOLUMES" != "disabled" ]]; then
-			volumes_yml_file="$(get_config_dir_dc)/stacks/volumes-$DOCKSAL_VOLUMES.yml"
-			if [[ -f "$volumes_yml_file" ]]; then
-				COMPOSE_FILE="${volumes_yml_file}${SEPARATOR}${COMPOSE_FILE}"
-			else
-				echo-error "Volumes definition not found in ${volumes_yml_file}." \
-					"Please check that ${yellow}DOCKSAL_VOLUMES${NC} is set properly." \
-					"You may need to run ${yellow}fin update${NC} to download volume definitions."
-				exit 1
-			fi
-		fi
-		export DOCKSAL_VOLUMES
-
-		# Fix bind volumes on Docker Desktop v2.3.0.2+
-		# See https://github.com/docksal/docksal/issues/1368
-		overrides_dd_bind_file="$(get_config_dir_dc)/stacks/overrides-dd-bind.yml"
-		if [[ -f "${overrides_dd_bind_file}" ]] && \
-			is_docker_native && \
-			(( $(ver_to_int $(docker_desktop_version)) >= $(ver_to_int '2.3.0.2') )) && \
-			[[ "$DOCKSAL_VOLUMES" == "bind" ]];
-		then
-			COMPOSE_FILE="${COMPOSE_FILE}${SEPARATOR}${overrides_dd_bind_file}"
-		fi
-
-		# Enable VSCode (Coder) IDE
-		overrides_ide_file="$(get_config_dir_dc)/stacks/overrides-ide.yml"
-		if [[ -f "${overrides_ide_file}" ]] && [[ "$IDE_ENABLED" != "" ]] && [[ "$IDE_ENABLED" != "0" ]]; then
-			COMPOSE_FILE="${COMPOSE_FILE}${SEPARATOR}${overrides_ide_file}"
-		fi
-
-		# Enable xhprof integration
-		overrides_xhprof_file="$(get_config_dir_dc)/stacks/overrides-xhprof.yml"
-		if [[ -f "${overrides_xhprof_file}" ]] && [[ "$XHPROF_ENABLED" != "" ]] && [[ "$XHPROF_ENABLED" != "0" ]]; then
-			COMPOSE_FILE="${COMPOSE_FILE}${SEPARATOR}${overrides_xhprof_file}"
-		fi
+	# Enable xhprof integration
+	overrides_xhprof_file="$(get_config_dir_dc)/stacks/overrides-xhprof.yml"
+	if [[ -f "${overrides_xhprof_file}" ]] && [[ "$XHPROF_ENABLED" != "" ]] && [[ "$XHPROF_ENABLED" != "0" ]]; then
+		COMPOSE_FILE="${COMPOSE_FILE}${SEPARATOR}${overrides_xhprof_file}"
 	fi
 
 	export COMPOSE_FILE
-	export DOCKSAL_ENVIRONMENT
 
 	# Set project name if it was not set previously
 	if [[ -d $(get_project_path) ]]; then
@@ -8213,15 +8212,8 @@ case "$1" in
 			init "$@"
 		fi
 		;;
-	start)
+	start|up)
 		load_configuration
-		check_for_updates
-		shift
-		up
-		;;
-	up)
-		# force re-reading of configuration files
-		COMPOSE_FILE="" ENV_FILE="" DOCKSAL_VOLUMES="" load_configuration
 		check_for_updates
 		shift
 		up
@@ -8294,15 +8286,8 @@ case "$1" in
 				check_for_updates
 				project_status
 				;;
-			start)
+			start|up)
 				load_configuration
-				check_for_updates
-				shift
-				up
-				;;
-			up)
-				# force re-reading of configuration files
-				COMPOSE_FILE="" ENV_FILE="" DOCKSAL_VOLUMES="" load_configuration
 				check_for_updates
 				shift
 				up

--- a/bin/fin
+++ b/bin/fin
@@ -6078,7 +6078,6 @@ ngrok_share ()
 # Check whether cloudflared container is running
 cloudflared_is_running ()
 {
-	load_configuration
 	# docker ps is about 1s faster than docker-compose ps
 	local container_id=$(docker ps --quiet --filter "name=${COMPOSE_PROJECT_NAME_SAFE}_cloudflared_1")
 	[[ "${container_id}" != "" ]] && return 0 || return 1
@@ -6093,7 +6092,6 @@ cloudflared_get_status ()
 # Output cloudflared container logs
 cloudflared_get_logs ()
 {
-	load_configuration
 	# docker logs is about 1s faster than docker-compose logs
 	docker logs "${COMPOSE_PROJECT_NAME_SAFE}_cloudflared_1"
 }
@@ -6121,10 +6119,8 @@ cloudflared_print_status ()
 # Enable and start cloudflared integration
 cloudflared_start ()
 {
-	# Write the variables into docksal-local.env
-	config_set --env=local "CLOUDFLARED_ENABLED=1"
-	# Force re-reading of configuration files and updated stack
-	COMPOSE_FILE="" ENV_FILE="" DOCKSAL_VOLUMES="" load_configuration
+	config_set --env=local "CLOUDFLARED_ENABLED=1" 1>/dev/null
+	load_configuration 1>/dev/null # Reload stack config after variable update
 	up
 
 	sleep 10 # Give the tunnel some time to initialize
@@ -6134,10 +6130,9 @@ cloudflared_start ()
 # Disable and remove cloudflared integration
 cloudflared_stop ()
 {
-	# Remove the variables from docksal-local.env
-	config_remove --env=local "CLOUDFLARED_ENABLED"
-	# Force re-reading of configuration files and updated stack
-	COMPOSE_FILE="" ENV_FILE="" DOCKSAL_VOLUMES="" load_configuration
+	config_remove --env=local "CLOUDFLARED_ENABLED" 1>/dev/null
+	unset CLOUDFLARED_ENABLED
+	load_configuration 1>/dev/null # Reload stack config after variable update
 	up
 }
 
@@ -8703,6 +8698,7 @@ case "$1" in
 		ngrok_share "$@"
 		;;
 	share-v2)
+		load_configuration
 		shift
 		case "$1" in
 			start)

--- a/bin/fin
+++ b/bin/fin
@@ -371,6 +371,7 @@ URL_REPO_SYMFONY_WEBAPP="https://github.com/docksal/boilerplate-symfony-webapp.g
 URL_REPO_BACKDROP="https://github.com/docksal/boilerplate-backdrop.git"
 URL_ADDONS_HOSTING="https://raw.githubusercontent.com"
 URL_ADDONS_REPO="$URL_ADDONS_HOSTING/docksal/addons"
+STACKS_OVERRIDES_CLOUDFLARED="overrides-cloudflared.yml"
 STACKS_OVERRIDES_DD_BIND="overrides-dd-bind.yml"
 STACKS_OVERRIDES_IDE="overrides-ide.yml"
 STACKS_OVERRIDES_XHPROF="overrides-xhprof.yml"
@@ -1718,6 +1719,7 @@ show_help ()
 	printh "pull [options]" "Commands for interacting with Hosting Providers (${yellow}fin help pull${NC})"
 	printh "run-cli (rc) <command>" "Run a command in a standalone cli container in the current directory (${yellow}fin help run-cli${NC})"
 	printh "share" "Create temporary public url for current project using ngrok"
+	printh "share-v2" "Create a temporary public URL for the project using Cloudflare Tunnel"
 	printh "vhosts" "List all virtual *.docksal hosts registered in Docksal proxy"
 	echo
 
@@ -2244,7 +2246,7 @@ show_help_alias ()
 show_help_share ()
 {
 	echo
-	echo "Share the project via public url generated with ngrok"
+	echo "Create a temporary public URL for the project using ngrok"
 
 	echo
 	echo "Usage: share [options]"
@@ -2261,6 +2263,27 @@ show_help_share ()
 	echo
 	echo "Examples:"
 	printh "fin share --host=subdomain.mysite.docksal" "Expose certain subdomain"
+}
+
+show_help_share-v2 ()
+{
+	echo
+	echo "Create a temporary public URL for the project using Cloudflare Tunnel"
+
+	echo
+	echo "Usage: share-v2 [command]"
+
+	echo
+	echo "Commands:"
+	printh "start" "Start tunnel and print public URL"
+	printh "stop" "Stop tunnel"
+	printh "status" "Prints tunnel status and public URL (if Active)"
+	printh "url" "Prints tunnel public URL"
+	printh "logs" "Prints tunnel container logs"
+
+	echo
+	echo "Examples:"
+	printh "fin share-v2 start" "Start tunnel and print public URL"
 }
 
 show_help_config ()
@@ -4950,6 +4973,7 @@ update_tools ()
 update_config_files ()
 {
 	files_to_download="
+			$STACKS_OVERRIDES_CLOUDFLARED
 			$STACKS_OVERRIDES_DD_BIND
 			$STACKS_OVERRIDES_IDE
 			$STACKS_OVERRIDES_XHPROF
@@ -6049,6 +6073,74 @@ ngrok_share ()
 		sh -c "${ARGS}"
 }
 
+# Cloudflare Tunnel (cloudflared) integration
+
+# Check whether cloudflared container is running
+cloudflared_is_running ()
+{
+	load_configuration
+	# docker ps is about 1s faster than docker-compose ps
+	local container_id=$(docker ps --quiet --filter "name=${COMPOSE_PROJECT_NAME_SAFE}_cloudflared_1")
+	[[ "${container_id}" != "" ]] && return 0 || return 1
+}
+
+# Get cloudflared container status
+cloudflared_get_status ()
+{
+	cloudflared_is_running && echo "Active" || echo "Inactive"
+}
+
+# Output cloudflared container logs
+cloudflared_get_logs ()
+{
+	load_configuration
+	# docker logs is about 1s faster than docker-compose logs
+	docker logs "${COMPOSE_PROJECT_NAME_SAFE}_cloudflared_1"
+}
+
+# Extracts tunnel host name from cloudflared container logs
+cloudflared_get_host ()
+{
+	cloudflared_get_logs 2>&1 | grep "trycloudflare.com" | tail -1 | awk '{print $4}'
+}
+
+# Nicely print tunnel URL
+cloudflared_print_url ()
+{
+	echo -e "${green}Public URL:${NC} ${yellow}$(cloudflared_get_host)${NC}"
+}
+
+# Nicely print tunnel status
+cloudflared_print_status ()
+{
+	echo -e "${green}Status:${NC} $(cloudflared_get_status)"
+	cloudflared_is_running &&
+		echo -e "${green}Public URL:${NC} ${yellow}$(cloudflared_get_host)${NC}"
+}
+
+# Enable and start cloudflared integration
+cloudflared_start ()
+{
+	# Write the variables into docksal-local.env
+	config_set --env=local "CLOUDFLARED_ENABLED=1"
+	# Force re-reading of configuration files and updated stack
+	COMPOSE_FILE="" ENV_FILE="" DOCKSAL_VOLUMES="" load_configuration
+	up
+
+	sleep 10 # Give the tunnel some time to initialize
+	cloudflared_print_url
+}
+
+# Disable and remove cloudflared integration
+cloudflared_stop ()
+{
+	# Remove the variables from docksal-local.env
+	config_remove --env=local "CLOUDFLARED_ENABLED"
+	# Force re-reading of configuration files and updated stack
+	COMPOSE_FILE="" ENV_FILE="" DOCKSAL_VOLUMES="" load_configuration
+	up
+}
+
 # Print information required for issue diagnostics
 # --all will print additional information that is hidden by default as it's not usually needed
 diagnose ()
@@ -6467,6 +6559,12 @@ load_configuration ()
 		COMPOSE_FILE="${COMPOSE_FILE}${SEPARATOR}${overrides_xhprof_file}"
 	fi
 
+	# Enable Cloudflare Tunnel (cloudflared) integration
+	overrides_cloudflared_file="$(get_config_dir_dc)/stacks/overrides-cloudflared.yml"
+	if [[ -f "${overrides_cloudflared_file}" ]] && [[ "$CLOUDFLARED_ENABLED" != "" ]] && [[ "$CLOUDFLARED_ENABLED" != "0" ]]; then
+		COMPOSE_FILE="${COMPOSE_FILE}${SEPARATOR}${overrides_cloudflared_file}"
+	fi
+
 	export COMPOSE_FILE
 
 	# Set project name if it was not set previously
@@ -6594,8 +6692,12 @@ config_show ()
 	echo "VIRTUAL_HOST: ${VIRTUAL_HOST}"
 	echo "VIRTUAL_HOST_ALIASES: *.${VIRTUAL_HOST}"
 	echo "IP: $DOCKSAL_IP"
+	echo ""
 
-	echo "MYSQL:" $(docker-compose port db 3306 2>/dev/null | sed "s/0\.0\.0\.0/$DOCKSAL_IP/")
+	echo "MySQL endpoint:" $(docker-compose port db 3306 2>/dev/null | sed "s/0\.0\.0\.0/$DOCKSAL_IP/")
+	echo "Public URL:" $(cloudflared_get_host)
+
+	# Stop here for "fin config env"
 	[[ "$1" == "env" ]] && return
 
 	echo
@@ -8599,6 +8701,35 @@ case "$1" in
 		load_configuration
 		shift
 		ngrok_share "$@"
+		;;
+	share-v2)
+		shift
+		case "$1" in
+			start)
+				shift
+				cloudflared_start
+				;;
+			stop)
+				shift
+				cloudflared_stop
+				;;
+			status)
+				shift
+				cloudflared_print_status
+				;;
+			url)
+				shift
+				cloudflared_print_url
+				;;
+			logs)
+				shift
+				cloudflared_get_logs
+				;;
+			*)
+				shift
+				show_help_share-v2
+				;;
+		esac
 		;;
 	cleanup)
 		# no load_configuration

--- a/stacks/overrides-cloudflared.yml
+++ b/stacks/overrides-cloudflared.yml
@@ -1,0 +1,9 @@
+# Adds Cloudflare Argo Tunnel (cloudflared) service to the project
+
+version: "3.9"
+
+services:
+  cloudflared:
+    extends:
+      file: ${HOME}/.docksal/stacks/services.yml
+      service: cloudflared

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -264,7 +264,7 @@ services:
   # Cloudflare Argo Tunnel
   cloudflared:
     hostname: cloudflared
-    image: ${CLOUDFLARED_IMAGE:-cloudflare/cloudflared:2021.8.1}
+    image: ${CLOUDFLARED_IMAGE:-cloudflare/cloudflared:2022.3.4}
     environment:
       - TUNNEL_URL=http://web
       - NO_AUTOUPDATE=true

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -264,7 +264,7 @@ services:
   # Cloudflare Argo Tunnel
   cloudflared:
     hostname: cloudflared
-    image: ${CLOUDFLARED_IMAGE:-cloudflare/cloudflared:2022.3.4}
+    image: ${CLOUDFLARED_IMAGE:-raspbernetes/cloudflared:latest}
     environment:
       - TUNNEL_URL=http://web
       - NO_AUTOUPDATE=true

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -260,3 +260,15 @@ services:
     << : *dns
     << : *logging
     << : *healthcheck
+
+  # Cloudflare Argo Tunnel
+  cloudflared:
+    hostname: cloudflared
+    image: ${CLOUDFLARED_IMAGE:-cloudflare/cloudflared:2021.8.1}
+    environment:
+      - TUNNEL_URL=http://web
+      - NO_AUTOUPDATE=true
+    command: ["tunnel"]
+    << : *dns
+    << : *logging
+    << : *healthcheck

--- a/tests/scripts/share-v2.sh
+++ b/tests/scripts/share-v2.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mkdir "$GITHUB_WORKSPACE/../test-share-v2"
+cd "$GITHUB_WORKSPACE/../test-share-v2"
+mkdir .docksal
+bats "$GITHUB_WORKSPACE/tests/share-v2.bats"

--- a/tests/share-v2.bats
+++ b/tests/share-v2.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+
+# Debugging
+teardown() {
+	echo "Status: $status"
+	echo "Output:"
+	echo "================================================================"
+	for line in "${lines[@]}"; do
+		echo $line
+	done
+	echo "================================================================"
+}
+
+# To work on a specific test:
+# run `export SKIP=1` locally, then comment skip in the test you want to debug
+
+@test "Start project stack" {
+	[[ $SKIP == 1 ]] && skip
+
+	fin start
+	run fin project list
+	echo "$output" | grep 'test-share-v2'
+	unset output
+}
+
+@test "fin share-v2 start" {
+	[[ $SKIP == 1 ]] && skip
+
+	run fin share-v2 start 2>&1
+	echo "$output" | grep '_cloudflared_1' | grep 'Started'
+	echo "$output" | grep 'Public URL' | grep 'trycloudflare.com'
+	unset output
+}
+
+@test "fin share-v2 status (Active)" {
+	[[ $SKIP == 1 ]] && skip
+
+	run fin share-v2 status
+	echo "$output" | grep 'Status' | grep 'Active'
+	echo "$output" | grep 'Public URL' | grep 'trycloudflare.com'
+	unset output
+}
+
+@test "fin share-v2 stop" {
+	[[ $SKIP == 1 ]] && skip
+
+	run fin share-v2 stop 2>&1
+	echo "$output" | grep '_cloudflared_1' | grep 'Removed'
+	unset output
+}
+
+@test "fin share-v2 status (Inactive)" {
+	[[ $SKIP == 1 ]] && skip
+
+	run fin share-v2 status
+	echo "$output" | grep 'Status' | grep 'Inactive'
+	unset output
+}


### PR DESCRIPTION
Creates a temporary public URL for the project using a [free Cloudflare Tunnel](https://try.cloudflare.com/) ([formerly Argo Tunnel](https://developers.cloudflare.com/cloudflare-one/glossary#cloudflare-tunnel)).

This integration is implemented similar to the IDE integration.
`cloudflared` services runs as part of the project's Docker Compose stack.

It can be enabled via an environment variable:

```
❯ fin config set --env=local CLOUDFLARED_ENABLED=1
Added value for CLOUDFLARED_ENABLED into /Users/leonid/Work/Projects/test/.docksal/docksal-local.env

~/Work/Projects/test main*
❯ fin project start
Starting services...
test_db_1 is up-to-date
test_cli_1 is up-to-date
test_web_1 is up-to-date
Creating test_cloudflared_1 ... done
Project URL: http://test.docksal.site
```

It also can be managed via a dedicated `fin share-v2` command group:

```
❯ fin share-v2

Create a temporary public URL for the project using Cloudflare Argo Tunnel

Usage: share-v2 [command]

Commands:
  start                         Start tunnel and print public URL
  stop                          Stop tunnel
  status                        Prints tunnel status and public URL (if Active)
  url                           Prints tunnel public URL
  logs                          Prints tunnel container logs

Examples:
  fin share-v2 start            Start tunnel and print public URL
```

**To test**

```
DOCKSAL_VERSION=feature/share-v2 fin update
fin share-v2
```

**Demo**

[![image](https://user-images.githubusercontent.com/1205005/128408568-58945e27-9ab7-49ce-9a82-c3f5b9cbc83e.png)](https://asciinema.org/a/429133)

Related to #1494 