### PR TITLE
Update xhprof to work with m1.

### DIFF
--- a/stacks/overrides-xhprof.yml
+++ b/stacks/overrides-xhprof.yml
@@ -14,7 +14,7 @@ services:
 
   # XHProf Service to review
   xhprof:
-    image: ${XHPROF_IMAGE:-wodby/xhprof:3.0.2}
+    image: ${XHPROF_IMAGE:-wodby/xhprof:2-3.7.6}
     hostname: xhprof
     depends_on:
       - cli


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docksal/docksal/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Write a short summary that describes the changes in this pull request:
-->

Updates default xhprof stack to use woodby/xhprof:2-3.7.6 which is compatible with M1 and Intel macs.
