### PR TITLE
Updating pantheon stack to use default MariaDB version.

### DIFF
--- a/stacks/stack-pantheon.yml
+++ b/stacks/stack-pantheon.yml
@@ -24,8 +24,6 @@ services:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml
       service: mariadb
-    # Pin MariaDB version
-    image: ${DB_IMAGE:-docksal/mariadb:10.1-1.1}
 
   cli:
     extends:


### PR DESCRIPTION
Small update to use the default MariaDB version in the Pantheon stack.

Closes #1590 
