### PR TITLE
Update stack-platformsh.yml mariadb version

### DIFF
--- a/stacks/stack-platformsh.yml
+++ b/stacks/stack-platformsh.yml
@@ -2,7 +2,7 @@
 # see https://github.com/platformsh-templates/drupal9
 #
 # - Nginx 1.14
-# - MariaDB 10.3
+# - MariaDB 10.4
 # - PHP 7.4
 # - Redis 6.0
 
@@ -24,7 +24,7 @@ services:
       file: ${HOME}/.docksal/stacks/services.yml
       service: mariadb
     # Pin MariaDB version
-    image: ${DB_IMAGE:-docksal/mariadb:10.3-1.1}
+    image: ${DB_IMAGE:-docksal/mariadb:10.4}
 
   cli:
     extends:


### PR DESCRIPTION
Now that docksal offers mariadb:10.4, update platformsh stack to match [Platform.sh Drupal 9 template](https://github.com/platformsh-templates/drupal9).

Redis stays at 6.0 as that is recommended version in [docs.platform.sh](https://docs.platform.sh/guides/drupal9/redis.html).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docksal/docksal/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Write a short summary that describes the changes in this pull request:
-->
