### PR TITLE
Fix MTU settings on Gitpod to 1440

### DIFF
--- a/stacks/overrides-gitpod.yml
+++ b/stacks/overrides-gitpod.yml
@@ -6,3 +6,19 @@ services:
   web:
     labels:
       - io.docksal.virtual-host=${DOCKSAL_VHOST_PROXY_PORT_HTTP}-${GITPOD_WORKSPACE_ID}.${GITPOD_WORKSPACE_CLUSTER_HOST}
+      
+# Since Gitpod removed slirp4netns as part of performance improvements,
+# MTU value should be aligned to the one in gitpod.io
+#
+# Gitpod fixed it for docker - https://github.com/gitpod-io/gitpod/pull/9356
+# and for docker-compose - https://github.com/gitpod-io/template-docker-compose/pull/4
+#
+# Docksal doesn't use Gitpod's custom docker-compose binary. Instead, Docksal
+# uses its own docker-compose binary at /home/gitpod/.docksal/bin/docker-compose
+#
+# Align the MTU value to the one that is set in Gitpod (1440)
+
+networks:
+  default:
+    driver_opts:
+      com.docker.network.driver.mtu: 1440


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docksal/docksal/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Write a short summary that describes the changes in this pull request:
-->
This PR fixes an issue with Gitpod network setup.

```
# Since Gitpod removed slirp4netns as part of performance improvements,
# MTU value should be aligned to the one in gitpod.io
#
# Gitpod fixed it for docker - https://github.com/gitpod-io/gitpod/pull/9356
# and for docker-compose - https://github.com/gitpod-io/template-docker-compose/pull/4
#
# Docksal doesn't use Gitpod's custom docker-compose binary. Instead, Docksal
# uses its own docker-compose binary at /home/gitpod/.docksal/bin/docker-compose
#
# Align the MTU value to the one that is set in Gitpod (1440)
```


Please see a similar issue in ddev project -
https://github.com/drud/ddev/issues/3766

This is how it was solved temporarily in DrupalPod -
https://github.com/shaal/DrupalPod/pull/84