### PR TITLE
Release 1.18.2

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -86,8 +86,8 @@ jobs:
       -
         name: Install Docksal
         env:
-          DOCKSAL_VERSION: ${{ steps.use_branch.outputs.branch }}
-        # This installs Docksal using the passed DOCKSAL_VERSION value
+          DOCKSAL_UPDATE_VERSION: ${{ steps.use_branch.outputs.branch }}
+        # This installs Docksal using the passed DOCKSAL_UPDATE_VERSION value
         run: curl -fsSL https://get.docksal.io | bash
       -
         name: fin sysinfo

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -81,8 +81,8 @@ jobs:
           if [[ "${GITHUB_REF}" =~ "refs/tags/" ]]; then USE_BRANCH="${GITHUB_REF#refs/tags/}"; fi # Release tag
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" && "${GITHUB_REPOSITORY}" == "${REPO}" ]]; then USE_BRANCH="${PR_BRANCH}"; fi # Internal PR
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" && "${GITHUB_REPOSITORY}" != "${REPO}" ]]; then USE_BRANCH='develop'; fi # External PR
-          echo "::set-output name=branch::$(echo ${USE_BRANCH})"
-          echo "branch: ${USE_BRANCH}"
+          echo "branch=${USE_BRANCH}" >> $GITHUB_OUTPUT
+          echo "branch=${USE_BRANCH}"
       -
         name: Install Docksal
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 1.18.2 (2023-04-03)
+
+❗**IMPORTANT:** This release addresses a bug in the update process introduced in [v1.17.0](https://github.com/docksal/docksal/releases/tag/v1.17.0).
+
+Please use the command below to force the update to this release.
+
+```bash
+DOCKSAL_VERSION=v1.18.2 fin update
+```
+
+### New software versions ✨
+
+- fin v1.113.1
+
+### Changes and improvements ⚙️
+
+- Fixed stack files download URL
+- Replaced the legacy set-output command in GitHub Actions
+
+
 ## 1.18.1 (2023-03-31)
 
 ❗**IMPORTANT:** This release addresses a bug in the update process introduced in [v1.17.0](https://github.com/docksal/docksal/releases/tag/v1.17.0).

--- a/bin/fin
+++ b/bin/fin
@@ -4952,7 +4952,7 @@ update_config_files ()
 		for f in ${files_to_download}; do
 			echo "$(basename ${f})"
 			# exit subshell with error if download failed
-			curl -kfsSLO "${URL_REPO}/${DOCKSAL_VERSION}/stacks/$f" || exit 1
+			curl -kfsSLO "${URL_REPO}/${DOCKSAL_UPDATE_VERSION}/stacks/$f" || exit 1
 		done
 	)
 

--- a/bin/fin
+++ b/bin/fin
@@ -7,8 +7,8 @@
 DOCKSAL_UPDATE_VERSION="${DOCKSAL_UPDATE_VERSION:-$DOCKSAL_VERSION}"
 
 # Set current version constants
-FIN_VERSION=1.113.0
-DOCKSAL_VERSION=v1.18.0
+FIN_VERSION=1.113.1
+DOCKSAL_VERSION=v1.18.2
 
 # Predefined terminal colors
 # Format: '\033[<formatting>;<text-color>;<background-color>m'


### PR DESCRIPTION
## 1.18.2 (2023-04-03)

❗**IMPORTANT:** This release addresses a bug in the update process introduced in [v1.17.0](https://github.com/docksal/docksal/releases/tag/v1.17.0).

Please use the command below to force the update to this release.

```bash
DOCKSAL_VERSION=v1.18.2 fin update
```

### New software versions ✨

- fin v1.113.1

### Changes and improvements ⚙️

- Fixed stack files download URL
- Replaced the legacy `set-output` command in GitHub Actions
