### PR TITLE
Fix fin image registry image_name command

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -5281,10 +5281,10 @@ image_registry_list ()
 		tag_escaped=${1//\//\\\/}
 		# for instance $1 == "docksal/db"
 		curl -ksSL https://registry.hub.docker.com/v2/repositories/${1}/tags\?page_size\=100 | \
-                        grep -o '"name\":\"[-_\.a-zA-Z0-9]*' | \
-                        cut -d ":" -f2 | \
-                        tr -d \" | \
-                        sed "s/^/${tag_escaped}:/"	
+			grep -o '"name\":\"[-_\.a-zA-Z0-9]*' | \
+			cut -d ":" -f2 | \
+			tr -d \" | \
+			sed "s/^/${tag_escaped}:/"
 	else
 		fin docker search "docksal" | grep "^docksal\/"
 	fi

--- a/bin/fin
+++ b/bin/fin
@@ -5280,11 +5280,11 @@ image_registry_list ()
 	if [[ "$1" != "" ]]; then
 		tag_escaped=${1//\//\\\/}
 		# for instance $1 == "docksal/db"
-		curl -ksSL https://registry.hub.docker.com/v1/repositories/${1}/tags | \
-			grep -o 'name\":\ \"[-_\.a-zA-Z0-9]*' | \
-			cut -d " " -f2 | \
-			tr -d \" | \
-			sed "s/^/${tag_escaped}:/"
+		curl -ksSL https://registry.hub.docker.com/v2/repositories/${1}/tags\?page_size\=100 | \
+                        grep -o '"name\":\"[-_\.a-zA-Z0-9]*' | \
+                        cut -d ":" -f2 | \
+                        tr -d \" | \
+                        sed "s/^/${tag_escaped}:/"	
 	else
 		fin docker search "docksal" | grep "^docksal\/"
 	fi


### PR DESCRIPTION
Fixes #1711 which is due to the move of Docker API to version 2. 
Be aware that with the new API version the list of resulting tags is limited to 100 at least for non-authenticated requests. A pagination is at disposal to retrieve all the results. 