### PR TITLE
Release 1.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## 1.16.0 (2021-09-27)
+## 1.16.2 (2021-09-28)
+
+### New software versions
+
+- fin v1.107.1
+
+### Changes and improvements
+
+- Fixed terminal colors in `fin` broken on some systems after update to v1.16.1
+
+
+## 1.16.1 (2021-09-27)
 
 ### New software versions
 

--- a/bin/fin
+++ b/bin/fin
@@ -1,26 +1,27 @@
 #!/usr/bin/env bash
 
-FIN_VERSION=1.107.0
+FIN_VERSION=1.107.1
 
 # Predefined terminal colors
-# Format: '\e[<formatting>;<text-color>;<background-color>m'
+# Format: '\033[<formatting>;<text-color>;<background-color>m'
 # See https://misc.flogisoft.com/bash/tip_colors_and_formatting
+# Note: Using "\033" (and not "\e") as it seems to have a wider support in different shells.
 if [[ "$TERM" != "dumb" ]]; then
 	# Console colors
-	green='\e[0;32;49m'
-	green_bg='\e[0;42;30m'
-	yellow='\e[0;33;49m'
-	yellow_bold='\e[1;33;49m'
-	yellow_bg='\e[0;43;30m'
-	red='\e[0;91;49m'
-	red_bg='\e[0;101;30m'
-	blue='\e[0;34;49m'
-	lime='\e[0;92;49m'
-	acqua='\e[0;96;49m'
-	magenta='\e[0;35;49m'
-	lightmagenta='\e[0;95;49m'
-	lightmagenta_bg='\e[0;105;30m'
-	NC='\e[0m'
+	green='\033[0;32;49m'
+	green_bg='\033[0;42;30m'
+	yellow='\033[0;33;49m'
+	yellow_bold='\033[1;33;49m'
+	yellow_bg='\033[0;43;30m'
+	red='\033[0;91;49m'
+	red_bg='\033[0;101;30m'
+	blue='\033[0;34;49m'
+	lime='\033[0;92;49m'
+	acqua='\033[0;96;49m'
+	magenta='\033[0;35;49m'
+	lightmagenta='\033[0;95;49m'
+	lightmagenta_bg='\033[0;105;30m'
+	NC='\033[0m'
 fi
 
 #-------------------------------- OS Checks ------------------------------------

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -12,7 +12,7 @@ theme = "learn"
   google_tag_manager = "GTM-58ST6XD"
   google_analytics = "UA-93724315-3"
 
-  version = "v1.16.1"
+  version = "v1.16.2"
 
   [[params.versions]]
   version = "Upcoming"
@@ -20,9 +20,14 @@ theme = "learn"
   url = "https://develop.docs.docksal.io/"
 
   [[params.versions]]
+  version = "v1.16.2"
+  branch = "v1.16.2"
+  url = "https://docs.docksal.io"
+
+  [[params.versions]]
   version = "v1.16.1"
   branch = "v1.16.1"
-  url = "https://docs.docksal.io"
+  url = "https://v1-16-1.docs.docksal.io"
 
   [[params.versions]]
   version = "v1.16.0"

--- a/docs/content/fin/fin-help.md
+++ b/docs/content/fin/fin-help.md
@@ -7,7 +7,7 @@ aliases:
 
 ## fin {#fin}
 
-	Docksal command line utility (v1.107.0)
+	Docksal command line utility (v1.107.1)
 	Docksal docs: https://docs.docksal.io/
 	
 	Usage: fin [command]


### PR DESCRIPTION
## 1.16.2 (2021-09-28)

### New software versions

- fin v1.107.1

### Changes and improvements

- Fixed terminal colors in `fin` broken on some systems after update to v1.16.1
