### PR TITLE
Change cli debugging instructions

### DIFF
--- a/docs/content/tools/xdebug.md
+++ b/docs/content/tools/xdebug.md
@@ -77,11 +77,13 @@ First, follow [automatic](#phpstorm-automatic) or [manual](#phpstorm-manual) ins
 mapping settings in PHPStorm.
 
 To debug PHP CLI scripts, we have to tell PHPStorm which **existing** server configuration to use via the
-`PHP_IDE_CONFIG` variable. This can be done using the following commands:
+`PHP_IDE_CONFIG` variable. This must be added to `docksal.yml`:
 
-```bash
-fin config set --env=local 'PHP_IDE_CONFIG=serverName=${VIRTUAL_HOST}'
-fin project start
+```yml
+services:
+  cli:
+    environment:
+      - PHP_IDE_CONFIG="serverName=${VIRTUAL_HOST}"
 ```
 
 {{% notice warning %}}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docksal/docksal/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Write a short summary that describes the changes in this pull request:
-->

In attempting to configure Xdebug with PHPStorm to debug with Drush I found that the existing instructions didn't correctly set the `PHP_IDE_CONFIG` variable, I think because `VIRTUAL_HOST` is in a different context than `docksal-local.env` so it's not able to be referenced.

Using the old instructions, this is what I get after `fin up`:

```
❯ fin exec printenv PHP_IDE_CONFIG
serverName=
```

My project is using the default `VIRTUAL_HOST` (as I'd imagine many are) and not setting it in `docksal.env`. After setting `PHP_IDE_CONFIG` in `docksal.yml`:

```
❯ fin exec printenv PHP_IDE_CONFIG
"serverName=my-project.docksal"
```