### PR TITLE
Use Blackfire Agent v2

### DIFF
--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -235,7 +235,7 @@ services:
 
   # Blackfire
   blackfire:
-    image: blackfire/blackfire
+    image: blackfire/blackfire:2
     environment:
       - BLACKFIRE_SERVER_ID
       - BLACKFIRE_SERVER_TOKEN


### PR DESCRIPTION
Blackfire Agent v1 is reaching end of life.
This PR ensures that v2 is used.
