### PR TITLE
Update mkcert.md addon step to use global option

### DIFF
--- a/docs/content/tools/mkcert.md
+++ b/docs/content/tools/mkcert.md
@@ -36,7 +36,7 @@ Open https://[project].docksal to validate.
 mkcert can also be installed as an [addon](https://github.com/docksal/addons/tree/master/mkcert). 
 
 ```bash
-fin addon install mkcert
+fin addon install mkcert -g
 ```
 
 This will download and install `mkcert` binary in `$HOME/.docksal/bin/mkcert` **except** when `mkcert` is already 


### PR DESCRIPTION
When following directions, there is an error

> > fin addon install mkcert
> Downloading addon hook files...
>   mkcert.pre-install
> Running pre-install hook...
> [PRE-INSTALL] ERROR: Mkcert addon should installed globally, use 'fin addon install mkcert -g'
> Pre-install hook has failed and aborted the installation.
> 