### PR TITLE
Use more recent mysql images

### DIFF
--- a/docs/content/service/db/settings.md
+++ b/docs/content/service/db/settings.md
@@ -19,11 +19,11 @@ When using the default stack (a custom project stack is not defined in `.docksal
 via the `DB_IMAGE` variable in `.docksal/docksal.env`, e.g.:
 
 ```bash
-DB_IMAGE='docksal/db:1.1-mysql-5.7'
+DB_IMAGE='docksal/mysql:5.7-1.6'
 ```
 This can also be set with `fin config set`.
 ```bash
-fin config set DB_IMAGE='docksal/db:1.1-mysql-5.7'
+fin config set DB_IMAGE='docksal/mysql:5.7-1.6'
 ```
 
 Remember to run `fin project start` (`fin p start`) to apply the configuration.
@@ -35,10 +35,9 @@ followed by a DB re-import.
 
 Available images:
 
-- MySQL 5.5 - `docksal/db:1.1-mysql-5.5`
-- MySQL 5.6 - `docksal/db:1.1-mysql-5.6` (default)
-- MySQL 5.7 - `docksal/db:1.1-mysql-5.7`
-- MySQL 8.0 - `docksal/db:1.1-mysql-8.0`
+- MySQL 5.6 - `docksal/mysql:5.6-1.5`
+- MySQL 5.7 - `docksal/mysql:5.7-1.6`
+- MySQL 8.0 - `docksal/mysql:8.0-2.0`
 
 There are also "edge" versions available that contain code from ongoing updates, but may not be stable. Don't switch to an
 edge image unless directed to do so by the Docksal team for testing purposes only.


### PR DESCRIPTION
If I understand correctly the docksal/db images are older and not updated anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated database configuration documentation with refreshed MySQL container image references.
  * Available MySQL version options now reflect the current docksal/mysql image naming convention.
  * Configuration examples updated to support MySQL 5.6, 5.7, and 8.0 versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->