### PR TITLE
removes solr 4 instructions and updates the listed default version to 8

### DIFF
--- a/docs/content/service/other/apache-solr.md
+++ b/docs/content/service/other/apache-solr.md
@@ -100,43 +100,10 @@ fin project reset solr
 
 To run multiple Solr cores, follow version specific instructions below.
 
-### Solr 4
-
-To set up multiple Solr cores for use with the [Drupal Search API Solr module](https://www.drupal.org/project/search_api_solr),
-modify your `.docksal/docksal.yml` or `.docksal/docksal-local.yml` file with the following:
-
-```yaml
-services:
-  solr:
-    extends:
-      file: ${HOME}/.docksal/stacks/services.yml
-      service: solr
-    labels:
-      io.docksal.virtual-host: solr-a.${VIRTUAL_HOST},solr-b.${VIRTUAL_HOST}
-    volumes:
-      - ${PROJECT_ROOT}/.docksal/etc/solr/a:/opt/solr/example/solr/a:ro
-      - /var/lib/solr/a/data:rw
-      - ${PROJECT_ROOT}/.docksal/etc/solr/b:/opt/solr/example/solr/b:ro
-      - /var/lib/solr/b/data:rw
-```
-
-Create the file `.docksal/etc/solr/a/core.properties` for instance a with the contents:
-
-```bash
-name=a
-dataDir=/var/lib/solr/a/data
-```
-
-Create the file `.docksal/etc/solr/b/core.properties` for instance b with the contents:
-
-```bash
-name=b
-dataDir=/var/lib/solr/b/data
-```
 
 ### Solr 6
 
-Docksal current has Solr 4 defined in the Docksal images. For users with a need to use Solr 6.x, you can set this in 
+Docksal current has Solr 8 defined in the Docksal images. For users with a need to use Solr 6.x, you can set this in 
 your `docksal.yml` file.
 
 ```yaml


### PR DESCRIPTION
The current services settings utilize the solr:8.6-edge image. This updates the documentation to reflect that as the current version and removes the Solr 4 instructions.