### PR TITLE
Make DOCKSAL_ENVIRONMENT variable visible in custom commands and addons by default

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -268,7 +268,8 @@ DOCKSAL_COMMANDS_PATH=".docksal/commands"
 DOCKSAL_ADDONS_PATH=".docksal/addons"
 
 # Docksal environment
-DOCKSAL_ENVIRONMENT="${DOCKSAL_ENVIRONMENT:-local}"
+# Exported to be visible in custom commands and addons by default.
+export DOCKSAL_ENVIRONMENT="${DOCKSAL_ENVIRONMENT:-local}"
 
 # Network settings
 


### PR DESCRIPTION
This was introduced in fce8f506992cd8127a9f5ad519e5b130e987b10a and then dropped unintentionally in fcb051c6c3e86b53328d426d0c67816c6ab06e0c.

Fixes #1668