### PR TITLE
Pinning redis version to version that works with ARM.

### DIFF
--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -197,7 +197,7 @@ services:
   # Redis
   redis:
     hostname: redis
-    image: ${REDIS_IMAGE:-wodby/redis:5.0}
+    image: ${REDIS_IMAGE:-wodby/redis:6.0}
     environment:
       - REDIS_MAXMEMORY=${REDIS_MAXMEMORY:-256m}
       # Additional variables can be found https://github.com/wodby/redis

--- a/stacks/stack-pantheon.yml
+++ b/stacks/stack-pantheon.yml
@@ -48,7 +48,7 @@ services:
       file: ${HOME}/.docksal/stacks/services.yml
       service: redis
     # Pin Redis version
-    image: ${REDIS_IMAGE:-wodby/redis:4.0}
+    image: ${REDIS_IMAGE:-wodby/redis:6.0}
 
   # http(s)://solr.VIRTUAL_HOST/solr
   solr:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docksal/docksal/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Write a short summary that describes the changes in this pull request:
-->

This pins the version of Redis in the default stack and the Pantheon stack to a version that works with ARM64.  The default Pantheon version of Redis is several versions behind any currently supported versions, so per a slack conversation with @lmakarov it's better to have a different version than no Redis at all.
