### PR TITLE
adds initial cloudflare tunnel doc page

### DIFF
--- a/docs/content/fin/fin-help.md
+++ b/docs/content/fin/fin-help.md
@@ -497,6 +497,25 @@ Examples:
   fin share --host=subdomain.mysite.docksal	Expose certain subdomain
 ```
 
+## share-v2 {#share-v2}
+
+```text
+
+Create a temporary public URL for the project using Cloudflare Tunnel
+
+Usage: share-v2 [command]
+
+Commands:
+  start                    	Start tunnel and print public URL
+  stop                     	Stop tunnel
+  status                   	Prints tunnel status and public URL (if Active)
+  url                      	Prints tunnel public URL
+  logs                     	Prints tunnel container logs
+
+Examples:
+  fin share-v2 start       	Start tunnel and print public URL
+```
+
 ## cleanup {#cleanup}
 
 ```text

--- a/docs/content/tools/cloudflare-tunnel.md
+++ b/docs/content/tools/cloudflare-tunnel.md
@@ -2,41 +2,13 @@
 title: "Cloudflare Tunnel"
 ---
 
+In certain cases you may want to share or expose your local web server on the internet (e.g., share access with 
+a teammate or customer to demonstrate the work or discuss the progress). Working with external web services that expect 
+a callback URL is also generally not possible with a local environment.
 
-In certain cases you may want to share or expose you local web server on the internet (e.g., share access with a teammate or customer to demonstrate the work or discuss the progress). Working with external web services that expect a callback URL is also generally not possible with a local environment.
-
-
-## cloudflared
-
-[cloudflared](https://developers.cloudflare.com/cloudflare-one/tutorials/share-new-site/) creates a tunnel from 
-the public internet to a port on your local machine. You can share the URL with anyone to give them access to 
-your local development environment.
-
+[Cloudflare Tunnel](https://try.cloudflare.com/) creates a tunnel from the public internet to a port on your local 
+machine. You can share the URL with anyone to give them access to your local development environment.
 
 ## Usage
 
-Inside the project folder run:
-
-```bash
-fin share-v2 start
-```
-
-The public URL will be output.
-
-To stop sharing:
-
-```bash
-fin share-v2 stop
-```
-
-To get the status and print the public URL:
-
-```bash
-fin share-v2 status
-```
-
-To simply print the public URL:
-
-```bash
-fin share-v2 url
-``` 
+See [fin share-v2](/fin/fin-help/#share-v2)

--- a/docs/content/tools/cloudflare-tunnel.md
+++ b/docs/content/tools/cloudflare-tunnel.md
@@ -1,0 +1,42 @@
+---
+title: "Cloudflare Tunnel"
+---
+
+
+In certain cases you may want to share or expose you local web server on the internet (e.g., share access with a teammate or customer to demonstrate the work or discuss the progress). Working with external web services that expect a callback URL is also generally not possible with a local environment.
+
+
+## cloudflared
+
+[cloudflared](https://developers.cloudflare.com/cloudflare-one/tutorials/share-new-site/) creates a tunnel from 
+the public internet to a port on your local machine. You can share the URL with anyone to give them access to 
+your local development environment.
+
+
+## Usage
+
+Inside the project folder run:
+
+```bash
+fin share-v2 start
+```
+
+The public URL will be output.
+
+To stop sharing:
+
+```bash
+fin share-v2 stop
+```
+
+To get the status and print the public URL:
+
+```bash
+fin share-v2 status
+```
+
+To simply print the public URL:
+
+```bash
+fin share-v2 url
+``` 

--- a/scripts/fin-help-generate.sh
+++ b/scripts/fin-help-generate.sh
@@ -24,6 +24,7 @@ sections="
 	pull
 	run-cli
 	share
+	share-v2
 
 	cleanup
 	update

--- a/stacks/overrides-cloudflared.yml
+++ b/stacks/overrides-cloudflared.yml
@@ -1,4 +1,4 @@
-# Adds Cloudflare Argo Tunnel (cloudflared) service to the project
+# Adds Cloudflare Tunnel (cloudflared) service to the project
 
 version: "3.9"
 

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -259,7 +259,7 @@ services:
     << : *logging
     << : *healthcheck
 
-  # Cloudflare Argo Tunnel
+  # Cloudflare Tunnel
   cloudflared:
     hostname: cloudflared
     image: ${CLOUDFLARED_IMAGE:-raspbernetes/cloudflared:latest}


### PR DESCRIPTION
The information is incomplete. Without being able to run it, I'm not sure what some of the expected processes are. This is simply built by starting with what we have from ngrok and the fin help text and examples in #1551 