### PR TITLE
Update minimal PHP for Platform.sh

### DIFF
--- a/stacks/stack-platformsh.yml
+++ b/stacks/stack-platformsh.yml
@@ -32,7 +32,7 @@ services:
       file: ${HOME}/.docksal/stacks/services.yml
       service: cli
     # Pin PHP version
-    image: ${CLI_IMAGE:-docksal/cli:php7.4-3.2}
+    image: ${CLI_IMAGE:-docksal/cli:php8.1-3.2}
 
   redis:
     extends:


### PR DESCRIPTION
Hi.
It seems to me that platform.sh stack is still connected to PHP.74 which is very old.
It is better to change it to the 8.1 which is compatible with the last Drupal9/10
