### PR TITLE
Readme badges updates

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -1,4 +1,4 @@
-name: Default (push)
+name: Default
 
 on:
   schedule:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Docksal [![Latest Release](https://img.shields.io/github/release/docksal/docksal.svg?style=flat-square)](https://github.com/docksal/docksal/releases/latest) [![Build Status](https://img.shields.io/travis/docksal/docksal.svg?style=flat-square)](https://travis-ci.org/docksal/docksal)
+# Docksal [![Latest Release](https://img.shields.io/github/release/docksal/docksal.svg?logo=github&style=for-the-badge)](https://github.com/docksal/docksal/releases/latest) [![Build Status](https://img.shields.io/github/workflow/status/docksal/docksal/Default?label=actions&logo=github&style=for-the-badge)](https://github.com/docksal/docksal/actions/workflows/default.yaml)
 
 [![Documentation](https://img.shields.io/badge/📖-Documentation-blue.svg?style=for-the-badge)](https://docs.docksal.io)
 [![Blog](https://img.shields.io/badge/📰-Tips%20and%20Updates-orange.svg?style=for-the-badge)](https://blog.docksal.io)


### PR DESCRIPTION
- Renamed workflow to Default 
  - shields.io Github Action badges rely on workflow names in the URL and that does not work when the name has spaces
- Updated Release and Build badges in readme 
  - Replaced Travis build status badge with Github Actions.

Preview updated badges: https://github.com/docksal/docksal/tree/feature/readme-badges

Fixes #1547, closes #1548 