### PR TITLE
Add environment override configuration support.

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -6287,6 +6287,7 @@ load_configuration ()
 	local SEPARATOR=':'; is_windows && SEPARATOR=';'
 	local env_file="$(get_project_path_dc)/.docksal/docksal.env"
 	local local_env_file="$(get_project_path_dc)/.docksal/docksal-${DOCKSAL_ENVIRONMENT}.env"
+	local overrides_env_file="$(get_project_path_dc)/.docksal/docksal-${DOCKSAL_ENVIRONMENT}-overrides.env"
 	if [[ -f "$env_file" ]]; then
 		ENV_FILE="$env_file"
 		fix_crlf_warning "$env_file"
@@ -6301,6 +6302,15 @@ load_configuration ()
 			fix_crlf_warning "$local_env_file"
 			# Source and allexport variables in the .env file
 			set -a; source "$local_env_file"; set +a
+	fi
+	# This is used to print the list of included env files in `fin config`
+
+  # Source overrides env file if it exist
+	if [[ -f "$overrides_env_file" ]]; then
+			ENV_FILE="${ENV_FILE}${SEPARATOR}${overrides_env_file}"
+			fix_crlf_warning "$overrides_env_file"
+			# Source and allexport variables in the .env file
+			set -a; source "$overrides_env_file"; set +a
 	fi
 	# This is used to print the list of included env files in `fin config`
 	export ENV_FILE
@@ -6337,6 +6347,16 @@ load_configuration ()
 			# Allow using this with the pre-configured stacks by not checking docksal.env presence.
 			local local_yml_file="$(get_project_path_dc)/.docksal/docksal-${DOCKSAL_ENVIRONMENT}.yml"
 			[[ -f "$local_yml_file" ]] && COMPOSE_FILE="${COMPOSE_FILE}${SEPARATOR}${local_yml_file}"
+		fi
+
+    # Throw an error if COMPOSE_FILE is empty here
+		if [[ "$COMPOSE_FILE" == "" ]]; then
+			echo-error "No configuration files found." "Expected in $yml_file"
+			exit 1
+		else
+			# Include docksal-{DOCKSAL_ENVIRONMENT}-overrides.yml (if exists)
+			local overrides_yml_file="$(get_project_path_dc)/.docksal/docksal-${DOCKSAL_ENVIRONMENT}-overrides.yml"
+			[[ -f "$overrides_yml_file" ]] && COMPOSE_FILE="${COMPOSE_FILE}${SEPARATOR}${overrides_yml_file}"
 		fi
 
 		# Include a volumes yml if requested. Use bind mount volumes by default.


### PR DESCRIPTION
Purpose: In some organizations, a single team provides shared
configuration across multiple projects.

Allowing for one or even an arbitrary amount of environment override
files should be doable, I think. It's just a matter of whether or not it makes sense for Docksal to support.

In my situation, one team desires the ability to create a custom docksal-local-overrides.yml file to make some configuration standard across all the organization's projects in an automated fashion. But the preference is for this to stand alone in its own configuration file. 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docksal/docksal/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Write a short summary that describes the changes in this pull request:
-->
