### PR TITLE
VirtualBox on macOS Monterey (12.x) support

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -2526,7 +2526,7 @@ docker_machine_create ()
 	fi
 
 	# Use 2 CPUs in case of 4 or more CPUs/cores on host
-	# This tremendously helps with network files sytem operations in some cases
+	# This tremendously helps with network files system operations in some cases
 	local VIRTUALBOX_CPU_COUNT=1
 	system_cpu_count=$(getconf _NPROCESSORS_ONLN 2>/dev/null)
 	# process possible failure as 1 cpu

--- a/bin/fin
+++ b/bin/fin
@@ -171,8 +171,8 @@ REQUIREMENTS_DOCKER_DESKTOP='4.4.2' # Build 73305
 
 # VirtualBox download URLs
 # Remember to update REQUIREMENTS_VBOX above
-URL_VBOX_MAC="https://download.virtualbox.org/virtualbox/6.1.22/VirtualBox-6.1.22-144080-OSX.dmg"
-URL_VBOX_WIN="https://download.virtualbox.org/virtualbox/6.1.22/VirtualBox-6.1.22-144080-Win.exe"
+URL_VBOX_MAC="https://download.virtualbox.org/virtualbox/6.1.32/VirtualBox-6.1.32-149290-OSX.dmg"
+URL_VBOX_WIN="https://download.virtualbox.org/virtualbox/6.1.32/VirtualBox-6.1.32-149290-Win.exe"
 
 # Configuration paths
 # Rewrite $HOME on windows to be absolute path in Unix notation

--- a/bin/fin
+++ b/bin/fin
@@ -2535,6 +2535,14 @@ docker_machine_create ()
 		VIRTUALBOX_CPU_COUNT=2
 	fi
 
+	# Allow Docksal subnet IPs to be assigned to a VirtualBox host-only adapter (VirtualBox v6.1.28+)
+	# https://github.com/docksal/docksal/issues/1596
+	if is_mac && ! (cat /etc/vbox/networks.conf 2>/dev/null | grep -e "^\* ${DOCKSAL_SUBNET}" >/dev/null); then
+		echo "Writing /etc/vbox/networks.conf..."
+		sudo mkdir -p /etc/vbox
+		echo "* ${DOCKSAL_SUBNET}" | sudo tee -a /etc/vbox/networks.conf >/dev/null
+	fi
+
 	docker-machine create \
  		--driver=virtualbox \
 		--virtualbox-boot2docker-url "${URL_BOOT2DOCKER}" \

--- a/docs/content/getting-started/setup.md
+++ b/docs/content/getting-started/setup.md
@@ -67,22 +67,13 @@ Click the preferred option to proceed to option-specific docs.
 
 ### macOS with VirtualBox {#install-macos-virtualbox}
 
-With this method, Docker will run inside a VM in VirtualBox.
-
-1. Install VirtualBox v6.1.22
-
-    [![Download VirtualBox v6.1.22](https://img.shields.io/badge/download-VirtualBox%20for%20Mac-blue.svg?logo=dropbox&style=for-the-badge&classes=inline)](https://download.virtualbox.org/virtualbox/6.1.22/VirtualBox-6.1.22-144080-OSX.dmg)
-
-1. Enable Kernel extension ([Why?](https://developer.apple.com/library/content/technotes/tn2459/_index.html))
-
-    Go to `System Preferences > Security & Privacy`.  
-    If you do not see the Allow button it means the extension is already enabled.
-
-    ![Allowing VirtualBox kernel extension](/images/virtualbox-kernel-extension-allow.png)
+With this method, Docker will run inside a VirtualBox VM.
 
 1. Open Terminal app and run
 
         bash <(curl -fsSL https://get.docksal.io)
+
+VirtualBox will be installed automatically if necessary. Follow the prompts in the Terminal app.
 
 ### macOS with Docker Desktop {#install-macos-docker-for-mac}
 

--- a/docs/content/troubleshooting/common-issues.md
+++ b/docs/content/troubleshooting/common-issues.md
@@ -329,15 +329,19 @@ to run the project.
 
 See Issue 3. Lack of memory for resolution.
 
-## Issue 12. VirtualBox Installation Fails on macOS High Sierra 10.13 {#issue-12}
+## Issue 12. VirtualBox Installation Fails on macOS {#issue-12}
 
-New Docksal / VirtualBox installations fail on a fresh macOS High Sierra 10.13.x due to the new policy Apple introduced
+VirtualBox installation fails on macOS High Sierra v10.13 or later due to the new policy Apple introduced
 around third-party kernel extensions.
 
 ### How to Resolve
 
-- Open System Preferences > Security & Privacy and click the `Allow` button for `Oracle America, Inc.`
-- Restart the VirtualBox installation manually
+- Open `System Preferences > Security & Privacy` and click the `Allow` button for `Oracle America, Inc.`
+- Restart VirtualBox installation manually
+
+If you do not see the "Allow" button, it means the extension is already enabled.
+
+![Allowing VirtualBox kernel extension](/images/virtualbox-kernel-extension-allow.png)
 
 In certain cases you may have to reboot your Mac and then reinstall VirtualBox manually.
 


### PR DESCRIPTION
- Bump VirtualBox to v6.1.32 
- Allow Docksal subnet IPs to be assigned to a VirtualBox host-only adapter (VirtualBox v6.1.28+)
- Simplified macOS + VirtualBox installation instructions in docs
  - Recent version of VirtualBox seem to be properly handling the Kernel Extension (kext) installation check and approval.

Docs updates preview:
- https://deploy-preview-1622--docs-docksal-io.netlify.app/getting-started/setup/#install-macos-virtualbox
- https://deploy-preview-1622--docs-docksal-io.netlify.app/troubleshooting/common-issues/#issue-12

Fixes #1596 