### PR TITLE
Add missing platformsh stack

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -349,6 +349,7 @@ STACKS_STACK_DEFAULT="stack-default.yml"
 STACKS_STACK_DEFAULT_NODB="stack-default-nodb.yml"
 STACKS_STACK_NODE="stack-node.yml"
 STACKS_STACK_PANTHEON="stack-pantheon.yml"
+STACKS_STACK_PLATFORMSH="stack-platformsh.yml"
 STACKS_VOLUMES_BIND="volumes-bind.yml"
 STACKS_VOLUMES_NFS="volumes-nfs.yml"
 STACKS_VOLUMES_NONE="volumes-none.yml"
@@ -4882,6 +4883,7 @@ update_config_files ()
 			$STACKS_STACK_DEFAULT_NODB
 			$STACKS_STACK_NODE
 			$STACKS_STACK_PANTHEON
+			$STACKS_STACK_PLATFORMSH
 			$STACKS_VOLUMES_BIND
 			$STACKS_VOLUMES_NFS
 			$STACKS_VOLUMES_NONE


### PR DESCRIPTION
The new platformsh stack is not actually installed/updated on local machine when installing or upgrading docksal.

Added entry to STACK variables and in `update_config_files` function to ensure the new stack is installed.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docksal/docksal/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Write a short summary that describes the changes in this pull request:
-->
