### PR TITLE
Fixed CLI_IMAGE reference in stack

### DIFF
--- a/stacks/stack-pantheon.yml
+++ b/stacks/stack-pantheon.yml
@@ -26,7 +26,7 @@ services:
       service: mariadb
     # Pin MariaDB version
     # MariaDB v10.4 functions as limited drop-in replacement for MySQL 5.7
-    image: ${DB_IMAGE:-docksal/mariadb:10.4-1.3}
+    image: ${CLI_IMAGE:-docksal/mariadb:10.4-1.3}
 
   cli:
     extends:

--- a/stacks/stack-pantheon.yml
+++ b/stacks/stack-pantheon.yml
@@ -26,14 +26,14 @@ services:
       service: mariadb
     # Pin MariaDB version
     # MariaDB v10.4 functions as limited drop-in replacement for MySQL 5.7
-    image: ${CLI_IMAGE:-docksal/mariadb:10.4-1.3}
+    image: ${DB_IMAGE:-docksal/mariadb:10.4-1.3}
 
   cli:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml
       service: cli
     # Pin PHP version
-    image: ${DB_IMAGE:-docksal/cli:php7.4-3.1}
+    image: ${CLI_IMAGE:-docksal/cli:php7.4-3.1}
 
   # http(s)://varnish.VIRTUAL_HOST
   varnish:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docksal/docksal/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Write a short summary that describes the changes in this pull request:
-->

Service stack references DB_IMAGE in the CLI stack
