### PR TITLE
Add --build option to docker-compose create to use dockerfiles

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -1376,7 +1376,7 @@ _start_containers ()
 	# This will recraete the project network if missing.
 	# docker-compose create &>/dev/null || (echo-error "Failed to create project resources"; return 1)
 	echo-yellow "(Re)creating resources..."
-	docker-compose create --no-recreate || return 1
+	docker-compose create --build --no-recreate || return 1
 
 	# (Re)connect containers to project network
 	# We have to manually reconnect project containers to project network (after restart).


### PR DESCRIPTION
fixes #1774 

Adds the --build option to recently added docker-compose create command, ensuring dockerfiles are used when project start is run.