### PR TITLE
Release 1.18.1

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -94,7 +94,7 @@ jobs:
         run: fin sysinfo
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Tests
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 1.18.1 (2023-03-31)
+
+❗**IMPORTANT:** This release addresses a bug in the update process introduced in [v1.17.0](https://github.com/docksal/docksal/releases/tag/v1.17.0).
+
+Please use the command below to force the update to this release.
+
+```bash
+DOCKSAL_VERSION=v1.18.1 fin update
+```
+
+### New software versions ✨
+
+- fin v1.113.0
+
+### Changes and improvements ⚙️
+
+- Fixed network issues after project stack stop/restart
+- Fixed update process
+- Switched CI builds to `actions/checkout@v3`
+
+## #Documentation 📖
+
+- Updated Docker Desktop links in setup.md docs
+
+
 ## 1.18.0 (2023-03-12)
 
 ### New software versions ✨

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## 1.18.0 (2023-03-12)
+
+### New software versions ✨
+
+- fin v1.112.0
+- Docker Desktop v4.17.0
+- Docker v20.10.23
+- Docker Compose v2.15.1
+- VirtualBox v6.1.42
+- New image versions
+  - [docksal/cli v3.3](https://github.com/docksal/service-cli/releases/tag/v3.3.0)
+- Switched all stacks to PHP 8.1 (`docksal/cli:php8.1-3.3` image)
+
+### Changes and improvements ⚙️
+
+- macOS Ventura 13.0 compatibility
+  - Adjusted NFS mount read/write buffers
+- Ubuntu 22.04 compatibility
+- Made `DOCKSAL_ENVIRONMENT` variable visible in custom commands and add-ons by default
+- Updated Solr version to v7 for the Acquia stack
+- Fixed `fin image registry <image_name>` command
+- Fixed `fin share` command
+- Fixed network settings in Gitpod
+- Updated the list of options for `fin project create` (added Drupal 10 options, removed Drupal 8)
+- Updated `xhprof` image to work with arm64/Apple Silicone
+- Switched `cloudflared` service to the official `cloudflare/cloudflared` image (which now supports arm64)
+- Dropped legacy xdebug v2 `remote_host` option in stack configs
+- Improved fin sysinfo output (added green/red colors for PASS/FAIL tests)
+
+### Documentation 📖
+
+- Adding Mutagen option in [Shared Volumes](https://docs.docksal.io/core/volumes/) docs
+- Updated PHP version docs
+- Removed Solr 4 instructions and updated the listed default version to Solr 8
+- Various small updates
+
+### Contributors 🤓
+
+@lmakarov, @froboy, @paulsheldrake, @shelane, @halisonfernandes, @obriat, @khaledzaidan, @nicoschi, @shaal, 
+@matthiasseghers, @eloso-uk, @sean-e-dietrich, @danshumaker, @rosenstrauch, @jasonawant, @anpolimus, 
+
+### Sponsors 🤑
+
+@markaspot, @lpeabody, @alexander-danilenko, @andreyzb, @twfahey1, @johnoltman65, [❤️ You ❤️ ](https://github.com/sponsors/docksal)
+
+
 ## 1.17.0 (2022-04-15)
 
 ### New software versions ✨ 

--- a/bin/fin
+++ b/bin/fin
@@ -3272,7 +3272,7 @@ project_status ()
 	check_docksal_environment
 	check_project_unique
 
-	docker-compose ps
+	docker-compose ps -a
 }
 
 # List Docksal projects

--- a/bin/fin
+++ b/bin/fin
@@ -7,7 +7,7 @@
 DOCKSAL_UPDATE_VERSION="${DOCKSAL_UPDATE_VERSION:-$DOCKSAL_VERSION}"
 
 # Set current version constants
-FIN_VERSION=1.112.0
+FIN_VERSION=1.113.0
 DOCKSAL_VERSION=v1.18.0
 
 # Predefined terminal colors

--- a/docs/content/getting-started/setup.md
+++ b/docs/content/getting-started/setup.md
@@ -85,8 +85,8 @@ to [v2.1.0.5](https://download.docker.com/mac/stable/40693/Docker.dmg) as a temp
 
 1. Install Docker Desktop for Mac v4.17.0
 
-    [![Docker Desktop for Mac v4.17.0 (Intel chip)](https://img.shields.io/badge/download-Docker%20Desktop%20for%20Mac-blue.svg?logo=docker&style=for-the-badge&classes=inline)](https://desktop.docker.com/mac/main/amd64/99724/Docker.dmg) <!-- when changing this version please change https://github.com/docksal/docksal.io/tree/master/src/pages/installation.js as well -->
-    [![Docker Desktop for Mac v4.17.0 (Apple silicon)](https://img.shields.io/badge/download-Docker%20Desktop%20for%20Mac-blue.svg?logo=docker&style=for-the-badge&classes=inline)](https://desktop.docker.com/mac/main/arm64/99724/Docker.dmg) <!-- when changing this version please change https://github.com/docksal/docksal.io/tree/master/src/pages/installation.js as well -->
+    [![Docker Desktop for Mac v4.17.0 (Intel chip)](https://img.shields.io/badge/Docker%20Desktop%20for%20Mac%20v4.17.0%20(Intel)-blue.svg?logo=docker&style=for-the-badge&classes=inline)](https://desktop.docker.com/mac/main/amd64/99724/Docker.dmg) <!-- when changing this version please change https://github.com/docksal/docksal.io/tree/master/src/pages/installation.js as well -->
+    [![Docker Desktop for Mac v4.17.0 (Apple silicon)](https://img.shields.io/badge/Docker%20Desktop%20for%20Mac%20v4.17.0%20(Apple)-blue.svg?logo=docker&style=for-the-badge&classes=inline)](https://desktop.docker.com/mac/main/arm64/99724/Docker.dmg) <!-- when changing this version please change https://github.com/docksal/docksal.io/tree/master/src/pages/installation.js as well -->
 
 1. Start Docker Desktop
 
@@ -189,9 +189,9 @@ to [v2.1.0.5](https://download.docker.com/win/stable/40693/Docker%20Desktop%20In
 
     [![Ubuntu App for Windows](https://img.shields.io/badge/Ubuntu%2020.04%20App-orange.svg?logo=ubuntu&style=for-the-badge&classes=inline)](https://www.microsoft.com/en-us/p/ubuntu-2004-lts/9n6svws3rx71)
 
-3. Install Docker Desktop for Windows v4.4.2
+3. Install Docker Desktop for Windows v4.17.0
 
-    [![Docker Desktop for Windows v4.4.2](https://img.shields.io/badge/download-Docker%20Desktop%20for%20Windows-blue.svg?logo=docker&style=for-the-badge&classes=inline)](https://desktop.docker.com/win/main/amd64/73305/Docker%20Desktop%20Installer.exe) <!-- when changing this version please change https://github.com/docksal/docksal.io/tree/master/src/pages/installation.js as well -->
+    [![Docker Desktop for Windows v4.17.0](https://img.shields.io/badge/Docker%20Desktop%20for%20Windows%20v4.17.0-blue.svg?logo=docker&style=for-the-badge&classes=inline)](https://desktop.docker.com/win/main/amd64/99724/Docker%20Desktop%20Installer.exe) <!-- when changing this version please change https://github.com/docksal/docksal.io/tree/master/src/pages/installation.js as well -->
     
 4. Configure Docker Desktop on Windows
 

--- a/tests/project.bats
+++ b/tests/project.bats
@@ -39,9 +39,9 @@ teardown() {
 
 	# Check that containers are running
 	run fin ps
-	echo "$output" | grep "_web_1" | grep "running"
-	echo "$output" | grep "_db_1" | grep "running"
-	echo "$output" | grep "_cli_1" | grep "running"
+	echo "$output" | grep "_web_1" | grep "Up"
+	echo "$output" | grep "_db_1" | grep "Up"
+	echo "$output" | grep "_cli_1" | grep "Up"
 	unset output
 }
 
@@ -58,9 +58,9 @@ teardown() {
 
 	# Check that containers are stopped
 	run fin ps
-	echo "$output" | grep "_web_1" | grep "exited"
-	echo "$output" | grep "_db_1" | grep "exited"
-	echo "$output" | grep "_cli_1" | grep "exited"
+	echo "$output" | grep "_web_1" | grep "Exited"
+	echo "$output" | grep "_db_1" | grep "Exited"
+	echo "$output" | grep "_cli_1" | grep "Exited"
 	unset output
 
 	# Start containers back
@@ -86,9 +86,9 @@ teardown() {
 
 	# Check that containers are running
 	run fin ps
-	echo "$output" | grep "_web_1" | grep "running"
-	echo "$output" | grep "_db_1" | grep "running"
-	echo "$output" | grep "_cli_1" | grep "running"
+	echo "$output" | grep "_web_1" | grep "Up"
+	echo "$output" | grep "_db_1" | grep "Up"
+	echo "$output" | grep "_cli_1" | grep "Up"
 	unset output
 }
 
@@ -153,9 +153,9 @@ teardown() {
 
 	# Check that containers are running
 	run fin ps
-	echo "$output" | grep "_web_1" | grep "running"
-	echo "$output" | grep "_db_1" | grep "running"
-	echo "$output" | grep "_cli_1" | grep "running"
+	echo "$output" | grep "_web_1" | grep "Up"
+	echo "$output" | grep "_db_1" | grep "Up"
+	echo "$output" | grep "_cli_1" | grep "Up"
 	unset output
 }
 
@@ -190,9 +190,9 @@ teardown() {
 
 	# Check that containers are running
 	run fin ps
-	echo "$output" | grep "_web_1" | grep "running"
-	echo "$output" | grep "_db_1" | grep "running"
-	echo "$output" | grep "_cli_1" | grep "running"
+	echo "$output" | grep "_web_1" | grep "Up"
+	echo "$output" | grep "_db_1" | grep "Up"
+	echo "$output" | grep "_cli_1" | grep "Up"
 	unset output
 
 	# Check if site is available and its name is correct


### PR DESCRIPTION
# 1.18.1 (2023-03-31)

❗**IMPORTANT:** This release addresses a bug in the update process introduced in [v1.17.0](https://github.com/docksal/docksal/releases/tag/v1.17.0).

Please use the command below to force the update to this release.

```bash
DOCKSAL_VERSION=v1.18.1 fin update
```

## New software versions ✨

- fin v1.113.0

## Changes and improvements ⚙️

- Fixed network issues after project stack stop/restart
- Fixed update process
- Switched CI builds to `actions/checkout@v3`

## Documentation 📖

- Updated Docker Desktop links in setup.md docs
