### PR TITLE
Switch default cli image to docksal/cli:php8.3-3.7

### DIFF
--- a/docs/content/stack/images-versions.md
+++ b/docs/content/stack/images-versions.md
@@ -53,12 +53,12 @@ e.g., `fin image registry docksal/cli`, to see list of available CLI images. [Se
 
 | Image                    | Notes                                                                                                      |
 |--------------------------|------------------------------------------------------------------------------------------------------------|
-| `docksal/cli:php8.2-3.5` | PHP 8.2.8, Nodejs 18.17.0 LTS, Ruby 2.7.4, Python 3.9.2                                                    |
-| `docksal/cli:php8.1-3.5` | *Default image* PHP 8.1.21, Nodejs 18.17.0 LTS, Ruby 2.7.4, Python 3.9.2                                   |
-| `docksal/cli:php8.0-3.5` | PHP 8.0.29, Nodejs 18.17.0 LTS, Ruby 2.7.4, Python 3.9.2                                                   |
+| `docksal/cli:php8.3-3.7` | *Default image* PHP 8.3.2, Nodejs 20.11.0 LTS, Ruby 2.7.4, Python 3.9.2                                    |
+| `docksal/cli:php8.2-3.7` | PHP 8.2.15, Nodejs 20.11.0 LTS, Ruby 2.7.4, Python 3.9.2                                                   |
+| `docksal/cli:php8.1-3.7` | PHP 8.1.27, Nodejs 20.11.0 LTS, Ruby 2.7.4, Python 3.9.2                                                   |
+| `docksal/cli:php8.3-3`   | Latest 3.x image version of PHP 8.3 flavor, convenient when [extending stock images](/stack/extend-images) |
 | `docksal/cli:php8.2-3`   | Latest 3.x image version of PHP 8.2 flavor, convenient when [extending stock images](/stack/extend-images) |
 | `docksal/cli:php8.1-3`   | Latest 3.x image version of PHP 8.1 flavor, convenient when [extending stock images](/stack/extend-images) |
-| `docksal/cli:php8.0-3`   | Latest 3.x image version of PHP 8.0 flavor, convenient when [extending stock images](/stack/extend-images) |
 
 ## Apache
 

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -124,7 +124,7 @@ services:
   # CLI - Used for all console commands and tools.
   cli:
     hostname: cli
-    image: ${CLI_IMAGE:-docksal/cli:php8.1-3.3}
+    image: ${CLI_IMAGE:-docksal/cli:php8.3-3.7}
     volumes:
       - project_root:/var/www:rw,nocopy,cached  # Project root volume
       - docksal_ssh_agent:/.ssh-agent:ro  # Shared ssh-agent socket


### PR DESCRIPTION
We have new cli images. This updates to the latest with php 8.3 as the default.