### PR TITLE
Update system-dns.md

### DIFF
--- a/docs/content/core/system-dns.md
+++ b/docs/content/core/system-dns.md
@@ -28,7 +28,7 @@ If you run into issues with DNS resolution, try disabling the automatic resolver
 
 ```bash
 fin system stop
-fin config set --global DOCKSAL_NO_DNS_RESOLVER=1
+fin config set --global DOCKSAL_DNS_DISABLED=1
 fin system start
 ```
 


### PR DESCRIPTION
With DOCKSAL_NO_DNS_RESOLVER=1 docksal will still try to start up the DNS service.
Need to use DOCKSAL_DNS_DISABLED=1 to actually disable the service completely.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docksal/docksal/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Write a short summary that describes the changes in this pull request:
-->
