### PR TITLE
Image updates in stacks

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -375,7 +375,7 @@ URL_WINPTY="https://github.com/rprichard/winpty/releases/download/${REQUIREMENTS
 IMAGE_SSH_AGENT=${IMAGE_SSH_AGENT:-docksal/ssh-agent:1.4}
 IMAGE_VHOST_PROXY=${IMAGE_VHOST_PROXY:-docksal/vhost-proxy:1.7}
 IMAGE_DNS=${IMAGE_DNS:-docksal/dns:1.2}
-IMAGE_RUN_CLI=${IMAGE_RUN_CLI:-docksal/cli:php7.4-3.0}
+IMAGE_RUN_CLI=${IMAGE_RUN_CLI:-docksal/cli:php7.4-3.1}
 
 #---------------------------- Helper functions --------------------------------
 

--- a/docs/content/service/cli/settings.md
+++ b/docs/content/service/cli/settings.md
@@ -37,13 +37,13 @@ When using the default stack (a custom project stack is not defined in `.docksal
 via the `CLI_IMAGE` variable in `.docksal/docksal.env`, e.g.:
 
 ```
-CLI_IMAGE='docksal/cli:2.12-php7.3'
+CLI_IMAGE='docksal/cli:php8.1-3.1'
 ```
 
 This can also be set with `fin config set`.
 
 ```bash
-fin config set CLI_IMAGE='docksal/cli:2.12-php7.3'
+fin config set CLI_IMAGE='docksal/cli:php8.1-3.1'
 ```
 
 Run `fin project reset cli` (`fin p reset cli`) to properly reset and update the `cli` service.

--- a/docs/content/service/web/multiple-web.md
+++ b/docs/content/service/web/multiple-web.md
@@ -38,7 +38,7 @@ Apache:
 services:
   ...
   styleguide:
-    image: docksal/apache:2.4-2.3
+    image: docksal/apache:2.4-2.4
     volumes:
       - project_root:/var/www:ro,nocopy,cached
     environment:

--- a/docs/content/service/web/multiple-web.md
+++ b/docs/content/service/web/multiple-web.md
@@ -53,7 +53,7 @@ Nginx:
 services:
   ...
   styleguide:
-    image: docksal/nginx:1.14-1.0
+    image: docksal/nginx:1.20-1.2
     volumes:
       - project_root:/var/www:ro,nocopy,cached
     environment:

--- a/docs/content/service/web/settings.md
+++ b/docs/content/service/web/settings.md
@@ -63,13 +63,13 @@ When using the default stack (a custom project stack is not defined in `.docksal
 via the `WEB_IMAGE` variable in `.docksal/docksal.env`, e.g.:
 
 ```bash
-WEB_IMAGE='docksal/apache:2.4-2.3'
+WEB_IMAGE='docksal/apache:2.4-2.4'
 ```
 
 This can also be set with `fin config set`.
 
 ```bash
-fin config set WEB_IMAGE='docksal/apache:2.4-2.3'
+fin config set WEB_IMAGE='docksal/apache:2.4-2.4'
 ```
 
 Remember to run `fin project restart web` (`fin p restart web`) to apply the configuration.

--- a/docs/content/stack/checking-configuration.md
+++ b/docs/content/stack/checking-configuration.md
@@ -41,7 +41,7 @@ networks: {}
 services:
   cli:
     hostname: cli
-    image: docksal/cli:2.11-php7.3
+    image: docksal/cli:php7.4-3.1
     volumes:
     - docksal_ssh_agent:/.ssh-agent:ro
     - project_root:/var/www:rw,nocopy,cached

--- a/docs/content/stack/checking-configuration.md
+++ b/docs/content/stack/checking-configuration.md
@@ -59,7 +59,7 @@ services:
     environment:
       APACHE_DOCUMENTROOT: /var/www/docroot
     hostname: web
-    image: docksal/apache:2.4-2.3
+    image: docksal/apache:2.4-2.4
     labels:
       io.docksal.project-root: /Users/testuser/projects/myproject
       io.docksal.virtual-host: myproject.docksal

--- a/docs/content/stack/extend-images.md
+++ b/docs/content/stack/extend-images.md
@@ -83,7 +83,7 @@ Here's another example for `web`:
 
 ```Dockerfile
 # Use a stock Docksal image as the base
-FROM docksal/apache:2.4-2.3
+FROM docksal/apache:2.4-2.4
 
 RUN set -x \
 	# Enabled extra modules

--- a/docs/content/stack/extend-images.md
+++ b/docs/content/stack/extend-images.md
@@ -48,7 +48,7 @@ Below is an example of extending the `cli` image with additional configs, apt, a
 ```Dockerfile
 # Note how we use cli:2 here, which refers to the latest available 2.x version
 # So that we wouldn't need to update this every time new version of Docksal cli releases
-FROM docksal/cli:2-php7.3
+FROM docksal/cli:php7.4-3
 
 # Install additional apt packages
 RUN apt-get update && apt-get -y --no-install-recommends install \

--- a/docs/content/stack/images-versions.md
+++ b/docs/content/stack/images-versions.md
@@ -82,7 +82,7 @@ v3 images bundle stock Debian versions of Ruby and Python, thus there is a versi
 
 | Image| Notes |
 |------|-------|
-| `docksal/apache:2.4-2.3` | *Default* Apache 2.4 |
+| `docksal/apache:2.4-2.4` | *Default* Apache 2.4 |
 | `docksal/apache:2.4`     | Apache 2.4 (latest) |
 
 ## Nginx 

--- a/docs/content/stack/images-versions.md
+++ b/docs/content/stack/images-versions.md
@@ -53,14 +53,15 @@ e.g., `fin image registry docksal/cli`, to see list of available CLI images. [Se
 
 | Image| Notes |
 |------|-------|
-| `docksal/cli:php8.0-3.0` | PHP 8.0, Nodejs 14.17.3, Ruby 2.5.5, Python 2.7.16, msmtp |
-| `docksal/cli:php7.4-3.0` | *Default image* PHP 7.4, Nodejs 14.17.3, Ruby 2.7.2, Python 2.7.16, msmtp |
-| `docksal/cli:php7.3-3.0` | PHP 7.3, Nodejs 14.17.3, Ruby 2.5.5, Python 3.8.3, msmtp |
+| `docksal/cli:php8.1-3.1` | PHP 8.1.3, Nodejs 14.17.3, Ruby 2.7.4, Python 3.9.2 |
+| `docksal/cli:php8.0-3.1` | PHP 8.0.16, Nodejs 14.17.3, Ruby 2.7.4, Python 3.9.2 |
+| `docksal/cli:php7.4-3.1` | *Default image* PHP 7.4.28, Nodejs 14.17.3, Ruby 2.7.4, Python 3.9.2 |
+| `docksal/cli:php8.1-3`    | Latest 3.x image version of PHP 8.1 flavor, convenient when [extending images](/stack/extend-images)
 | `docksal/cli:php8.0-3`    | Latest 3.x image version of PHP 8.0 flavor, convenient when [extending images](/stack/extend-images)
 | `docksal/cli:php7.4-3`    | Latest 3.x image version of PHP 7.4 flavor, convenient when [extending images](/stack/extend-images)
-| `docksal/cli:php7.3-3`    | Latest 3.x image version of PHP 7.3 flavor, convenient when [extending images](/stack/extend-images)
-| `docksal/cli:2.13-php7.4` | PHP 7.4, Nodejs 14.15.0, Ruby 2.7.2, Python 3.8.3, msmtp |
-| `docksal/cli:2.13-php7.3` | PHP 7.3, Nodejs 14.15.0, Ruby 2.7.2, Python 3.8.3, msmtp |
+| `docksal/cli:php7.3-3.0` | *Deprecated* PHP 7.3, Nodejs 14.17.3, Ruby 2.5.5, Python 3.8.3, msmtp |
+| `docksal/cli:2.13-php7.4` | *Deprecated* PHP 7.4, Nodejs 14.15.0, Ruby 2.7.2, Python 3.8.3, msmtp |
+| `docksal/cli:2.13-php7.3` | *Deprecated* PHP 7.3, Nodejs 14.15.0, Ruby 2.7.2, Python 3.8.3, msmtp |
 | `docksal/cli:2.11-php7.2` | *Deprecated* PHP 7.2, Nodejs 12.18.1, Ruby 2.7.1, Python 3.8.3, msmtp |
 | `docksal/cli:2.10-php7.1` | *Deprecated* PHP 7.1, Nodejs 12.13.0, Ruby 2.6.5, Python 3.8.3, msmtp |
 | `docksal/cli:2.5-php7.0`  | *Deprecated* PHP 7.0, mhsendmail |

--- a/docs/content/stack/images-versions.md
+++ b/docs/content/stack/images-versions.md
@@ -26,14 +26,14 @@ Note: `cli` is a special case, `cli` itself is seen as software here with `-php.
 You may notice that there are two versions of the same, e.g.:
 
 ```
-docksal/nginx:1.15
-docksal/nginx:1.15-1.0
+docksal/nginx:1.21
+docksal/nginx:1.21-1.2
 ```
 
-As described above `...-1.0` means image version here. `docksal/nginx:1.15` will always refer to the latest 
-available image version. Right now `docksal/nginx:1.15` is the same as `docksal/nginx:1.15-1.0`, but should
-we release `docksal/nginx:1.15-1.1`, and `docksal/nginx:1.15` would refer to `docksal/nginx:1.15-1.1`, while
-`docksal/nginx:1.15-1.0` would still exist for backwards compatibility. 
+As described above `...-1.2` means image version here. `docksal/nginx:1.21` will always refer to the latest 
+available image version. At some point, `docksal/nginx:1.21` is the same as `docksal/nginx:1.21-1.2`, but should
+we release `docksal/nginx:1.21-1.3`, and `docksal/nginx:1.21` would refer to `docksal/nginx:1.21-1.3`, while
+`docksal/nginx:1.21-1.1` would still exist for backwards compatibility. 
 
 Having this latest image tag is a convenient shortcut, but in stacks that are delivered with Docksal, 
 the exact version will always be used to avoid a situation when the newer image version was not pulled to your local.
@@ -92,16 +92,12 @@ v3 images bundle stock Debian versions of Ruby and Python, thus there is a versi
 
 | Image| Notes |
 |------|-------|
-| `docksal/nginx:1.15-1.0` | Nginx 1.15 (v. 1.0) |
-| `docksal/nginx:1.15`     | Nginx 1.15 (latest 1.15 image version) |
-| `docksal/nginx:1.14-1.0` | *Default* Nginx 1.14 (v. 1.0) |
-| `docksal/nginx:1.14`     | Nginx 1.14 (latest 1.14 image version) |
-| `docksal/nginx:1.13-1.0` | Nginx 1.13 (v. 1.0) |
-| `docksal/nginx:1.13`     | Nginx 1.13 (latest 1.13 image version) |
-| `docksal/nginx:1.12-1.0` | Nginx 1.12 (v. 1.0) |
-| `docksal/nginx:1.12`     | Nginx 1.12 (latest 1.12 image version) |
-| `docksal/nginx:1.11-1.0` | Nginx 1.11 (v. 1.0) |
-| `docksal/nginx:1.11`     | Nginx 1.11 (latest 1.11 image version) |
+| `docksal/nginx:1.21-1.2` | Nginx 1.21 (pinned version) |
+| `docksal/nginx:1.21`     | Nginx 1.21 (latest version) |
+| `docksal/nginx:1.20-1.2` | Nginx 1.20 (pinned version, default) |
+| `docksal/nginx:1.20`     | Nginx 1.20 (latest version) |
+| `docksal/nginx:1.15`     | Nginx 1.15 (legacy version) |
+| ...                      | ... |
 
 ## MySQL 
 

--- a/docs/content/stack/images-versions.md
+++ b/docs/content/stack/images-versions.md
@@ -118,16 +118,16 @@ v3 images bundle stock Debian versions of Ruby and Python, thus there is a versi
 
 | Image| Notes |
 |------|-------|
-| `docksal/mariadb:10.3-1.1`     | MariaDB 10.3 (default) |
-| `docksal/mariadb:10.3`         | MariaDB 10.3 (latest image version) |
-| `docksal/mariadb:10.2-1.1`     | MariaDB 10.2 |
-| `docksal/mariadb:10.2`         | MariaDB 10.2 (latest image version) |
-| `docksal/mariadb:10.1-1.1`     | MariaDB 10.1 |
-| `docksal/mariadb:10.1`         | MariaDB 10.1 (latest image version) |
-| `docksal/mariadb:10.0-1.1`     | MariaDB 10.0 |
-| `docksal/mariadb:10.0`         | MariaDB 10.0 (latest image version) |
-| `docksal/mariadb:5.5-1.1`      | MariaDB 5.5 |
-| `docksal/mariadb:5.5`          | MariaDB 5.5 (latest image version) |
+| `docksal/mariadb:10.6-1.3`     | MariaDB 10.6 (image v1.3, default) |
+| `docksal/mariadb:10.6`         | MariaDB 10.6 (latest version) |
+| `docksal/mariadb:10.5-1.3`     | MariaDB 10.5 (pinned version) |
+| `docksal/mariadb:10.5`         | MariaDB 10.5 (latest version) |
+| `docksal/mariadb:10.4-1.3`     | MariaDB 10.4 (pinned version) |
+| `docksal/mariadb:10.4`         | MariaDB 10.4 (latest version) |
+| `docksal/mariadb:10.3-1.3`     | MariaDB 10.3 (pinned version) |
+| `docksal/mariadb:10.3`         | MariaDB 10.3 (latest version) |
+| `docksal/mariadb:10.2`         | MariaDB 10.2 (legacy version) |
+| ...                            | ... |
 
 ## Apache Solr
 

--- a/docs/content/stack/images-versions.md
+++ b/docs/content/stack/images-versions.md
@@ -106,12 +106,10 @@ v3 images bundle stock Debian versions of Ruby and Python, thus there is a versi
 
 | Image| Notes |
 |------|-------|
-| `docksal/mysql:8.0-1.5`  | MySQL 8.0 |
-| `docksal/mysql:8.0`      | MySQL 8.0 (latest 8.0 image version) |
-| `docksal/mysql:5.7-1.5`  | MySQL 5.7 |
-| `docksal/mysql:5.7`      | MySQL 5.7 (latest 5.7 image version) |
-| `docksal/mysql:5.6-1.5`  | MySQL 5.6 (default) |
-| `docksal/mysql:5.6`      | MySQL 5.6 (latest image version) |
+| `docksal/mysql:8.0-2.0`  | MySQL 8.0 (pinned version, default) |
+| `docksal/mysql:8.0`      | MySQL 8.0 (latest version) |
+| `docksal/mysql:5.7`      | MySQL 5.7 (legacy version) |
+| ...                      | ... |
 
 ## MariaDB
 

--- a/examples/.docksal/docksal.env
+++ b/examples/.docksal/docksal.env
@@ -10,7 +10,7 @@ DOCKSAL_STACK=default
 
 # Lock images versions for LAMP services
 # This will prevent images from being updated when Docksal is updated
-#WEB_IMAGE='docksal/apache:2.4-2.3'
+#WEB_IMAGE='docksal/apache:2.4-2.4'
 #DB_IMAGE='docksal/mariadb:10.3-1.1'
 #CLI_IMAGE='docksal/cli:2.11-php7.3'
 

--- a/examples/.docksal/docksal.env
+++ b/examples/.docksal/docksal.env
@@ -11,8 +11,8 @@ DOCKSAL_STACK=default
 # Lock images versions for LAMP services
 # This will prevent images from being updated when Docksal is updated
 #WEB_IMAGE='docksal/apache:2.4-2.4'
-#DB_IMAGE='docksal/mariadb:10.3-1.1'
 #CLI_IMAGE='docksal/cli:2.11-php7.3'
+#DB_IMAGE='docksal/mariadb:10.6-1.3'
 
 # Override virtual host (matches project folder name by default)
 #VIRTUAL_HOST=drupal8.docksal

--- a/examples/.docksal/docksal.env
+++ b/examples/.docksal/docksal.env
@@ -11,8 +11,8 @@ DOCKSAL_STACK=default
 # Lock images versions for LAMP services
 # This will prevent images from being updated when Docksal is updated
 #WEB_IMAGE='docksal/apache:2.4-2.4'
-#CLI_IMAGE='docksal/cli:2.11-php7.3'
 #DB_IMAGE='docksal/mariadb:10.6-1.3'
+#CLI_IMAGE='docksal/cli:php7.4-3.1'
 
 # Override virtual host (matches project folder name by default)
 #VIRTUAL_HOST=drupal8.docksal

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -85,7 +85,7 @@ services:
   # DB: MySQL
   mariadb:
     hostname: db
-    image: ${DB_IMAGE:-docksal/mariadb:10.3-1.1}
+    image: ${DB_IMAGE:-docksal/mariadb:10.6-1.3}
     ports:
     - "${MYSQL_PORT_MAPPING:-3306}"
     volumes:

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -124,7 +124,7 @@ services:
   # CLI - Used for all console commands and tools.
   cli:
     hostname: cli
-    image: ${CLI_IMAGE:-docksal/cli:php7.4-3.0}
+    image: ${CLI_IMAGE:-docksal/cli:php7.4-3.1}
     volumes:
       - project_root:/var/www:rw,nocopy,cached  # Project root volume
       - docksal_ssh_agent:/.ssh-agent:ro  # Shared ssh-agent socket

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -42,7 +42,7 @@ services:
   # Web: Nginx
   nginx:
     hostname: web
-    image: ${WEB_IMAGE:-docksal/nginx:1.14-1.0}
+    image: ${WEB_IMAGE:-docksal/nginx:1.20-1.2}
     volumes:
     - project_root:/var/www:ro,nocopy,cached  # Project root volume (read-only)
     labels:

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -22,7 +22,7 @@ services:
   # Web: Apache
   apache:
     hostname: web
-    image: ${WEB_IMAGE:-docksal/apache:2.4-2.3}
+    image: ${WEB_IMAGE:-docksal/apache:2.4-2.4}
     volumes:
       - project_root:/var/www:ro,nocopy,cached  # Project root volume (read-only)
     labels:

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -63,7 +63,7 @@ services:
   # DB: MySQL
   mysql:
     hostname: db
-    image: ${DB_IMAGE:-docksal/mysql:5.7-1.5}
+    image: ${DB_IMAGE:-docksal/mysql:8.0-2.0}
     ports:
       - "${MYSQL_PORT_MAPPING:-3306}"
     volumes:

--- a/stacks/stack-pantheon.yml
+++ b/stacks/stack-pantheon.yml
@@ -16,7 +16,7 @@ services:
       file: ${HOME}/.docksal/stacks/services.yml
       service: nginx
     # Pin nginx version
-    image: ${WEB_IMAGE:-docksal/nginx:1.14-edge}
+    image: ${WEB_IMAGE:-docksal/nginx:1.20-1.2}
     depends_on:
       - cli
 

--- a/stacks/stack-pantheon.yml
+++ b/stacks/stack-pantheon.yml
@@ -25,7 +25,7 @@ services:
       file: ${HOME}/.docksal/stacks/services.yml
       service: mariadb
     # Pantheon supports 10.4
-    image: ${DB_IMAGE:-docksal/mariadb:10.4}
+    image: ${DB_IMAGE:-docksal/mariadb:10.4-1.3}
 
   cli:
     extends:

--- a/stacks/stack-platformsh.yml
+++ b/stacks/stack-platformsh.yml
@@ -15,7 +15,7 @@ services:
       file: ${HOME}/.docksal/stacks/services.yml
       service: nginx
     # Pin nginx version
-    image: ${WEB_IMAGE:-docksal/nginx:1.14-edge}
+    image: ${WEB_IMAGE:-docksal/nginx:1.20-1.2}
     depends_on:
       - cli
 

--- a/stacks/stack-platformsh.yml
+++ b/stacks/stack-platformsh.yml
@@ -31,7 +31,7 @@ services:
       file: ${HOME}/.docksal/stacks/services.yml
       service: cli
     # Pin PHP version
-    image: ${CLI_IMAGE:-docksal/cli:stable-php7.4}
+    image: ${CLI_IMAGE:-docksal/cli:php7.4-3.1}
 
   redis:
     extends:

--- a/stacks/stack-platformsh.yml
+++ b/stacks/stack-platformsh.yml
@@ -24,7 +24,7 @@ services:
       file: ${HOME}/.docksal/stacks/services.yml
       service: mariadb
     # Pin MariaDB version
-    image: ${DB_IMAGE:-docksal/mariadb:10.4}
+    image: ${DB_IMAGE:-docksal/mariadb:10.4-1.3}
 
   cli:
     extends:


### PR DESCRIPTION
- Switched `apache` service to `docksal/apache:2.4-2.4`
- Switched `nginx` to `docksal/nginx:1.20-1.2`
- Switched `mysql` to `docksal/mysql:8.0-2.0`
  - 8.0 is the only amd64/arm64 compatible version (image based on Oracle Linux)
- Switched `mariadb` to `docksal/mariadb:10.6-1.3`
  - Note: Pantheon and Platform are pinned at docksal/mariadb:10.4-1.3
- Switch `cli` to `docksal/cli:php7.4-3.1` in all stacks and "fin run-cli" command

These new image versions are multi-arch with amd64/arm64 platform support.