### PR TITLE
replaces mailhog service with mailpit

### DIFF
--- a/docs/content/core/system-vhost-proxy.md
+++ b/docs/content/core/system-vhost-proxy.md
@@ -87,13 +87,13 @@ for a workaround.
 The `io.docksal.virtual-host` lable allows setting the domain(s) that will be routed to an HTTP service (listening on port 80) in your project stack.
 If the service inside the container listens on a different port, you can use the `io.docksal.virtual-port` lable to override the default port mapping.
 
-This is how it is set up for the MailHog service definition found in `services.yml`:
+This is how it is set up for the Mailpit service definition found in `services.yml`:
 
 ```yaml
- # MailHog
+ # Mailpit
  mail:
    hostname: mail
-   image: ${MAILHOG_IMAGE:-mailhog/mailhog}
+   image: ${MAILPIT_IMAGE:-axllent/mailpit}
    volumes:
      - project_root:/var/www:ro,nocopy,cached  # Project root volume (read-only)
    labels:
@@ -102,7 +102,7 @@ This is how it is set up for the MailHog service definition found in `services.y
      - io.docksal.cert-name=${VIRTUAL_HOST_CERT_NAME:-none}
 ```
 
-In the example above, MailHog application listends on port `8025` inside the `mail` container.
+In the example above, Mailpit application listends on port `8025` inside the `mail` container.
 Docksal's vhost-proxy handles the routing and mapping from `http(s)://mail.${VIRTUAL_HOST}` (e.g., http://mail.myproject.docksal.site) to http://mail:8025 (internal endpoint accessible only between containers in a project stack).
 
 Your host machine as well as containers will be able to access the exposed virtual host endpoint.

--- a/docs/content/service/other/mailpit.md
+++ b/docs/content/service/other/mailpit.md
@@ -3,6 +3,7 @@ title: "Mailpit"
 aliases:
   - /en/master/tools/mailhog/
   - /tools/mailhog/
+  - /service/other/mailhog/
 ---
 
 

--- a/docs/content/service/other/mailpit.md
+++ b/docs/content/service/other/mailpit.md
@@ -1,15 +1,15 @@
 ---
-title: "MailHog"
+title: "Mailpit"
 aliases:
   - /en/master/tools/mailhog/
   - /tools/mailhog/
 ---
 
 
-Sending/capturing email is available via [MailHog](https://github.com/mailhog/MailHog).
+Sending/capturing email is available via [Mailpit](https://mailpit.axllent.org/docs/usage/).
 
 {{% notice warning %}}
-Out-of-the box only capturing works. For email delivery, you have to point MailHog to a working mail server/service.
+Out-of-the box only capturing works. For email delivery, you have to point Mailpit to a working mail server/service.
 {{% /notice %}}
 
 
@@ -18,7 +18,7 @@ Out-of-the box only capturing works. For email delivery, you have to point MailH
 Add the `mail` service under the `services` section in `.docksal/docksal.yml`:
 
 ```yaml
-  # MailHog
+  # Mailpit
   mail:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml
@@ -27,4 +27,4 @@ Add the `mail` service under the `services` section in `.docksal/docksal.yml`:
 
 Apply new configuration with `fin project start` (`fin p start`).
 
-Use `http://mail.<VIRTUAL_HOST>` to access the MailHog web UI.
+Use `http://mail.<VIRTUAL_HOST>` to access the Mailpit web UI.

--- a/docs/content/stack/custom-configuration.md
+++ b/docs/content/stack/custom-configuration.md
@@ -19,7 +19,7 @@ with additional docker-compose overrides and definitions via the `.docksal/docks
 
 Examples:
 
-- Extend the default stack with the [MailHog](/service/other/mailhog/) service to capture outbound emails
+- Extend the default stack with the [Mailpit](/service/other/mailpit/) service to capture outbound emails
 - Repurpose the `cli` service to [run a different command](/service/cli/override-command/) on startup 
 (e.g., a node app instead of PHP-FPM).
 - [Pass variables](#pass-variables) from the host/project config inside containers 

--- a/stacks/services.yml
+++ b/stacks/services.yml
@@ -215,10 +215,10 @@ services:
     << : *logging
     << : *healthcheck
 
-  # MailHog
+  # Mailpit
   mail:
     hostname: mail
-    image: ${MAILHOG_IMAGE:-mailhog/mailhog:v1.0.1}
+    image: ${MAILPIT_IMAGE:-axllent/mailpit:v1.15.1}
     volumes:
       - project_root:/var/www:ro,nocopy,cached  # Project root volume (read-only)
     labels:


### PR DESCRIPTION
This was pointed out in the addons repo:

https://github.com/docksal/addons/issues/93

Here is the mailpit repo and the latest tag is 1.15.1, which was released Mar 30, 2024.
https://github.com/axllent/mailpit