### PR TITLE
Fix checking web container in project

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -5898,7 +5898,7 @@ ngrok_share ()
 	eval $(parse_params "$@")
 
 	local network="${COMPOSE_PROJECT_NAME_SAFE}_default"
-	local container_name=${container:-$(docker-compose ps web | grep Up | grep _web_ | cut -d " " -f 1)}
+	local container_name=${container:-$(docker-compose ps web | grep 'Up\|running' | grep _web_ | cut -d " " -f 1)}
 	if [[ "$container_name" == "" ]]; then
 		echo-error "Could not find running web container in this project"
 		exit 1


### PR DESCRIPTION
Fin share checks if a web container is running inside the project. The check looks for "Up" but "fin ps web" returns "running", therefore reporting the project as not having a running web container.